### PR TITLE
docs: document the current state of the system

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# LatinoMigra documentation
+
+These documents describe the **current state** of the project. They are
+descriptive, not aspirational: everything here was verified against the code at
+the time of writing. Where a document lists a known problem, that problem exists
+today.
+
+Planned work lives in GitHub issues, not here.
+
+| Document | Covers |
+|---|---|
+| [architecture.md](./architecture.md) | Stack, structure, modules, data flow, architectural decisions |
+| [product.md](./product.md) | Features, user flows, roles, states, feature dependencies |
+| [data.md](./data.md) | Firestore collections, access rules, static datasets, write paths |
+| [security.md](./security.md) | Auth, authorization, secrets, API hardening, known weaknesses |
+| [testing.md](./testing.md) | Test suites, what is covered, what is not, test quality |
+| [ci-cd.md](./ci-cd.md) | Workflows, merge gates, deployment pipeline |
+| [observability.md](./observability.md) | What can and cannot be observed today |
+| [performance.md](./performance.md) | Bundle, rendering, network, measured Web Vitals |
+| [accessibility.md](./accessibility.md) | WCAG 2.2 AA status per criterion |
+| [ux.md](./ux.md) | Navigation, states, information architecture |
+| [seo.md](./seo.md) | Metadata, crawlability, structural limits |
+| [ai.md](./ai.md) | Gemini integration, prompts, the two chat surfaces |
+| [development.md](./development.md) | Local setup, environment variables, scripts |
+| [deployment.md](./deployment.md) | How the app reaches production |
+
+## Conventions
+
+- Development artefacts — commits, pull requests, issues, code comments and
+  these documents — are written in **English**.
+- The product itself (UI copy, guides, scholarship data) is in **Spanish**,
+  because it is built for Latin American migrants.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,85 @@
+# Accessibility
+
+Status against WCAG 2.2 AA. Measured from the source, not from an automated
+audit tool — no such tool runs in CI today.
+
+## Summary
+
+The application is usable with a mouse and a screen, and largely **unusable with
+a screen reader**. Recent work fixed touch ergonomics, which are visible. The
+semantic layer, which is not visible, remains largely unaddressed.
+
+## Per-criterion status
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| 1.3.1 Info and relationships | **Fails** | Two `<h1>` on the home screen (`HeroLanding` + `BecasExplorer`). 24 `<input>` elements and a single `htmlFor` in the whole codebase |
+| 1.4.3 Contrast | **Needs measurement** | Frequent `text-[10px]` and `text-[11px]` on tinted backgrounds; not yet measured |
+| 1.4.4 Resize text | Passes | Relative units throughout; no fixed-height text containers |
+| 1.4.10 Reflow | Passes | Verified by E2E: no horizontal document scroll on any screen at 390 px |
+| 2.1.1 Keyboard | **Partial** | Menus and the mobile drawer close on Escape. Modals do not trap focus and mostly cannot be dismissed by keyboard |
+| 2.3.3 Animation from interactions | Passes | `prefers-reduced-motion` honoured in `src/index.css` |
+| 2.4.7 Focus visible | Passes | Global 3 px `:focus-visible` ring in `src/index.css` |
+| 2.5.5 Target size | Passes | 44 px minimum on touch layouts, enforced by E2E assertions |
+| 3.3.2 Labels or instructions | **Fails** | Form controls rely on placeholders; almost no associated `<label>` |
+| 4.1.2 Name, role, value | **Fails** | 12 `fixed inset-0` modal overlays; 2 declare `role="dialog"`, 1 declares `aria-modal` |
+| 4.1.3 Status messages | **Fails** | Zero `aria-live`, `role="status"` or `role="alert"` anywhere |
+
+## What is in place
+
+- A single global focus ring, added after several components had cleared the
+  default `outline` without replacing it.
+- 44 px minimum touch targets on layouts under 1024 px, with E2E tests that fail
+  if a control shrinks below 40 px.
+- 16 px minimum font on form controls under 1024 px, which prevents iOS from
+  zooming the page on focus.
+- `prefers-reduced-motion` short-circuits all animations and smooth scrolling.
+- `aria-label` on icon-only navigation controls (menu toggle, theme, alerts,
+  account) and `aria-current="page"` on the active navigation item.
+- `aria-haspopup` and `aria-expanded` on the desktop tools and preferences menus.
+- The mobile drawer declares `role="dialog"`, `aria-modal` and an `aria-label`.
+- Escape closes the drawer and both desktop menus.
+- Semantic landmarks: `<nav>`, `<main>`, `<header>`, `<footer>` are used.
+
+## What is missing
+
+**Form labels.** 24 inputs, one `htmlFor`. Screen readers announce "edit box"
+with no indication of what it is for. This affects the scholarship search, the
+cost calculator, the forum composer, the feedback form and the alert settings.
+
+**Status messages.** No live regions of any kind. Every asynchronous message —
+sync results, publish errors, loading completion, the language-change toast —
+is invisible to assistive technology. There are 52 loading indicators and none
+announce anything.
+
+**Modal semantics and focus management.** Nine components implement their own
+overlay. Focus is not moved into the dialog on open, not trapped while open, and
+not returned on close. Most cannot be closed with Escape. Background content is
+not hidden from the accessibility tree.
+
+**Heading structure.** The home screen has two `<h1>`. Section headings are
+mostly `<h2>`/`<h3>` but nesting has not been verified against content order.
+
+**Native `alert()`.** Three error paths in `Comunidad.tsx` use browser alerts,
+which interrupt flow and give no context.
+
+## Tooling
+
+`eslint-plugin-jsx-a11y` is configured in `eslint.config.js` with five rules as
+errors: `alt-text`, `anchor-has-content`, `aria-props`, `aria-role`,
+`role-has-required-aria-props`. These pass.
+
+The rules that would catch the failures above — `label-has-associated-control`,
+`no-static-element-interactions`, `click-events-have-key-events` — are not
+enabled.
+
+No `axe-core` check runs in CI, so none of the failures listed here would be
+caught by the test suite.
+
+## Why this matters for this product
+
+The audience includes people navigating an unfamiliar bureaucracy in a second
+language, often on modest devices, and including people with disabilities. The
+information here — visa requirements, consular addresses, scam warnings — is the
+kind that has real consequences when it is inaccessible. This is a barrier to
+service, not only a conformance gap.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,0 +1,109 @@
+# AI integration
+
+How the product uses generative AI today.
+
+## Provider
+
+Google Gemini via `@google/genai` (v2.x), model `gemini-3.6-flash`. The client is
+initialised lazily in `server.ts` and reads `GEMINI_API_KEY` from the
+environment. The key is server-side only and never reaches the browser.
+
+If the key is unset the client is constructed with `"dummy-key-for-boot"` so the
+process still starts; requests then fail at call time.
+
+## Endpoints
+
+### `POST /api/chat`
+
+Accepts `{ message, history }`.
+
+- Rate limited to 40 requests per 15 minutes per client.
+- `message` must be a non-empty string of at most 4,000 characters, otherwise
+  400 or 413.
+- `history` is truncated to the last 20 turns; each entry is capped at 4,000
+  characters and non-string content is skipped.
+- Roles are mapped: `user` → `user`, `model`/`assistant` → `model`.
+- Sends a large Spanish `systemInstruction` with `temperature: 0.7`.
+- Returns `{ text }`, or 500 with `{ error, details }`.
+
+### `POST /api/cron/sync-scholarships`
+
+Accepts `{ academicYear, secretKey }`.
+
+- Rate limited to 10 requests per 15 minutes.
+- Requires `CRON_SECRET`; returns 503 when the variable is unset and 401 when the
+  provided key does not match.
+- Prompts Gemini for at least 15 scholarship records in a fixed JSON shape, with
+  `responseMimeType: "application/json"` and `temperature: 0.2`.
+- Strips markdown fences from the response, parses it, and accepts either an
+  array or an object with `scholarships`/`items`.
+- Returns the parsed records in the response body.
+
+**It does not write to Firestore.** `server.ts` does not import Firebase. See
+[data.md](./data.md).
+
+## The system instruction
+
+`server.ts` holds a Spanish prompt defining the assistant as a migration adviser.
+It specifies four behaviours: answer in the user's language; produce a structured
+migration diagnosis when the user shares career, age, family situation, budget or
+languages; always cite official portals; keep a warm but rigorous tone.
+
+The prompt contains **hardcoded factual figures** — IPREM amounts, Sperrkonto,
+Express Entry age points, Stamp 2 conditions. These duplicate values that also
+exist in `src/data/migrationGuides.ts` and can drift from it. Updating them
+requires editing the prompt and redeploying.
+
+## Two chat surfaces that behave differently
+
+| Surface | Component | Backend |
+|---|---|---|
+| Chat IA tab | `ChatIA.tsx` (857 lines) | `POST /api/chat` → Gemini |
+| Floating bubble | `FloatingChatWidget.tsx` (273 lines) | Hardcoded `if/else` over keywords |
+
+`FloatingChatWidget.handleSendMessage` matches five keyword branches — scams,
+empadronamiento, budget, student work, and a generic fallback — and returns a
+fixed string. It makes no network call. The bubble is rendered on every screen,
+so it is the more prominent entry point.
+
+The consequence: the same question produces different answers depending on where
+it is asked. The fixed replies also embed their own figures (350–650 € rent,
+2,500–4,000 € starting buffer), a third copy of numbers that exist in the prompt
+and in the datasets.
+
+## Retrieval
+
+There is none. The model answers from its training data. The application's own
+verified content — 57 visa records, 22 scholarships, anti-scam guidance, consular
+addresses — is never passed as context.
+
+`ChatIA` already renders a `sources` array on assistant messages, but the backend
+never populates it, so citations only appear on the seeded example conversation.
+
+## Entry points into the chat
+
+Four screens navigate to the chat tab with a pre-filled prompt:
+
+- Scholarship detail — asks how to stand out in that specific application.
+- Country guide — asks about a named visa or the best visa for that country.
+- Planner step — asks for deadlines, costs and pitfalls for that step.
+- Budget — asks about the calculated budget.
+
+Prompts are built by string interpolation in `App.tsx` and the source components.
+
+## Input handling and abuse surface
+
+Length is capped and history is bounded, which limits cost. There is **no
+semantic filtering**: user text reaches the model directly, so prompt injection
+is possible. The practical risk is a manipulated answer rather than data
+exposure, since the model has no tools and no data access — but in a product
+where users act on migration advice, a manipulated answer has real consequences.
+
+There is no logging of prompts or responses, so a bad answer cannot be
+reproduced or investigated after the fact.
+
+## Client-side error handling
+
+`ChatIA` catches request failures and appends an assistant message telling the
+user to check their connection and retry. The failure is not reported anywhere
+else.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,220 @@
+# Architecture
+
+Current state of the system. Verified against the code, not a target design.
+
+## Stack
+
+| Layer | Technology | Version |
+|---|---|---|
+| UI | React (SPA) | 19 |
+| Build | Vite | 6 |
+| Styling | Tailwind CSS (via `@tailwindcss/vite`) | 4 |
+| Icons | lucide-react | 0.546 |
+| Maps | `@vis.gl/react-google-maps` | 1.9 |
+| Database | Firebase Firestore (client SDK) | 12 |
+| Auth | Firebase Auth — Google popup | 12 |
+| API server | Express | 4 |
+| AI | `@google/genai` — Gemini | 2.x |
+| Hosting | Vercel | — |
+| Tests | Vitest + Playwright | 4 / 1.62 |
+| Language | TypeScript | 5.8 |
+
+Approximately 19,400 lines of TypeScript across 88 tracked files.
+
+## Repository structure
+
+```
+├── api/index.ts             Vercel serverless entry — re-exports the Express app
+├── server.ts                Express app: 2 API routes + static/dev serving
+├── index.html               SPA shell, SEO meta tags, GA4 script tag
+├── public/analytics.js      GA4 configuration (external so the page needs no inline script)
+├── src/
+│   ├── main.tsx             Root render; mounts the three context providers
+│   ├── App.tsx              Tab state and conditional rendering of 10 screens
+│   ├── types.ts             Shared domain types
+│   ├── index.css            Tailwind theme, mobile ergonomics, animations, focus
+│   ├── components/          21 components, one per screen plus shared widgets
+│   ├── lib/                 firebase, i18n, currency, preferences, sanitize, auth, calendar
+│   ├── data/                6 static TypeScript datasets (135 KB)
+│   └── test/                Vitest setup, provider helper, server-side tests
+├── tests/e2e/               Playwright: desktop journeys, mobile layout, consistency
+├── firestore.rules          The only enforced data access control
+├── firebase-blueprint.json  Entity descriptions — documentation only, nothing enforces it
+└── .github/workflows/       ci.yml, update-scholarships.yml
+```
+
+## Main modules
+
+### `src/lib` — 1,555 lines, high cohesion
+
+| Module | Lines | Responsibility |
+|---|---|---|
+| `firebase.ts` | 808 | All Firestore and Auth access. The data layer. |
+| `i18n.tsx` | 218 | `LanguageProvider` + 45 translation keys (`es` / `en`). |
+| `currency.ts` | 165 | Conversion and formatting across supported currencies. |
+| `PreferencesContext.tsx` | 88 | Shared origin/destination country, in memory. |
+| `CurrencyContext.tsx` | 60 | Selected currency, in memory. |
+| `googleCalendar.ts` | 125 | Builds Google Calendar event URLs. |
+| `sanitize.ts` | 55 | `getSafeImageUrl`, `sanitizePlainText`. |
+| `authUtils.ts` | 23 | `isAdmin()` and the admin email allowlist. |
+
+### `src/components` — 11,881 lines
+
+One component per screen. Four exceed 1,000 lines and mix data fetching,
+business rules, UI state and presentation in a single file:
+
+| Component | Lines | Concerns held in one file |
+|---|---|---|
+| `BecasExplorer.tsx` | 1,935 | catalogue, filters, favourites, 3 modals, Firestore sync |
+| `PlanificadorMigracion.tsx` | 1,905 | plan, budget, checklist, persistence |
+| `Comunidad.tsx` | 1,022 | forum, replies, posting, filters |
+| `CalculadoraCostoVida.tsx` | 1,009 | cost model, currency, export, calendar |
+
+Shared widgets: `TopNavBar`, `MobileBottomNav`, `Footer`, `Breadcrumbs`,
+`FloatingChatWidget`, `ScrollTopBottomButton`, `AuthModal`,
+`NotificationSettingsModal`, `CalendarAgendaButton`.
+
+### `src/data` — 135 KB, bundled into the client
+
+| Dataset | Records | Size |
+|---|---|---|
+| `migrationGuides.ts` | 7 countries, 57 visas | 48 KB |
+| `scholarships.ts` | 22 | 35 KB |
+| `locations.ts` | 32 consulates and campuses | 20 KB |
+| `antiScamData.ts` | anti-scam guidance per country | 15 KB |
+| `volunteeringData.ts` | 6 programmes | 11 KB |
+| `countriesData.ts` | 29 Latin American + destination countries | 7 KB |
+
+All six are imported eagerly and ship in the initial bundle.
+
+## State management
+
+Three React contexts, all in-memory with no persistence:
+
+- `LanguageProvider` — `es` / `en`
+- `CurrencyProvider` — selected display currency
+- `PreferencesProvider` — origin and destination country, shared across screens
+
+Everything else is component-local `useState`. Across `src/components` there are
+**148 `useState`, 9 `useMemo`, 0 `useCallback` and 0 `React.memo`**.
+
+## Routing
+
+**There is no router.** `App.tsx` holds `activeTab` in `useState` and
+conditionally renders one of ten screens.
+
+Consequences of this decision, all currently in effect:
+
+- No shareable URLs; every visitor lands on the same entry point.
+- The browser back button does not navigate within the app.
+- No deep linking to a specific scholarship, guide or consulate.
+- Crawlers only ever see the home screen (see [seo.md](./seo.md)).
+
+## Data flow
+
+```
+Browser ──► Firestore (direct, client SDK)   all persistent reads and writes
+   │
+   └─────► Express /api/chat                  Gemini chat
+           Express /api/cron/sync-scholarships Gemini scholarship generation
+```
+
+The browser talks to Firestore directly. Express exists only to hold the Gemini
+API key server-side. There is **no service layer and no server-side validation
+of persisted data**: `firestore.rules` is the only enforced access control.
+
+### Write paths
+
+| What | Written by | Notes |
+|---|---|---|
+| User profile, plans, notes, bookmarks | Browser | Owner-scoped rules |
+| Forum posts, replies, suggestions | Browser | `create` currently allows unauthenticated writes |
+| Scholarship catalogue | Browser (admin UI) | `seedScholarshipsToDB()` writes documents one at a time |
+
+`/api/cron/sync-scholarships` generates scholarship data with Gemini and
+**returns it in the response body**. It does not import Firebase and does not
+write to Firestore. The only component that persists the result is the browser.
+
+## API surface
+
+| Route | Method | Auth | Rate limit |
+|---|---|---|---|
+| `/api/health` | GET | none | 120 / 15 min |
+| `/api/chat` | POST | none | 40 / 15 min |
+| `/api/cron/sync-scholarships` | POST | `secretKey` in body vs `CRON_SECRET` | 10 / 15 min |
+
+Input caps on `/api/chat`: 4,000 characters per message, 20 history turns,
+128 KB JSON body.
+
+## Architectural decisions detected
+
+These are inferred from the code. Some are deliberate, some appear incidental.
+
+1. **Client-direct database access.** No backend for data. Keeps the server
+   trivial; makes `firestore.rules` the entire security boundary.
+2. **Static datasets as the source of truth, Firestore as a cache.** Every
+   dataset has a static fallback, so the app stays useful when Firestore is
+   unavailable. The trade-off is that failures degrade silently.
+3. **Tab state instead of routing.** Simplest possible navigation; costs URLs,
+   history and crawlability.
+4. **Express only for AI.** The API key never reaches the client. On Vercel this
+   process serves only `/api/*`; the HTML and assets come from the CDN.
+5. **No browser storage.** Nothing is written to `localStorage` or
+   `sessionStorage`; a test enforces this. Preferences reset on reload.
+6. **Two deployment targets in the repo.** `vercel.json` + `api/index.ts` for
+   Vercel, and an unused multi-stage `Dockerfile` from an earlier Cloud Run
+   deployment.
+7. **Email allowlist for admin.** `authUtils.ts` holds four addresses; the
+   Firestore rule checks the verified email on the token.
+
+## Known problems
+
+Listed as facts about the current code.
+
+| Area | Problem |
+|---|---|
+| Type safety | `@types/react` and `@types/react-dom` are **not installed**. `React.FC` resolves to `any`, so JSX prop checking is disabled across ~12,000 lines. `npm run lint` runs `tsc --noEmit` and passes without checking components. |
+| Type safety | `tsconfig.json` does not set `strict`. `strictNullChecks` and `noImplicitAny` are off. |
+| Authorization | `AuthModal.tsx` renders a role selector that lets any signed-in user set `role: "admin"`. `isAdmin()` returns true on that field, and `users/{uid}` is writable by its owner, so the value persists. |
+| Data rules | `forumPosts`, `forumPosts/{id}/replies` and `feedbackSuggestions` allow `create` without authentication. |
+| Data rules | `visa_guide_votes` is read and written by `firebase.ts` but has **no rule declared**, so it falls through to the deny-all catch-all. The feature has never worked against Firestore; the in-memory fallback hides it. |
+| Data integrity | The weekly sync workflow calls an endpoint that returns data and never persists it. The catalogue only updates when an admin opens the app and clicks a button. |
+| Concurrency | `toggleBookmarkScholarship` is a query-check-write with `addDoc`, with no transaction. Zero `runTransaction` and zero `writeBatch` in the codebase. |
+| Admin API | `triggerScholarshipSync()` calls the cron endpoint without `secretKey`, so the admin sync button receives 401/503 since `CRON_SECRET` was made fail-closed. |
+| Resilience | No `ErrorBoundary` anywhere. A render exception blanks the whole app. |
+
+## Technical debt
+
+**Component size.** Four files over 1,000 lines mixing four concerns each. Adding
+a feature means editing a file that already does everything.
+
+**Render cost.** 148 `useState` against 9 `useMemo` and no memoisation. Every
+state change re-renders the whole component subtree. Vercel Speed Insights
+reports 40–80 ms renders when switching country in the guides.
+
+**Duplicated modal markup.** Twelve `fixed inset-0` overlays across nine
+components, each implemented separately. Two declare `role="dialog"`, one
+declares `aria-modal`, none trap focus.
+
+**Split i18n convention.** 125 inline `language === "en" ? … : …` ternaries
+against 86 `t()` calls. This already produced five tests asserting fallback
+strings that never render in production.
+
+**Dead and misplaced dependencies.** `motion` (804 KB) is installed with zero
+imports. `ConversorMonedas.tsx` (256 lines) is never imported. `vite`,
+`@vitejs/plugin-react` and `@tailwindcss/vite` sit in `dependencies` rather than
+`devDependencies`, and `vite` is listed in both.
+
+**Two chat implementations.** `ChatIA` calls Gemini through `/api/chat`.
+`FloatingChatWidget` answers from a hardcoded `if/else` over keywords. The same
+question gets different answers depending on entry point.
+
+**No code splitting.** Zero `React.lazy` or dynamic imports. The bundle is
+1,484 KB of JavaScript; all ten screens and all six datasets download to view one.
+
+**Lockfile ambiguity.** Both `package-lock.json` and `bun.lock` are tracked. CI
+runs `npm ci || npm install`, so a lockfile mismatch silently falls back to a
+different dependency tree.
+
+**Encoding artefact.** `vite.config.ts` contains a mojibake character in a
+comment (`Do not modify�file watching…`).

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,96 @@
+# CI/CD
+
+## Workflows
+
+Two workflows in `.github/workflows/`.
+
+### `ci.yml` — "CI / Unit & E2E Tests"
+
+Triggers: push to `main`/`master`, pull requests to those branches, and manual
+dispatch with a `full_e2e` input.
+
+**Job `unit-tests`** (5 min timeout, `contents: read` + `pull-requests: write`):
+1. `npm ci || npm install`
+2. `npm run format:check` — Prettier
+3. `npm run lint` — ESLint then `tsc --noEmit`
+4. `npm run test:coverage` — fails when thresholds are not met
+5. Renders the coverage table into the job summary via
+   `scripts/coverage-summary.mjs`
+6. Posts the same table as a sticky pull request comment, updating the existing
+   one rather than adding a new comment per push
+7. Uploads the HTML coverage report (7-day retention)
+
+**Job `e2e-tests`** (10 min timeout, needs `unit-tests`):
+1. `npm ci || npm install`
+2. `npx playwright install chromium --with-deps`
+3. `npm run build`
+4. `npm run test:e2e`
+5. Uploads the Playwright report (7-day retention)
+
+### `update-scholarships.yml` — "Scholarship Sync (Cron Job)"
+
+Triggers: Sundays at 04:00 UTC, plus manual dispatch with an `academic_year`
+input.
+
+1. Verifies `secrets.CRON_SECRET` and `vars.APP_BASE_URL` are set, failing with
+   an annotation if not.
+2. `POST {APP_BASE_URL}/api/cron/sync-scholarships` with the secret and academic
+   year, with retries and a 300 s cap.
+3. Parses `updatedCount` from the response and writes it to the job summary.
+4. Warns when the sync returns zero scholarships.
+
+> The endpoint it calls returns the generated data but does not persist it (see
+> [data.md](./data.md)). The workflow reports success while the catalogue is
+> unchanged.
+
+## Merge gates
+
+Documented in `CONTRIBUTING.md`. CI blocks a merge when `format:check`, `lint`,
+`test:coverage` or `e2e-tests` fails.
+
+Branch protection itself is **not configured in the repository** — it must be
+enabled in GitHub settings. `CONTRIBUTING.md` records the intended ruleset and
+notes that "Require approvals" should stay off while a single person maintains
+the project.
+
+## Deployment
+
+Not in the repository. Vercel deploys from its git integration:
+
+- Production on pushes to the default branch.
+- A preview deployment per pull request.
+
+`vercel.json` controls the build (`vite build` → `dist`), security headers, and
+routing: `/api/*` to the serverless function, everything except `/api/` and
+`/_vercel/` to `index.html`.
+
+## Secrets and variables
+
+| Name | Type | Used by |
+|---|---|---|
+| `CRON_SECRET` | secret | `update-scholarships.yml` |
+| `APP_BASE_URL` | variable | `update-scholarships.yml` |
+| `GITHUB_TOKEN` | automatic | coverage PR comment |
+
+Gemini and Firebase credentials are configured in Vercel, not in GitHub Actions.
+
+## Pipeline risks
+
+**`npm ci || npm install`** — the fallback turns a lockfile mismatch, which is a
+real signal, into a silent install of a different dependency tree. CI can pass
+green against dependencies nobody tested and that are not what deploys.
+
+**No `concurrency` group** — successive pushes to the same pull request run
+redundant jobs that compete for runners.
+
+**Playwright browsers are not cached** — `npx playwright install` re-downloads
+Chromium on every run.
+
+**E2E do not run against production configuration** — `npm run start` leaves
+`NODE_ENV` unset, so the server serves through Vite rather than `dist/`.
+
+**Two lockfiles** — `package-lock.json` and `bun.lock` are both tracked. CI uses
+npm; a contributor using Bun would resolve a different tree.
+
+**No CodeQL workflow in the repository.** Code scanning runs through GitHub's
+default setup, so its configuration is not versioned alongside the code.

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,144 @@
+# Data
+
+Firestore collections, access rules, static datasets and write paths, as they
+exist today. There is no ORM, no migrations and no schema enforcement.
+
+## Storage model
+
+Two sources of truth coexist:
+
+1. **Static TypeScript datasets** in `src/data/`, bundled into the client.
+2. **Firestore**, read directly by the browser via the Firebase client SDK.
+
+Every Firestore-backed screen falls back to the static dataset when the query
+fails or returns empty. This keeps the app usable without a database, and also
+means database failures are invisible to the user.
+
+## Static datasets
+
+| File | Records | Size | Changes with |
+|---|---|---|---|
+| `migrationGuides.ts` | 7 countries / 57 visas | 48 KB | Immigration law |
+| `scholarships.ts` | 22 | 35 KB | Annual calls and deadlines |
+| `locations.ts` | 32 | 20 KB | Consular addresses, phones, hours |
+| `antiScamData.ts` | per-country guidance | 15 KB | Rarely |
+| `volunteeringData.ts` | 6 | 11 KB | Programme availability |
+| `countriesData.ts` | 29 | 7 KB | Effectively static (reference data) |
+
+All six are eagerly imported and ship in the initial bundle.
+
+## Firestore collections
+
+`firebase-blueprint.json` documents entity shapes but nothing enforces it.
+Documents are whatever the client writes.
+
+| Collection | Read | Write | Written by |
+|---|---|---|---|
+| `scholarships` | public | admin only (verified email on token) | Browser, admin UI |
+| `users/{uid}` | owner | owner — **including `role`** | Browser, on sign-in |
+| `savedScholarships` | owner | owner | Browser |
+| `userNotes` | owner | owner | Browser |
+| `migrationPlans/{uid}` | owner | owner | Browser |
+| `userPreferences` | owner | owner | Browser |
+| `forumPosts` | public | **`create` unauthenticated** | Browser |
+| `forumPosts/{id}/replies` | public | **`create` unauthenticated** | Browser |
+| `feedbackSuggestions` | public | **`create` unauthenticated** | Browser |
+| `visa_guide_votes/{code}/visas` | **no rule declared** | **no rule declared** | Browser (always denied) |
+
+### Rule structure
+
+`firestore.rules` opens with a deny-all catch-all:
+
+```
+match /{document=**} { allow read, write: if false; }
+```
+
+Owner-scoped collections then check
+`isSignedIn() && resource.data.userId == request.auth.uid` on read/update/delete
+and `request.resource.data.userId == request.auth.uid` on create. That pattern is
+correct and consistently applied.
+
+`isAdmin()` checks `request.auth.token.email_verified == true` and the lowercased
+token email against a four-address allowlist. It is kept in sync manually with
+`ADMIN_EMAILS` in `src/lib/authUtils.ts`.
+
+### `visa_guide_votes` — undeclared path
+
+`fetchVisaGuideVotes` and `voteVisaHelpful` in `src/lib/firebase.ts` read and
+write `visa_guide_votes/{countryCode}/visas`. That path appears in no `match`
+block, so the deny-all catch-all applies. Both functions catch the permission
+error and fall back to a module-level `Map`, so the failure is invisible. Guide
+helpfulness votes have never persisted.
+
+It is the only collection referenced in code but absent from the rules.
+
+## Write paths
+
+### Owner-scoped writes
+Straightforward: the browser writes documents keyed to the signed-in user, and
+the rules confirm ownership.
+
+### Scholarship catalogue
+```
+GitHub Actions (weekly)
+      │  POST /api/cron/sync-scholarships
+      ▼
+Express ──► Gemini ──► returns JSON in the response body
+      │
+      └──►  (nothing persists it)
+
+Admin browser ──► triggerScholarshipSync() ──► same endpoint
+      └──► seedScholarshipsToDB(result.data) ──► Firestore
+```
+
+`server.ts` does not import Firebase. The only code that writes the catalogue is
+`seedScholarshipsToDB()` in the browser, called from `AdminDashboard` and
+`BecasExplorer`. The scheduled workflow therefore consumes Gemini quota and
+discards the result.
+
+`seedScholarshipsToDB` loops with sequential `await setDoc(..., { merge: true })`.
+There is no batching, so a failure part-way leaves the catalogue holding two
+academic years at once. `merge: true` means it never deletes, but it does
+overwrite the whole catalogue from a single UI button with no confirmation.
+
+### Bookmarks
+`toggleBookmarkScholarship` queries by `userId` + `scholarshipId`, checks whether
+the result is empty, then either deletes `snapshot.docs[0]` or calls `addDoc`
+with a random ID. There is no transaction. Two concurrent calls — a double tap
+on mobile — both see an empty result and create two documents; deletion only
+removes the first, leaving orphans.
+
+The codebase contains **zero `runTransaction` and zero `writeBatch`**.
+
+## Queries
+
+- 8 `getDocs` calls; 5 have no `limit()`.
+- The high-traffic ones are bounded: `fetchScholarshipsFromDB` at 100,
+  `fetchCommunityPostsPaginated` by `fetchLimit`.
+- Only `fetchCommunityPostsPaginated` combines `orderBy` with pagination.
+- No `firestore.indexes.json` exists, so any future composite query will fail
+  first in production.
+
+## Connections and pooling
+
+Handled by the Firebase client SDK. Nothing to configure or tune. Initialisation
+is wrapped in try/catch and falls back to a "safe mode" where `db` is null and
+every helper returns a static fallback.
+
+## Error handling
+
+`handleFirestoreError(error, operationType, path)` logs a JSON object and
+re-throws. The logged object includes `authInfo.userId` **and
+`authInfo.email`**, so user email addresses appear in error logs.
+
+## Data risks in the current design
+
+| Risk | Mechanism |
+|---|---|
+| Data loss | No Point-in-Time Recovery, scheduled exports or documented restore procedure. |
+| Corruption | Non-atomic catalogue seeding; Gemini output written without schema validation. |
+| Duplication | Bookmark toggle without transaction or deterministic ID. |
+| Race conditions | No transactions or batches anywhere in the data layer. |
+| Unauthorized access | Unauthenticated `create` on three collections; self-writable `role` field. |
+| Unbounded growth | Anonymous document creation is reachable through the public Firebase config, bypassing the Express rate limiter entirely. |
+| Counter manipulation | `hasOnly(['likes'])` constrains which keys change, not their values, and does not require authentication. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,96 @@
+# Deployment
+
+How the application reaches production today.
+
+## Target
+
+**Vercel**, via its git integration. There is no deployment workflow in
+`.github/workflows/`; Vercel builds on push.
+
+- Production deploys from the default branch.
+- Every pull request gets a preview deployment.
+
+## Configuration
+
+`vercel.json`:
+
+```json
+{
+  "buildCommand": "vite build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}
+```
+
+**Rewrites**
+- `/api/(.*)` → `/api/index` — the serverless function
+- `/((?!api/|_vercel/).*)` → `/index.html` — the SPA fallback
+
+The `_vercel/` exclusion matters: Vercel injects Analytics and Speed Insights
+scripts under that prefix, and a catch-all rewrite makes both report "No data
+available".
+
+**Headers** applied to every response: `X-Content-Type-Options`,
+`X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`,
+`Strict-Transport-Security`.
+
+`src/test/vercelConfig.test.ts` validates this file — the schema's allowed keys
+and both routing rules — because Vercel only validates it at deploy time, so a
+mistake here is invisible to the build, the linter and every other test.
+
+## How the two halves are served
+
+| Path | Served by |
+|---|---|
+| `/`, `/assets/*`, `/analytics.js` | Vercel CDN, from `dist/` |
+| `/api/*` | Serverless function from `api/index.ts` |
+
+`api/index.ts` re-exports the Express app from `server.ts`, so routes are defined
+once for local development, tests and production.
+
+`server.ts` skips `app.listen` when `process.env.VERCEL` is set, and imports Vite
+lazily so it is never pulled into the serverless bundle.
+
+Because the CDN serves the HTML, the page-level Content-Security-Policy set by
+Helmet in `server.ts` does not apply in production — it only applies when Express
+serves the SPA locally. Production security headers come from `vercel.json`.
+
+## Environment variables in production
+
+Configured in the Vercel project, not in the repository:
+`GEMINI_API_KEY`, `CRON_SECRET`, the `VITE_FIREBASE_*` set and the Google Maps
+key.
+
+`GOOGLE_MAPS_PLATFORM_KEY` is inlined at build time by `vite.config.ts` through
+`define`, so it is baked into the bundle.
+
+## The unused Dockerfile
+
+A multi-stage `Dockerfile` builds the frontend and the esbuild server bundle,
+installs production dependencies and runs `npm start` on port 3000. It is a
+Cloud Run configuration from an earlier deployment — the git history includes
+`fix:remove Cloud Run badge from README`.
+
+**Vercel does not use it.** Two deployment paths therefore coexist in the
+repository with nothing indicating which is authoritative.
+
+`server.ts` retains the corresponding static-serving branch for
+`NODE_ENV=production`, which is what `npm start` exercises locally.
+
+## Scheduled work
+
+`.github/workflows/update-scholarships.yml` runs Sundays at 04:00 UTC and calls
+`{APP_BASE_URL}/api/cron/sync-scholarships` with `CRON_SECRET`. It requires the
+`APP_BASE_URL` repository variable to be set.
+
+The endpoint returns generated data without persisting it, so the workflow
+reports success while the catalogue is unchanged. See [data.md](./data.md).
+
+## Backups and recovery
+
+None configured or documented. Firestore does not take automatic backups unless
+Point-in-Time Recovery or scheduled exports are enabled; there is no evidence of
+either, and no `firestore.indexes.json` is versioned.
+
+There is no documented procedure for restoring data after an accidental
+deletion, a bad rules deployment or a faulty sync.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,127 @@
+# Development
+
+Local setup, environment and tooling as they exist today.
+
+## Requirements
+
+- Node.js 22 (the version CI uses)
+- npm — note that `bun.lock` is also tracked, so a contributor using Bun would
+  resolve a different dependency tree
+
+## Setup
+
+```bash
+npm ci
+cp .env.example .env    # then fill in the values below
+npm run dev             # tsx server.ts — Express + Vite middleware on :3000
+```
+
+> The app starts **without** a `.env`. `src/lib/firebase.ts` falls back to a
+> hardcoded configuration pointing at the `refined-coral-0zp2g` project, and
+> `server.ts` constructs the Gemini client with `"dummy-key-for-boot"`. Nothing
+> warns about this, so an unconfigured checkout can read from and write to a real
+> Firebase project.
+
+## Environment variables
+
+`.env.example` documents 9 variables; the code reads 14.
+
+### Documented and used
+
+| Variable | Used by |
+|---|---|
+| `GEMINI_API_KEY` | `server.ts` — Gemini client |
+| `VITE_FIREBASE_API_KEY` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_AUTH_DOMAIN` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_PROJECT_ID` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_STORAGE_BUCKET` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_APP_ID` | `src/lib/firebase.ts` |
+| `VITE_FIREBASE_DATABASE_ID` | `src/lib/firebase.ts` — named Firestore database |
+
+### Used but **not** documented in `.env.example`
+
+| Variable | Used by |
+|---|---|
+| `CRON_SECRET` | `server.ts` — required, fails closed when unset |
+| `GOOGLE_MAPS_PLATFORM_KEY` | `vite.config.ts` — injected at build time |
+| `VITE_GOOGLE_MAPS_PLATFORM_KEY` | `src/components/MapaConsulados.tsx` |
+| `PORT` | `server.ts` — defaults to 3000 |
+| `NODE_ENV` | `server.ts` — selects the Vite or static branch |
+| `VERCEL` | `server.ts` — skips `app.listen` when set |
+
+### Documented but obsolete
+
+| Variable | Note |
+|---|---|
+| `APP_URL` | Described as injected by AI Studio at Cloud Run runtime. The project deploys to Vercel; nothing reads it |
+
+`firebase-applet-config.json` is also supported as a local config source via
+`import.meta.glob` in `src/lib/firebase.ts`, and is gitignored.
+
+## Scripts
+
+| Script | Does |
+|---|---|
+| `dev` | `tsx server.ts` — Express with Vite middleware |
+| `build` | `vite build` then esbuild bundles `server.ts` to `dist/server.cjs` |
+| `start` | `node dist/server.cjs` |
+| `preview` | `vite preview` |
+| `lint` | `eslint .` then `tsc --noEmit` |
+| `lint:fix` | `eslint . --fix` |
+| `typecheck` | `tsc --noEmit` |
+| `format` | `prettier --write .` |
+| `format:check` | `prettier --check .` — what CI runs |
+| `test` / `test:unit` | `vitest run` |
+| `test:watch` | `vitest` |
+| `test:coverage` | `vitest run --coverage`, thresholds enforced |
+| `test:e2e` | `playwright test` |
+| `test:e2e:full` | `FULL_E2E=true playwright test` — adds firefox, webkit, iPhone 12 |
+| `test:e2e:ui` | `playwright test --ui` |
+| `test:e2e:report` | `playwright show-report` |
+| `test:smoke` | `playwright test --grep @smoke` — **no test carries this tag yet** |
+| `clean` | `rm -rf dist server.js` |
+
+## Tooling
+
+**ESLint 9** — flat config in `eslint.config.js` with `typescript-eslint`,
+`eslint-plugin-react-hooks` and `eslint-plugin-jsx-a11y`. Defect-catching rules
+are errors (`rules-of-hooks`, five a11y rules, `no-console` except
+warn/error/info); the pre-existing backlog warns (`no-explicit-any`,
+`exhaustive-deps`, unused vars, `no-alert`). Current state: **0 errors, 144
+warnings**.
+
+**Prettier** — `.prettierrc.json`, 100-column width, double quotes, ES5 trailing
+commas. `.prettierignore` excludes build output, lockfiles and Markdown.
+
+**TypeScript 5.8** — `tsconfig.json` sets no `strict`, so `strictNullChecks` and
+`noImplicitAny` are off. `skipLibCheck` is on.
+
+> `@types/react` and `@types/react-dom` are **not installed**. Without them
+> `React.FC` resolves to `any` and JSX prop checking is disabled, so
+> `npm run lint` passes without type-checking components. See
+> [architecture.md](./architecture.md#known-problems).
+
+## Debugging
+
+- No source maps are published for the client build, so production stack traces
+  are minified.
+- No error tracking, so client exceptions are not collected. See
+  [observability.md](./observability.md).
+- `dist/server.cjs.map` is generated for the server bundle.
+- Playwright traces on first retry, screenshots and video on failure.
+
+## Reproducibility
+
+- CI runs `npm ci || npm install`. The fallback means a lockfile mismatch does
+  not fail the build; it silently installs a different dependency tree.
+- Two lockfiles are tracked (`package-lock.json`, `bun.lock`).
+- No `.nvmrc` or `engines` field pins the Node version; CI uses 22 by workflow
+  configuration only.
+- Development and production share the same Firebase project.
+
+## Onboarding gaps
+
+A new developer can start the app quickly, but cannot determine from the
+repository which environment variables are required (5 are undocumented), which
+of the two deployment paths is live, or what to do when data needs restoring.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,81 @@
+# Observability
+
+What the system can and cannot report about itself today.
+
+## Two different things
+
+**Product analytics** — what people do. Partially present.
+**Application observability** — what the system does. Absent.
+
+## Current capabilities
+
+| Capability | Status | Detail |
+|---|---|---|
+| Web Vitals | Present | Vercel Speed Insights (`@vercel/speed-insights`), mounted in `main.tsx`. Reports INP around 80 ms |
+| Page analytics | Present | Vercel Analytics (`@vercel/analytics`), mounted in `main.tsx` |
+| Google Analytics 4 | **Not configured** | `public/analytics.js` ships with the placeholder `G-MEASUREMENT_ID`. The tag loads; no property receives data |
+| Health endpoint | Present, unmonitored | `GET /api/health` returns `{ status: "ok" }`. Nothing polls it |
+| Error tracking | Absent | No Sentry or equivalent, client or server |
+| Structured logging | Absent | 41 `console.*` calls in plain text |
+| Request / correlation IDs | Absent | No way to follow one request end to end |
+| API monitoring | Absent | Latency and error rate of `/api/chat` are unknown |
+| Database monitoring | Absent | No visibility into Firestore reads, writes or cost |
+| Uptime monitoring | Absent | — |
+| Alerting | Absent | No condition triggers a notification |
+| Audit log | Absent | No record of catalogue changes, moderation or role changes |
+| Error boundary | Absent | A render exception blanks the app with no report |
+
+## What can be observed today
+
+- Aggregate page views and Web Vitals, through the Vercel dashboard.
+- CI results and test reports, through GitHub Actions artifacts.
+- Firestore usage and billing, through the Firebase and Google Cloud consoles,
+  by looking manually.
+
+## What cannot be observed
+
+- **Whether the API is working.** If `/api/chat` started returning 500 because
+  the Gemini quota ran out, nothing would report it.
+- **Whether the database is working.** If a rules deployment denied all writes,
+  every screen would keep rendering from its static fallback and look correct.
+- **Who did what.** No trail for catalogue overwrites, forum moderation or role
+  changes.
+- **Whether anyone is abusing the open write paths.** Anonymous document
+  creation is reachable directly through the Firebase REST API; the first signal
+  would be the bill.
+- **Client-side exceptions.** No aggregation, so a crash affecting some users is
+  invisible until someone reports it.
+
+## The silent-fallback pattern
+
+Every Firestore-backed screen falls back to static data on error, and the
+fallback path logs a warning to the browser console and returns. The effect is
+that failures degrade into stale-but-plausible content rather than visible
+errors.
+
+`visa_guide_votes` demonstrates this concretely: it has no Firestore rule, so
+every read and write is denied, and the in-memory fallback has hidden that for
+the lifetime of the feature. Nothing in the system reports it.
+
+Combined with the absence of error tracking, this is the most consequential gap:
+**the application is designed to keep working when it is broken, and nothing
+records that it is broken.**
+
+## Logging detail
+
+`handleFirestoreError` in `src/lib/firebase.ts` builds a JSON object containing
+the error message, operation type, path, and the user's **uid and email
+address**, then writes it with `console.error`. In the browser that stays local;
+anywhere it is collected it becomes stored personal data.
+
+API error responses include `details: error.message`, which can pass upstream
+provider messages through to the client.
+
+## Instrumentation points that already exist
+
+Useful anchors if instrumentation is added later:
+
+- `/api/health` — ready for an uptime check.
+- `handleFirestoreError` — a single funnel for every Firestore failure.
+- `OperationType` enum in `firebase.ts` — already classifies read/write/update.
+- The Express error handlers in `server.ts` — one place per route.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,80 @@
+# Performance
+
+Measured and observed characteristics of the current build.
+
+## Measurements
+
+| Metric | Value | Source |
+|---|---|---|
+| JavaScript bundle | 1,484 KB (≈385 KB gzipped) | `vite build` output |
+| CSS bundle | 123 KB | `vite build` output |
+| Static datasets in bundle | 135 KB | `src/data/` |
+| Code split points | 0 | no `React.lazy` or dynamic imports |
+| INP | ~80 ms | Vercel Speed Insights (good band is ≤200 ms) |
+| Slowest observed interaction | 40–80 ms | country buttons in the guides |
+| Images with `loading="lazy"` | 1 of 8 `<img>` | source |
+| Remote image URLs | 44 (images.unsplash.com) | source |
+| `useState` in components | 148 | source |
+| `useMemo` / `useCallback` / `React.memo` | 9 / 0 / 0 | source |
+
+Vite emits its "chunks larger than 500 kB" warning on every build.
+
+## Bundle composition
+
+Everything ships in one chunk: all ten screens, all six datasets, the Firebase
+SDK, the Google Maps wrapper and the icon library. A visitor who only wants the
+scholarship catalogue downloads the planner, the calculator, the forum, the map
+and 48 KB of visa guides for seven countries.
+
+`migrationGuides.ts` alone is 48 KB and is fully parsed to display one country.
+
+## Dependency weight
+
+- `motion` is installed (804 KB in `node_modules`) with **zero imports** in the
+  source.
+- `vite`, `@vitejs/plugin-react` and `@tailwindcss/vite` are listed in
+  `dependencies` rather than `devDependencies`, so they are installed in
+  production and pulled into the serverless function's dependency resolution.
+  `vite` appears in both `dependencies` and `devDependencies`.
+
+## Rendering
+
+With 148 `useState` against 9 `useMemo` and no `React.memo` or `useCallback`,
+each state change re-renders the full component subtree. In the four
+1,000-line components that subtree is large.
+
+`PlanificadorMigracion` rebuilds its migration step list from
+`originCountry`, `destinationCountry` and `pathway` on each render of that
+effect. `GuiaMigracion` re-renders the whole guide when the selected country
+changes, which is what Speed Insights records as the 40–80 ms interactions.
+
+## Network
+
+- Firestore queries are mostly bounded (`fetchScholarshipsFromDB` at 100,
+  community posts paginated). Five of eight `getDocs` calls have no `limit()`.
+- 44 images load from `images.unsplash.com` with sizing parameters in the URL.
+  Each card depends on a third party to render, with no cache control and no
+  availability guarantee. This is also why the CSP must allow `https:` broadly
+  in `img-src`.
+- The Google Maps SDK loads on the consular screen.
+- No service worker, so no offline capability or asset precaching.
+
+## Caching
+
+- Static assets are served by Vercel's CDN with its default headers.
+- `vercel.json` sets security headers but no explicit `Cache-Control`.
+- No application-level caching beyond the in-memory fallbacks in
+  `src/lib/firebase.ts`.
+
+## Loading states
+
+52 loading indicators across the components, so perceived performance during
+data fetches is handled. The gap is error states (2), not loading.
+
+## Assessment
+
+Real user metrics are in the good band, so performance is **not currently a user
+problem**. It is unhedged debt: the bundle grows with every screen added, and
+nothing in CI measures it. The three largest levers, in order of effect, are
+route-level code splitting, removing the unused and misplaced dependencies, and
+loading guide data per country instead of all seven.

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,163 @@
+# Product
+
+What the application does today, as built.
+
+## Purpose
+
+A Spanish-language platform for Latin American students and professionals
+planning to migrate to Europe or North America. It combines a verified
+scholarship catalogue, step-by-step visa guides, cost-of-living planning,
+consular directory, community forum and an AI assistant.
+
+The content is the product's core asset: 22 scholarships, 57 visa types across
+7 destination countries, 32 consulates and campuses, and country-specific
+anti-scam guidance.
+
+## Screens
+
+Ten screens, defined by the `NavigationTab` union in `src/types.ts`.
+
+| Tab | Screen | What it does |
+|---|---|---|
+| `home` | Hero + catalogue | Landing hero, feature cards, then the **full** scholarship explorer |
+| `becas` | Scholarship catalogue | Filter by country, education level, area, support type, institution, deadline; favourites; detail modal; suggest a scholarship |
+| `guia` | Migration guides | Per-country visa guides: requirements, costs, timelines, document checklist, anti-scam section |
+| `mapa` | Consular directory | Map + list of consulates, embassies and campuses; GPS detection; filter by origin and destination |
+| `chat` | AI assistant | Full-screen chat backed by Gemini; conversation list; profile diagnosis form |
+| `planificador` | 360° planner | Migration plan by origin/destination/pathway, step checklist, budget |
+| `calculadora` | Cost of living | City-based budget model, currency conversion, export, calendar reminder |
+| `voluntariados` | Volunteering | Catalogue of exchange, au pair, work & travel and language assistant programmes |
+| `comunidad` | Community forum | Posts, replies, likes, category filters |
+| `feedback` | Suggestions | Submit and upvote feature or scholarship suggestions |
+| `admin` | Admin dashboard | Metrics, database view, cron controls, security tab. Hidden unless `isAdmin()` |
+
+## Navigation
+
+- **Desktop (≥1024 px):** four primary items inline — Becas, Guía de Migración,
+  Mapa Consular, Chat IA — plus a **Herramientas** menu holding Comunidad,
+  Planificador, Calculadora, Voluntariados, Sugerencias and Panel Admin.
+  Currency, language and theme sit in a **Preferencias** menu.
+- **Mobile (<1024 px):** bottom bar with Inicio, Becas, Guías, Chat IA and Menú;
+  the drawer holds every destination plus currency, language and theme.
+
+There are no URLs. Navigation is `useState` in `App.tsx`.
+
+## Critical user flows
+
+### 1. Find and save a scholarship
+`home` or `becas` → filter → open detail modal → *Ver Detalles* → optionally
+*Consultar IA* (jumps to chat with a pre-filled prompt) or *Calendar* (Google
+Calendar deadline) → heart icon to favourite.
+
+Favourites persist to Firestore only when signed in. For guests they live in
+component state and are lost on reload.
+
+### 2. Research a visa
+`guia` → pick country → browse visa types by category → read requirements,
+proof-of-funds, costs → *Preguntar a IA* → chat with a pre-filled question.
+
+Selecting a country here updates the app-wide destination, so the planner,
+calculator, consular map and alert settings follow.
+
+### 3. Plan a migration
+`planificador` → set origin, destination and pathway → the step list regenerates
+from those three values → tick steps → per-step *Consultar IA*.
+
+Completed steps persist to Firestore for signed-in users only.
+
+### 4. Ask the assistant
+Two entry points that behave differently:
+- `chat` tab → `POST /api/chat` → Gemini.
+- Floating bubble (visible on every screen) → hardcoded keyword matching, no
+  network call.
+
+### 5. Sign in
+`AuthModal` → Google popup → profile written to `users/{uid}` → `App.tsx` reads
+it back and derives `role`.
+
+## Roles and permissions
+
+Two roles: `user` and `admin`.
+
+`isAdmin()` in `src/lib/authUtils.ts` returns true when **either**:
+1. `user.role === "admin"`, or
+2. the user's email is in the four-address allowlist.
+
+`firestore.rules` uses a different and independent check: the verified email on
+the auth token against the same four addresses. The `role` field is **not**
+consulted server-side.
+
+What admin unlocks in the UI: the `admin` tab, the database sync button in
+`BecasExplorer`, and admin-only controls in the dashboard.
+
+> **Known issue.** `AuthModal.tsx` renders "👤 Persona Normal" / "🔑 Administrador"
+> buttons to any signed-in user. The second calls
+> `onSignIn({ ...currentUser, role: "admin" })`. Because `users/{uid}` is
+> writable by its owner and `App.tsx` reads `role` from it, the elevation
+> persists across sessions. Firestore data writes remain protected by the
+> email-based rule; the UI authorization layer does not.
+
+## Important states
+
+| State | Where it lives | Survives reload |
+|---|---|---|
+| Active tab | `App.tsx` `useState` | No |
+| Theme | `App.tsx`, seeded from `prefers-color-scheme` | No |
+| Language | `LanguageProvider` | No |
+| Currency | `CurrencyProvider` | No |
+| Origin / destination country | `PreferencesProvider` | No |
+| Scholarship favourites | Component state + Firestore | Only when signed in |
+| Completed plan steps | Component state + Firestore | Only when signed in |
+| Chat history | Component state | No |
+
+Nothing is written to `localStorage` or `sessionStorage`; a test enforces this.
+
+## Feature dependencies
+
+- **Country selection** is shared through `PreferencesContext`. Guides, planner,
+  consular map, scholarship filter and alert settings all read and write it. It
+  starts empty so the catalogue is not pre-filtered before the user chooses.
+- **Chat** is a destination for four other screens, which navigate to it with a
+  pre-filled prompt (scholarship detail, guide, planner step, budget).
+- **Currency** affects the calculator, planner budget and scholarship amounts.
+- **Auth** gates persistence, not access. Every screen is usable signed out;
+  only saving is lost.
+- **Static datasets** back every Firestore-backed screen, so the app works
+  without a database.
+
+## Incomplete or partially wired features
+
+| Feature | State |
+|---|---|
+| Visa guide helpfulness votes | Client code reads and writes `visa_guide_votes`, but no Firestore rule declares that path, so every operation is denied and silently falls back to an in-memory cache. Votes have never persisted. |
+| Weekly scholarship sync | The workflow calls `/api/cron/sync-scholarships`, which generates data with Gemini and returns it. Nothing writes it to Firestore. The catalogue only updates through the admin UI. |
+| Admin sync button | `triggerScholarshipSync()` posts without `secretKey`; since the endpoint was made fail-closed it returns 401/503. |
+| Floating chat assistant | Answers from five hardcoded keyword branches; anything else gets a generic reply. Not connected to Gemini. |
+| Google Analytics | `public/analytics.js` ships with the placeholder `G-MEASUREMENT_ID`. No data is collected. |
+| Push notifications | `NotificationSettingsModal` requests browser permission and shows a confirmation, but no push subscription is registered and no service worker exists. |
+| `ConversorMonedas.tsx` | 256-line currency converter component, never imported. |
+
+## Edge cases worth knowing
+
+- **Destinations without consular data.** `locations.ts` covers Alemania,
+  Canadá, EE.UU., España, Reino Unido and Suiza. Choosing Portugal or Australia
+  as destination leaves the map filter with no matching option, and it silently
+  resets to "todos".
+- **Guest favourites.** Lost on reload, with no warning that signing in would
+  preserve them.
+- **Firestore unavailable.** Every screen falls back to static data without
+  telling the user, so stale content can look current.
+- **Deadlines in the past.** The catalogue sorts by `deadlineDate` but nothing
+  filters or flags expired calls, and the sync that would refresh them does not
+  persist.
+- **Two `<h1>` on home.** `HeroLanding` and `BecasExplorer` both render one.
+
+## Potential functional errors
+
+| Symptom | Cause |
+|---|---|
+| Duplicate favourites that cannot be removed | `toggleBookmarkScholarship` queries, checks, then writes with `addDoc` and no transaction. Two fast taps create two documents; deletion only removes `snapshot.docs[0]`. |
+| Blank screen with no message | No `ErrorBoundary`; any render exception unmounts the app. |
+| Chat scrolls to the bottom on open | `scrollIntoView` runs on first render against a seeded conversation that already has messages. |
+| Partially updated catalogue | `seedScholarshipsToDB` writes sequentially with no batching; a mid-loop failure leaves two academic years mixed. |
+| Guide labels never visible | `BecasExplorer` used an `xs:` breakpoint that was undefined until it was added to the theme. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,165 @@
+# Security
+
+Current security posture. Findings are stated as facts about the code.
+
+## Authentication
+
+Firebase Auth with Google sign-in via popup (`signInWithPopup`). No password
+handling, no custom session management. Tokens are stored by the Firebase SDK in
+IndexedDB — outside the "nothing in browser storage" policy, which covers
+application state only.
+
+`subscribeToAuthState` in `App.tsx` reacts to auth changes and loads the profile
+from `users/{uid}`.
+
+## Authorization
+
+Two independent checks that do **not** agree:
+
+| Layer | Check | Trusts |
+|---|---|---|
+| Client (`authUtils.ts`) | `user.role === "admin"` **or** email in allowlist | A field the user can write |
+| Firestore rules | `request.auth.token.email_verified` + token email in allowlist | The identity provider |
+
+The server-side rule is sound. The client-side check is not.
+
+### Privilege escalation (present)
+
+`src/components/AuthModal.tsx` renders two buttons to any signed-in user:
+
+```tsx
+onClick={() => { onSignIn({ ...currentUser, role: "admin" }); }}
+```
+
+Because `isAdmin()` short-circuits on `user.role === "admin"`, this unlocks the
+admin tab and admin-only UI. Because `firestore.rules` allows
+`users/{uid}` to be written by its owner, and `App.tsx` reads
+`role: profile?.role` back from that document, the elevation survives sign-out.
+
+What it grants: the admin dashboard and its controls. What it does **not** grant:
+scholarship writes, which the email-based rule still blocks. The data layer
+holds; the application authorization layer does not.
+
+## Data access control
+
+`firestore.rules` is the only enforced boundary — there is no server-side
+validation of anything persisted.
+
+**Sound:** deny-all catch-all, consistent owner scoping on the six private
+collections, admin-only scholarship writes, size limits on user-generated text.
+
+**Unsound:**
+
+- `forumPosts`, `forumPosts/{id}/replies` and `feedbackSuggestions` allow
+  `create` without `isSignedIn()`. The Firebase config ships in the client
+  bundle, so anyone can write directly through the Firestore REST API, bypassing
+  the app and every Express rate limiter.
+- Those `create` rules do not validate `userId` or `author`, so posts can be
+  attributed to another user.
+- `allow update: ... hasOnly(['likes'])` restricts which keys change but not the
+  value, and requires no authentication. `likes: 999999999` is accepted.
+- `visa_guide_votes` has no rule and is denied by the catch-all.
+
+## Secrets and environment
+
+| Item | Status |
+|---|---|
+| `.env` | Not tracked by git |
+| Real API keys in source | None found |
+| Firebase config in bundle | Yes — public by design for web SDKs |
+| Fallback project ID in source | `refined-coral-0zp2g` hardcoded in `src/lib/firebase.ts` as a default |
+| Admin emails in bundle | Yes — four addresses in `src/lib/authUtils.ts` |
+| `GEMINI_API_KEY` | Server-side only, never sent to the client |
+| `CRON_SECRET` | Server-side; fails closed when unset |
+| Google Maps key | Client-side; referrer restrictions not documented |
+
+The hardcoded fallback project ID is not a secret, but it does mean a developer
+without `.env` silently connects to a real Firebase project.
+
+The admin allowlist in the bundle is not a credential, but it is a target list
+for phishing aimed at the accounts that can modify the catalogue.
+
+## API hardening
+
+`server.ts`:
+
+- **Rate limiting** — `express-rate-limit` on all routes: 120/15 min general,
+  40/15 min chat, 10/15 min cron, 600/15 min static and SPA fallback.
+- **Input caps** — 4,000 characters per chat message, 20 history turns, 128 KB
+  JSON body.
+- **`CRON_SECRET` fails closed** — returns 503 when the variable is unset rather
+  than allowing the request.
+- **Helmet** — baseline headers plus a Content-Security-Policy enforced in every
+  environment, relaxed in development only (`'unsafe-inline'` for Vite's inline
+  preamble, `ws:` for HMR). A deny-all CSP (`default-src 'none'`) is scoped to
+  `/api`.
+- **`trust proxy` = 1** so the rate limiter keys on the real client address.
+- **`x-powered-by` disabled** by Helmet.
+
+`vercel.json` adds `X-Content-Type-Options`, `X-Frame-Options`,
+`Referrer-Policy`, `Permissions-Policy` and `Strict-Transport-Security` to the
+static site.
+
+The rate limiter's blind spot: it only protects Express. Direct Firestore writes
+from an anonymous client never reach it.
+
+## OWASP Top 10 status
+
+| Category | Status | Detail |
+|---|---|---|
+| A01 Broken Access Control | **Critical** | Role self-assignment; unauthenticated writes; unconstrained counters |
+| A02 Cryptographic Failures | OK | TLS at Vercel, HSTS set, no custom crypto |
+| A03 Injection | Medium | No SQL. Prompt injection possible on `/api/chat` — only length is filtered. No `dangerouslySetInnerHTML` anywhere |
+| A04 Insecure Design | High | One endpoint with one auth mechanism serving both cron and admin; catalogue written from the client |
+| A05 Security Misconfiguration | Medium | CSP in place. App Check absent. Maps key restrictions undocumented |
+| A06 Vulnerable Components | OK | `npm audit --omit=dev`: 0 vulnerabilities |
+| A07 Auth Failures | High | Authentication delegated correctly; authorization decided client-side |
+| A08 Data Integrity | High | Gemini output persisted without schema validation |
+| A09 Logging Failures | High | No structured logs, no alerts, no audit trail |
+| A10 SSRF | N/A | The server does not fetch user-supplied URLs |
+
+## XSS
+
+No `dangerouslySetInnerHTML`, no `innerHTML`, no `eval` in the codebase. React's
+default escaping applies throughout.
+
+`src/lib/sanitize.ts` provides `getSafeImageUrl` (protocol allowlist) and
+`sanitizePlainText` (HTML entity escaping). `getSafeImageUrl` is **not** applied
+in three places that render remote URLs:
+
+- `VoluntariadosExplorer.tsx:168` — `prog.imageUrl`
+- `AdminDashboard.tsx:365` — `currentUser.avatar`
+- `BecasExplorer.tsx:1339` — `beca.imageUrl` (from Firestore)
+
+Its allowlist includes `data:`, which contradicts the function's own comment.
+`data:` URIs do not execute in `<img src>`, so impact is low.
+
+## CSRF
+
+Not applicable. The API accepts no cookie-based credentials, so there is no
+ambient authority for a cross-site request to abuse. CORS is not configured on
+Express, which in practice means same-origin only.
+
+## Sensitive information
+
+`handleFirestoreError` logs the user's **email address and uid** on every
+Firestore error. In the browser that is the user's own console; in any log
+aggregation it becomes stored PII. Relevant under GDPR given the audience.
+
+API error responses on `/api/chat` and the cron endpoint include
+`details: error.message`, which can surface upstream provider messages to the
+client.
+
+## Dependency security
+
+`npm audit --omit=dev` reports 0 vulnerabilities. GitHub code scanning (CodeQL)
+is enabled and previously raised two alerts, both now resolved: missing rate
+limiting and an insecure Helmet configuration.
+
+## Not present
+
+- Firebase App Check — no attestation that requests come from the real app.
+- Audit log — no record of who changed the catalogue, moderated content or
+  changed roles.
+- Budget alerts or Firestore quotas — no ceiling on abuse cost.
+- Server-side validation of persisted data.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,85 @@
+# SEO
+
+Current search and social metadata, and the structural limits on discoverability.
+
+## What is in place
+
+`index.html` carries a reasonably complete set of tags:
+
+- `<html lang="es">`
+- `<title>` — "LatinoMigra - Becas, Guías Migratorias y Asistente IA"
+- `meta description` — names the specific programmes (Carolina, DAAD, Fulbright,
+  OEA) and destination countries
+- `meta keywords` — present, though ignored by major search engines
+- `meta author`, `meta robots` = `index, follow`
+- Open Graph: `og:type`, `og:site_name`, `og:url`, `og:title`, `og:description`,
+  `og:image`
+- Twitter Card: `summary_large_image` with title, description and image
+- `viewport` with `viewport-fit=cover`
+
+## What is missing
+
+| Item | Status |
+|---|---|
+| `robots.txt` | Absent |
+| `sitemap.xml` | Absent |
+| `rel="canonical"` | Absent |
+| `hreflang` | Absent, despite the app supporting `es` and `en` |
+| Structured data (JSON-LD) | Absent |
+| `manifest.json` | Absent |
+| `favicon.ico` | Absent |
+| Per-screen titles or descriptions | Absent |
+
+## Structural limits
+
+Two properties of the current architecture cap what any metadata work can
+achieve.
+
+**No routing.** Navigation is `useState` in `App.tsx`, so the entire application
+lives at one URL. There is no page for a scholarship, a country guide or a
+consulate. A crawler can only index the home screen, regardless of the 22
+scholarships, 57 visa types and 32 consular records the app contains. A sitemap
+would have exactly one entry.
+
+**No server-side rendering.** `server.ts` runs Vite in `appType: "spa"`, and on
+Vercel the build is a static SPA. The HTML shipped to a crawler is the shell in
+`index.html` — an empty `<div id="root">` plus meta tags. All content requires
+JavaScript execution. Google can render JavaScript, but does so on a delay and
+with less reliability than server-rendered HTML; other crawlers and most social
+scrapers do not render at all.
+
+Together these mean the product's main asset — a large body of specific,
+searchable migration content — is not indexable.
+
+## Stale metadata
+
+`og:url` points at a Cloud Run host from an earlier deployment:
+
+```
+https://ais-pre-5qazlj6w4zn36uak32ku6x-6760394599.europe-west2.run.app
+```
+
+The application deploys to Vercel. Every social share therefore advertises a URL
+that is not the production site.
+
+`og:image` and `twitter:image` both point at an Unsplash photograph rather than
+project-owned artwork, so link previews carry a generic stock image and depend on
+a third party remaining available.
+
+## Analytics
+
+`public/analytics.js` configures GA4 with the placeholder `G-MEASUREMENT_ID`.
+The Google Tag Manager script loads but no property receives data, so there is
+currently no search or acquisition data to work from.
+
+## Content strengths worth noting
+
+The underlying content is well suited to search, which is what makes the
+structural limits costly:
+
+- Long-tail specificity: named scholarships, named visa types, named consulates.
+- Question-shaped topics that match how people search ("cuánto dinero necesito
+  para estudiar en España").
+- Bilingual copy already exists for 45 UI keys, though the content datasets are
+  Spanish-only.
+- Genuine authority signals: every guide links its official government source.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,133 @@
+# Testing
+
+Current test suites, what they cover and where they mislead.
+
+## Suites
+
+| Suite | Runner | Files | Tests |
+|---|---|---|---|
+| Unit / component | Vitest 4 (jsdom) | 15 | 65 |
+| End-to-end | Playwright 1.62 | 4 | 29 |
+
+Coverage: **43.17 % statements, 43.40 % branches, 36.17 % functions,
+43.27 % lines** (v8 provider).
+
+## Commands
+
+```bash
+npm run test           # vitest run
+npm run test:unit      # same
+npm run test:watch     # vitest
+npm run test:coverage  # with thresholds enforced
+npm run test:e2e       # playwright, desktop + mobile projects
+npm run test:e2e:full  # FULL_E2E=true — adds firefox, webkit, iPhone 12
+npm run test:e2e:ui    # interactive
+```
+
+## Playwright projects
+
+Desktop and mobile are separate projects so neither suite runs against a layout
+it was not written for:
+
+- **chromium** (Desktop Chrome) — everything except `mobile.spec.ts`
+- **Mobile Chrome** (Pixel 5) — only `mobile.spec.ts`
+
+`PLAYWRIGHT_CHROMIUM_PATH` overrides the browser binary for environments that
+ship their own Chromium. `PLAYWRIGHT_TEST_BASE_URL` overrides the target URL.
+
+## What is genuinely covered
+
+**Mobile layout regressions** (`tests/e2e/mobile.spec.ts`) — the strongest part
+of the suite. Each test pins a defect that actually shipped:
+
+- No horizontal document scroll on any of the ten screens.
+- Layout viewport equals device width (catches shrink-to-fit).
+- Account, alerts and menu controls render inside the viewport.
+- Bottom-bar navigation reaches the main screens in one tap.
+- Drawer opens from the bottom bar, closes on Escape, restores scroll position.
+- Form controls compute to ≥16 px so iOS does not zoom on focus.
+- Navigation and account controls are ≥40 px.
+- No undersized controls on the home screen.
+- The floating chat button is inside the viewport, clickable, and clear of the
+  bottom bar.
+
+**Cross-screen consistency** (`consistency.spec.ts`) — a destination picked in
+the guides propagates to the planner and the consular map; the catalogue is not
+pre-filtered before the user chooses; nothing is written to browser storage;
+desktop navigation does not overlap the account controls; the tools and
+preferences menus open, close on outside click, and reach their screens.
+
+**Server behaviour** (`src/test/`) — rate limiter budget, 429 response, standard
+headers, per-client separation; `CRON_SECRET` failing closed; chat input caps;
+API security headers; `vercel.json` schema and routing rules.
+
+**Domain data** (`latinomigra.test.ts`) — every translation key has both
+languages; scholarships carry required metadata; guides exist for ES, DE, CA.
+
+**Country context** (`PreferencesContext.test.tsx`) — propagation between
+consumers, code/name mapping, no storage writes. 100 % covered.
+
+## What is not covered
+
+| Gap | Why it matters |
+|---|---|
+| Firestore rules | The three most serious data findings are all rule defects, and no test touches the rules. Requires the Firestore emulator. |
+| Admin authorization | The role-elevation path would pass every current test. |
+| `currency.ts` (5.6 % covered) | Pure logic affecting every amount the user sees. |
+| `sanitize.ts` (50 %) | A security function, half tested. |
+| `/api/chat` failure modes | No coverage of Gemini errors, timeouts or malformed responses. |
+| Runtime console errors | No test fails when the app throws. A CSP change once prevented React from mounting entirely and only a manual check caught it. |
+| Accessibility | Nothing checks labels, roles or live regions. |
+| Visual regression | The desktop navigation overlap was not caught by any test. |
+
+## Test quality issues
+
+**A test that asserts nothing after acting.**
+`src/components/GuiaMigracion.test.tsx:28` is named "allows clicking on checklist
+documents to toggle status". It clicks and then makes no assertion. It passes
+whether or not the toggle works.
+
+**Mocking depth removes the thing under test.**
+`src/test/setup.ts` mocks all of `firebase/firestore` with stubs returning empty
+results. No unit test exercises a real data path, which is why `firebase.ts` —
+808 lines and the most critical module — sits at 21 % coverage that validates
+no behaviour.
+
+**Text-coupled E2E selectors.**
+Several E2E assertions match visible Spanish copy (`text=Directorio Oficial de
+Becas`). Any wording change breaks them. Tests using stable `id` selectors are
+unaffected; the mix is inconsistent.
+
+**Provider-less rendering produced false positives.**
+Component tests originally rendered without the context providers. When they
+were wrapped in the real provider tree, five failed: they asserted i18n
+*fallback* strings such as `"Becas"` that never render in production, where the
+catalogue returns `"Becas & Estudios"`. Those expectations were corrected.
+`src/test/renderWithProviders.tsx` now mirrors `main.tsx` and should be used for
+any component test.
+
+**E2E do not exercise the production path.**
+`playwright.config.ts` starts the server with `npm run start`, which does not set
+`NODE_ENV=production`. `server.ts` therefore takes the Vite development branch.
+The 29 tests validate the dev server, not the built `dist/` output, so
+production-only behaviour — static routing, the stricter production CSP, the SPA
+fallback — is untested.
+
+## Coverage thresholds
+
+Defined in `vitest.config.ts` as a **ratchet**: set just below current numbers so
+coverage cannot regress, raised as tests land. `src/lib/PreferencesContext.tsx`
+carries a stricter per-file budget (95 % statements).
+
+Coverage excludes config, scripts, test helpers and `main.tsx`.
+
+The rationale for not setting a high global target is recorded in
+`CONTRIBUTING.md`: the codebase is ~11,900 lines of components against ~1,550 of
+pure logic, so a 95 % global threshold would mostly measure whether JSX renders.
+
+## What is only testable manually
+
+- Quality and accuracy of AI assistant answers.
+- Correctness of migration content against official government sources.
+- Comprehensibility for users with low digital literacy — this needs real users,
+  not tooling.

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -1,0 +1,103 @@
+# UX
+
+Current interaction design, as built.
+
+## Navigation
+
+Ten destinations. The structure differs by viewport.
+
+**Desktop (≥1024 px)** — four primary links inline (Becas, Guía de Migración,
+Mapa Consular, Chat IA), a **Herramientas** menu for the remaining six
+destinations, and a **Preferencias** menu holding currency, language and theme.
+
+This replaced ten inline items that overlapped each other and the account
+controls at common widths, and three unlabelled utility controls.
+
+**Mobile (<1024 px)** — a fixed bottom bar with Inicio, Becas, Guías, Chat IA
+and Menú. The drawer holds every destination plus currency, language and theme.
+Before the bottom bar existed, changing screens cost three taps.
+
+There are no URLs, so navigation state cannot be shared, bookmarked, or reached
+with the browser's back button.
+
+## Information architecture overlaps
+
+Three places where two things do the same job:
+
+1. **Scholarships appear twice.** The `home` tab mounts `HeroLanding` **and** the
+   complete `BecasExplorer`, with filters, pagination and modals. The `becas`
+   tab mounts the same component with the same props. Nothing distinguishes the
+   two views.
+2. **Planner and calculator overlap.** Both compute a migration budget and both
+   offer "Consultar IA". A user wanting to know how much money they need has no
+   basis for choosing.
+3. **Scholarships and volunteering share a pattern.** Both are filtered
+   catalogues with chips, cards and a detail modal, implemented separately.
+
+The footer also repeats most navigation destinations in four columns.
+
+## Interaction states
+
+| State | Count | Assessment |
+|---|---|---|
+| Loading | 52 indicators | Well covered |
+| Empty | 7 | Present on the main lists |
+| Error | 2 rendered | **Thin** — most failures are silent or use `alert()` |
+| Confirmation | 0 | "Sincronizar base de datos" overwrites the entire catalogue without asking |
+| Onboarding | 0 | No guided first run despite ten tools |
+
+The ratio of 52 loading indicators to 2 error states describes the dominant
+pattern: **the app communicates well when it works and says nothing when it
+fails.** Combined with the static fallbacks in the data layer, a user can be
+reading outdated content that looks current.
+
+## Feedback
+
+- Language changes show a transient toast.
+- Sync operations show inline status text in the admin and catalogue screens.
+- Three error paths in `Comunidad.tsx` use native `alert()`, which is jarring and
+  offers no recovery.
+- No toast or notification system exists; feedback is implemented per screen.
+
+## Mobile
+
+Recently addressed and verified by tests:
+
+- No horizontal scrolling on any screen. Previously the top bar rendered 543 px
+  of content in a 390 px viewport, which forced sideways scrolling everywhere and
+  made the browser shrink the whole page.
+- Sign-in, theme, currency and language controls are reachable. They were
+  previously off-screen.
+- 44 px touch targets and 16 px form fonts.
+- The floating chat collapses to a circular button so it stops covering the
+  primary call to action, and clears the bottom bar.
+- Range sliders have a visible, draggable thumb. They previously used
+  `appearance-none` with no thumb styling, leaving them invisible.
+- Dismissing the drawer restores the reading position instead of jumping to the
+  top.
+
+## Visual hierarchy
+
+- Type scale and spacing are consistent within screens.
+- A layered shadow scale distinguishes cards, popovers and modals, replacing
+  uniform hairline borders on a near-white ground.
+- Icons carry semantic colour per destination, applied consistently between the
+  desktop menu, mobile drawer and footer.
+
+## Cognitive load
+
+Dense screens present everything at once: the scholarship catalogue exposes six
+filters simultaneously; the planner shows budget and checklist together. For an
+audience that includes people with low digital literacy, a sequenced flow — one
+decision at a time — would fit better. This is a sequencing question about
+existing content, not a redesign.
+
+## Known interaction defects
+
+| Screen | Defect |
+|---|---|
+| Mapa Consular | Filters, map and list stack vertically, forcing scrolling on desktop where they would fit in one view |
+| Chat IA | The view jumps to the bottom on open, because `scrollIntoView` runs on first render against a seeded conversation that already has messages |
+| Home | Two `<h1>`, and the full catalogue renders twice per visit |
+| Becas | "Sincronizar base de datos" overwrites the catalogue with no confirmation or preview |
+| Comunidad | Native `alert()` on three error paths |


### PR DESCRIPTION
## What changes

Adds a `docs/` directory with 15 documents describing what the project **is
today**. No code changes.

## Why

The engineering audit surfaced findings that lived only in a report. This turns
the architecture diagnosis into reference documentation that stays with the
repository.

These documents are **descriptive, not aspirational**. Everything in them was
verified against the code — record counts, line counts, bundle sizes, rule
contents, dependency lists. Where a document states a problem, that problem
exists today. Planned work stays in GitHub issues rather than here.

## Contents

| Document | Covers |
|---|---|
| `architecture.md` | Stack, structure, modules, state, routing, data flow, decisions detected, known problems, technical debt |
| `product.md` | Screens, critical flows, roles, states, feature dependencies, incomplete features, edge cases |
| `data.md` | Firestore collections and rules, static datasets, write paths, query patterns |
| `security.md` | Auth, authorization, secrets, API hardening, OWASP Top 10 status |
| `testing.md` | Suites, what is genuinely covered, test quality issues |
| `ci-cd.md` | Workflows, merge gates, pipeline risks |
| `observability.md` | What can and cannot be observed today |
| `performance.md` | Bundle, rendering, network, measured Web Vitals |
| `accessibility.md` | WCAG 2.2 AA status per criterion |
| `ux.md` | Navigation, interaction states, information architecture |
| `seo.md` | Metadata and the structural limits on crawlability |
| `ai.md` | Gemini integration, prompts, the two chat surfaces |
| `development.md` | Local setup, environment variables, scripts, tooling |
| `deployment.md` | How the app reaches production, backups |
| `README.md` | Index and conventions |

## Beyond the requested set

Four extra areas were documented because the audit found material worth
recording:

- **`data.md`** — the Firestore layer is where the most consequential findings
  are, and nothing described the collections or their rules.
- **`ci-cd.md`** — the pipeline has real risks (`npm ci || npm install`, no
  concurrency group) that were undocumented.
- **`performance.md`** — measured numbers, so future changes have a baseline.
- **`development.md`** — closes a concrete gap: the code reads **14** environment
  variables, `.env.example` documents **9**, and one of those nine (`APP_URL`) is
  a leftover from the AI Studio / Cloud Run era that nothing reads.

## Notable facts recorded

Several of these were not previously written down anywhere:

- `@types/react` is not installed, so JSX prop checking is disabled and
  `npm run lint` passes without type-checking components.
- `visa_guide_votes` is read and written by `firebase.ts` but has no rule in
  `firestore.rules`, so every operation is denied and the in-memory fallback
  hides it. It is the only collection used in code but absent from the rules.
- `/api/cron/sync-scholarships` returns generated data without persisting it;
  only the browser writes the catalogue.
- `og:url` still points at a Cloud Run host from a previous deployment.
- `motion` is installed with zero imports; `ConversorMonedas.tsx` is never
  imported.

## How to test

```bash
npx prettier --check docs/
```

Cross-links between documents were verified to resolve.

## Checklist

- [x] Tested on mobile (375px) and desktop — n/a, documentation only
- [x] Tests added or updated — n/a, no code changed
- [x] No secrets or keys in the diff
- [x] If it touches data or Firestore rules, security implications reviewed — describes them, changes nothing

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_