### PR TITLE
fix(security): remove client-side role self-assignment

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -34,8 +34,9 @@ the table below is the only record of the intended shape.
 
 | Collection | Read | Write | Written by |
 |---|---|---|---|
-| `scholarships` | public | admin only (verified email on token) | Browser, admin UI |
-| `users/{uid}` | owner | owner — **including `role`** | Browser, on sign-in |
+| `scholarships` | public | admin only (entry in `admins`) | Browser, admin UI |
+| `admins/{uid}` | own entry only | **no rule — every client write denied** | Firebase console only |
+| `users/{uid}` | owner | owner, six named fields only | Browser, on sign-in |
 | `savedScholarships` | owner | owner | Browser |
 | `userNotes` | owner | owner | Browser |
 | `migrationPlans/{uid}` | owner | owner | Browser |
@@ -58,9 +59,17 @@ Owner-scoped collections then check
 and `request.resource.data.userId == request.auth.uid` on create. That pattern is
 correct and consistently applied.
 
-`isAdmin()` checks `request.auth.token.email_verified == true` and the lowercased
-token email against a four-address allowlist. It is kept in sync manually with
-`ADMIN_EMAILS` in `src/lib/authUtils.ts`.
+`isAdmin()` checks whether `admins/{request.auth.uid}` exists. Because that
+collection declares no write rule, the catch-all denies every client write and
+an administrator can only be added from the Firebase console.
+
+This replaced a four-address email allowlist that was duplicated in
+`src/lib/authUtils.ts` and shipped in the client bundle (#19).
+
+`users/{uid}` splits `create` and `update` so each can name the fields it
+accepts — `uid`, `displayName`, `email`, `photoURL`, `countryOfOrigin`,
+`updatedAt`. `allow write` previously accepted any field, including `role`,
+which `App.tsx` read back as an authorization decision.
 
 ### `visa_guide_votes` — undeclared path
 
@@ -139,6 +148,6 @@ re-throws. The logged object includes `authInfo.userId` **and
 | Corruption | Non-atomic catalogue seeding; Gemini output written without schema validation. |
 | Duplication | Bookmark toggle without transaction or deterministic ID. |
 | Race conditions | No transactions or batches anywhere in the data layer. |
-| Unauthorized access | Unauthenticated `create` on three collections; self-writable `role` field. |
+| Unauthorized access | Unauthenticated `create` on three collections. The self-writable `role` field was closed in #19. |
 | Unbounded growth | Anonymous document creation is reachable through the public Firebase config, bypassing the Express rate limiter entirely. |
 | Counter manipulation | `hasOnly(['likes'])` constrains which keys change, not their values, and does not require authentication. |

--- a/docs/product.md
+++ b/docs/product.md
@@ -73,29 +73,29 @@ Two entry points that behave differently:
 
 ### 5. Sign in
 `AuthModal` → Google popup → profile written to `users/{uid}` → `App.tsx` reads
-it back and derives `role`.
+it back, and separately reads `admins/{uid}` to decide whether the account is an
+administrator.
 
 ## Roles and permissions
 
 Two roles: `user` and `admin`.
 
-`isAdmin()` in `src/lib/authUtils.ts` returns true when **either**:
-1. `user.role === "admin"`, or
-2. the user's email is in the four-address allowlist.
+An account is an administrator when a document with its uid exists in the
+`admins` collection. Nothing else grants it. The interface reads that document
+once at sign-in (`isUserAdmin()` in `src/lib/firebase.ts`) and `isAdmin()` in
+`src/lib/authUtils.ts` reports the resolved flag; `firestore.rules` checks the
+same collection with `exists()`. One source of truth for both layers.
 
-`firestore.rules` uses a different and independent check: the verified email on
-the auth token against the same four addresses. The `role` field is **not**
-consulted server-side.
+Administrators are added and removed from the Firebase console. There is no
+in-app path — `admins` has no write rule, so the catch-all denies every client
+write.
 
 What admin unlocks in the UI: the `admin` tab, the database sync button in
-`BecasExplorer`, and admin-only controls in the dashboard.
+`BecasExplorer`, and admin-only controls in the dashboard. The `admin` tab is
+guarded at render and an effect returns a user who loses the role to `home`.
 
-> **Known issue.** `AuthModal.tsx` renders "👤 Persona Normal" / "🔑 Administrador"
-> buttons to any signed-in user. The second calls
-> `onSignIn({ ...currentUser, role: "admin" })`. Because `users/{uid}` is
-> writable by its owner and `App.tsx` reads `role` from it, the elevation
-> persists across sessions. Firestore data writes remain protected by the
-> email-based rule; the UI authorization layer does not.
+> Until #19 this was a self-service role: `AuthModal` offered a button that set
+> `role: "admin"` on the current user, and `isAdmin()` believed it.
 
 ## Important states
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,31 +14,46 @@ from `users/{uid}`.
 
 ## Authorization
 
-Two independent checks that do **not** agree:
+Both checks read the same source:
 
 | Layer | Check | Trusts |
 |---|---|---|
-| Client (`authUtils.ts`) | `user.role === "admin"` **or** email in allowlist | A field the user can write |
-| Firestore rules | `request.auth.token.email_verified` + token email in allowlist | The identity provider |
+| Client (`authUtils.ts`) | `user.isAdmin`, resolved once at sign-in from `admins/{uid}` | A collection no client can write |
+| Firestore rules | `exists(/databases/$(database)/documents/admins/$(request.auth.uid))` | The same collection |
 
-The server-side rule is sound. The client-side check is not.
+`admins` has a read-own rule and **no write rule at all**, so the deny-all
+catch-all rejects every create, update and delete from every client. Entries are
+added from the Firebase console.
 
-### Privilege escalation (present)
+### Privilege escalation (fixed in #19)
 
-`src/components/AuthModal.tsx` renders two buttons to any signed-in user:
+`AuthModal` used to render "👤 Persona Normal" / "🔑 Administrador" buttons to
+any signed-in user, the second calling
+`onSignIn({ ...currentUser, role: "admin" })`. `isAdmin()` short-circuited on
+`user.role === "admin"`, so that unlocked the admin tab and every admin-only
+control.
 
-```tsx
-onClick={() => { onSignIn({ ...currentUser, role: "admin" }); }}
-```
+Three things were wrong at once, and all three are closed:
 
-Because `isAdmin()` short-circuits on `user.role === "admin"`, this unlocks the
-admin tab and admin-only UI. Because `firestore.rules` allows
-`users/{uid}` to be written by its owner, and `App.tsx` reads
-`role: profile?.role` back from that document, the elevation survives sign-out.
+1. The selector existed. It is gone; a component test asserts no control changes
+   the role.
+2. `isAdmin()` trusted a client-supplied field. It now reads only the flag
+   derived from `admins/{uid}`.
+3. `users/{uid}` accepted any field, so `role: "admin"` written directly with
+   the SDK persisted and `App.tsx` read it back. The rule now allows only the
+   six fields the app writes, and `App.tsx` no longer reads `role` at all.
 
-What it grants: the admin dashboard and its controls. What it does **not** grant:
-scholarship writes, which the email-based rule still blocks. The data layer
-holds; the application authorization layer does not.
+A fourth path made it worse: the demo fallback in `AuthModal` signed a fake user
+in as a real administrator's address whenever the Google popup failed, which the
+email allowlist then accepted. The identity is now generic and the allowlist is
+gone.
+
+Data writes were never exposed — the scholarship rule validated the verified
+email on the token, not the `role` field.
+
+**Not covered by tests.** The `users` and `admins` rules have no automated
+verification: the project has no Firestore emulator (`firebase.json`,
+`@firebase/rules-unit-testing`). See `docs/testing.md`.
 
 ## Data access control
 
@@ -69,7 +84,7 @@ collections, admin-only scholarship writes, size limits on user-generated text.
 | Real API keys in git history | One leaked Google API key — see #16 |
 | Firebase config in bundle | Yes — public by design for web SDKs |
 | Fallback project ID in source | `refined-coral-0zp2g` hardcoded in `src/lib/firebase.ts` as a default |
-| Admin emails in bundle | Yes — four addresses in `src/lib/authUtils.ts` |
+| Admin emails in bundle | No — replaced by the `admins` collection in #19 |
 | `GEMINI_API_KEY` | Server-side only, never sent to the client |
 | `CRON_SECRET` | Server-side; fails closed when unset |
 | Google Maps key | Client-side; referrer restrictions not documented |
@@ -82,8 +97,10 @@ later flagged a Google API key committed in an earlier revision: removing a
 key from `HEAD` does not remove it from the objects git still holds, so the
 only remediation is rotation at the provider. Tracked in #16.
 
-The admin allowlist in the bundle is not a credential, but it is a target list
-for phishing aimed at the accounts that can modify the catalogue.
+The admin allowlist used to ship in the bundle — not a credential, but a target
+list for phishing aimed at the accounts that can modify the catalogue. It was
+removed in #19; administrator identities are no longer discoverable from the
+client.
 
 ## API hardening
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,12 +67,19 @@ languages; scholarships carry required metadata; guides exist for ES, DE, CA.
 **Country context** (`PreferencesContext.test.tsx`) — propagation between
 consumers, code/name mapping, no storage writes. 100 % covered.
 
+**Admin authorization** (`authUtils.test.ts`, `isUserAdmin.test.ts`,
+`AuthModal.test.tsx`, `TopNavBar.test.tsx`) — `isAdmin()` ignores a `role` field
+injected onto the user object and an address that used to be on the allowlist;
+`isUserAdmin()` fails closed and logs when the `admins` read is denied; the auth
+modal offers no control that changes a role; the admin navigation entry appears
+only for a user the `admins` collection granted. Regression cover for #19.
+
 ## What is not covered
 
 | Gap | Why it matters |
 |---|---|
-| Firestore rules | The three most serious data findings are all rule defects, and no test touches the rules. Requires the Firestore emulator. |
-| Admin authorization | The role-elevation path would pass every current test. |
+| Firestore rules | The most serious data findings are rule defects, and no test touches the rules. There is no `firebase.json` and no `@firebase/rules-unit-testing`, so the emulator would have to be set up first. This blocks verifying the `admins` and `users` rules added in #19, and issues #20, #22, #23 and #24. |
+| Signed-in E2E | The Playwright suite never authenticates, so "a signed-in non-administrator cannot reach the admin panel" is asserted at component level only. |
 | `currency.ts` (5.6 % covered) | Pure logic affecting every amount the user sees. |
 | `sanitize.ts` (50 %) | A security function, half tested. |
 | `/api/chat` failure modes | No coverage of Gemini errors, timeouts or malformed responses. |

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,18 +11,17 @@ service cloud.firestore {
       return request.auth != null;
     }
 
-    // Administrators, kept in sync with ADMIN_EMAILS in src/lib/authUtils.ts.
-    // The client-side check there is for showing UI only; this is the one that
-    // actually protects the data.
+    // Administrators are the documents present in /admins, keyed by uid. That
+    // collection has no write rule, so the catch-all denies every client write
+    // and entries can only be added from the Firebase console.
+    //
+    // This replaces a hardcoded list of four addresses that was duplicated in
+    // src/lib/authUtils.ts and had to be kept in sync by hand -- and which,
+    // being in the client bundle, published the admin accounts to anyone who
+    // read the JavaScript.
     function isAdmin() {
       return isSignedIn()
-             && request.auth.token.email_verified == true
-             && request.auth.token.email.lower() in [
-                  'ana.izaguirrematamoros@gmail.com',
-                  'latinomigra@gmail.com',
-                  'admin@latinomigra.com',
-                  'ana.izaguirre@gmail.com'
-                ];
+             && exists(/databases/$(database)/documents/admins/$(request.auth.uid));
     }
 
     // Default deny catch-all
@@ -38,9 +37,29 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    // User profile: owner can read/write
+    // Administrator registry: a user may check their own entry so the interface
+    // knows whether to offer the admin panel. Deliberately no write rule --
+    // the catch-all denies creates, updates and deletes from every client.
+    match /admins/{userId} {
+      allow read: if isSignedIn() && request.auth.uid == userId;
+    }
+
+    // User profile: owner can read and write, but only the fields the app
+    // actually writes. `allow write` used to accept any field, including
+    // `role`, which the client then read back as an authorisation decision --
+    // so a user could grant themselves the admin interface permanently.
     match /users/{userId} {
-      allow read, write: if isSignedIn() && request.auth.uid == userId;
+      allow read, delete: if isSignedIn() && request.auth.uid == userId;
+      allow create: if isSignedIn()
+                    && request.auth.uid == userId
+                    && request.resource.data.keys().hasOnly(
+                         ['uid', 'displayName', 'email', 'photoURL',
+                          'countryOfOrigin', 'updatedAt']);
+      allow update: if isSignedIn()
+                    && request.auth.uid == userId
+                    && request.resource.data.diff(resource.data).affectedKeys().hasOnly(
+                         ['uid', 'displayName', 'email', 'photoURL',
+                          'countryOfOrigin', 'updatedAt']);
     }
     
     // Saved Scholarships: user can access their own bookmarks

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import { ScrollTopBottomButton } from "./components/ScrollTopBottomButton";
 import { Footer } from "./components/Footer";
 import { AuthModal } from "./components/AuthModal";
 import { NotificationSettingsModal } from "./components/NotificationSettingsModal";
-import { subscribeToAuthState, getUserProfile, signOutUser } from "./lib/firebase";
+import { subscribeToAuthState, getUserProfile, isUserAdmin, signOutUser } from "./lib/firebase";
 import { isAdmin } from "./lib/authUtils";
 
 export default function App() {
@@ -51,7 +51,10 @@ export default function App() {
     const unsubscribe = subscribeToAuthState(async (fbUser) => {
       if (fbUser) {
         try {
-          const profile = await getUserProfile(fbUser.uid);
+          const [profile, admin] = await Promise.all([
+            getUserProfile(fbUser.uid),
+            isUserAdmin(fbUser.uid),
+          ]);
           const userData: GoogleUser = {
             id: fbUser.uid,
             name: fbUser.displayName || profile?.displayName || "Usuario LatinoMigra",
@@ -61,17 +64,14 @@ export default function App() {
               profile?.photoURL ||
               "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=150&auto=format&fit=crop&q=80",
             countryOfOrigin: profile?.countryOfOrigin || "Colombia",
-            role: profile?.role || "user",
+            // Never `profile?.role`: that document is writable by its owner.
+            isAdmin: admin,
             signedInAt: new Date().toLocaleDateString("es-ES", {
               day: "numeric",
               month: "short",
               year: "numeric",
             }),
           };
-          // Auto-verify admin role
-          if (isAdmin(userData)) {
-            userData.role = "admin";
-          }
           setCurrentUser(userData);
         } catch (e) {
           console.error("Error fetching user profile from Firestore:", e);
@@ -84,6 +84,16 @@ export default function App() {
 
     return () => unsubscribe();
   }, []);
+
+  // Leave the admin tab as soon as the user is not an administrator: on sign
+  // out, or when an admin entry is revoked while the panel is open. The render
+  // below is guarded too, so the panel never paints for an unauthorised user
+  // in the frame before this runs.
+  useEffect(() => {
+    if (activeTab === "admin" && !isAdmin(currentUser)) {
+      setActiveTab("home");
+    }
+  }, [activeTab, currentUser]);
 
   // Apply dark mode class to HTML element
   useEffect(() => {
@@ -221,7 +231,7 @@ export default function App() {
           </main>
         )}
 
-        {activeTab === "admin" && (
+        {activeTab === "admin" && isAdmin(currentUser) && (
           <main className="animate-fade-in">
             <AdminDashboard currentUser={currentUser} setActiveTab={setActiveTab} />
           </main>

--- a/src/components/AuthModal.test.tsx
+++ b/src/components/AuthModal.test.tsx
@@ -40,6 +40,47 @@ describe("AuthModal Component", () => {
     expect(screen.getByRole("button", { name: /Cerrar Sesión/i })).toBeInTheDocument();
   });
 
+  /**
+   * Regression for the privilege escalation in #19: the profile view used to
+   * render "👤 Persona Normal" / "🔑 Administrador" buttons, and the second
+   * called onSignIn({ ...currentUser, role: "admin" }). Administrators are
+   * defined by the admins collection now, so no control here may change a role.
+   */
+  it("offers no control that changes the account role", () => {
+    const mockUser: GoogleUser = {
+      id: "usr-1",
+      name: "Carlos Mendoza",
+      email: "carlos@example.com",
+      avatar: "https://example.com/avatar.jpg",
+      countryOfOrigin: "Colombia",
+      signedInAt: "13 ago 2026",
+    };
+    render(<AuthModal {...defaultProps} currentUser={mockUser} />);
+
+    expect(screen.queryByRole("button", { name: /Administrador/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Persona Normal/i })).toBeNull();
+
+    // The role is still shown, as a label rather than a choice. Matched on the
+    // exact badge text: the descriptive paragraph below it repeats the words.
+    expect(screen.getByText("👤 Usuario Estándar")).toBeInTheDocument();
+  });
+
+  it("shows the administrator label when the admins collection granted it", () => {
+    const adminUser: GoogleUser = {
+      id: "usr-2",
+      name: "Ana Izaguirre",
+      email: "ana@example.com",
+      avatar: "https://example.com/avatar.jpg",
+      countryOfOrigin: "Costa Rica",
+      signedInAt: "13 ago 2026",
+      isAdmin: true,
+    };
+    render(<AuthModal {...defaultProps} currentUser={adminUser} />);
+
+    expect(screen.getByText("🔑 Administrador")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Administrador/i })).toBeNull();
+  });
+
   it("calls onClose when close button is clicked", () => {
     render(<AuthModal {...defaultProps} />);
     const closeBtn = screen.getByRole("button", { name: /Cerrar modal/i });

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -11,7 +11,7 @@ import {
   LogOut,
 } from "lucide-react";
 import { GoogleUser } from "../types";
-import { signInWithGoogle, signOutUser } from "../lib/firebase";
+import { signInWithGoogle, isUserAdmin, signOutUser } from "../lib/firebase";
 import { getSafeImageUrl } from "../lib/sanitize";
 
 interface AuthModalProps {
@@ -40,6 +40,10 @@ export const AuthModal: React.FC<AuthModalProps> = ({
     setAuthError(null);
     try {
       const { user: fbUser, countryOfOrigin } = await signInWithGoogle(selectedCountry);
+      // App.tsx resolves this too, from its auth-state subscription, but the two
+      // race: whichever lands last wins. Without it here, an administrator who
+      // signs in can end up flagged as a normal user until the next reload.
+      const admin = await isUserAdmin(fbUser.uid);
       const userToSignIn: GoogleUser = {
         id: fbUser.uid,
         name: fbUser.displayName || "Usuario LatinoMigra",
@@ -48,6 +52,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           fbUser.photoURL ||
           "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=150&auto=format&fit=crop&q=80",
         countryOfOrigin: countryOfOrigin || selectedCountry,
+        isAdmin: admin,
         signedInAt: new Date().toLocaleDateString("es-ES", {
           day: "numeric",
           month: "short",
@@ -61,11 +66,15 @@ export const AuthModal: React.FC<AuthModalProps> = ({
         "Firebase Auth popup no completado o en modo de prueba, activando acceso rápido:",
         err
       );
-      // Demo Fallback for local preview if popup is blocked
+      // Demo fallback for local preview if the popup is blocked. The identity
+      // is deliberately generic: it used to be a real administrator's name and
+      // address, which shipped a personal email in the bundle and -- while
+      // isAdmin() still consulted an email allowlist -- handed the admin
+      // interface to anyone whose popup failed to open.
       const fallbackUser: GoogleUser = {
         id: "google-user-" + Date.now(),
-        name: "Ana Izaguirre",
-        email: "ana.izaguirre@gmail.com",
+        name: "Invitada LatinoMigra",
+        email: "invitado@latinomigra.local",
         avatar:
           "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=150&auto=format&fit=crop&q=80",
         countryOfOrigin: selectedCountry,
@@ -135,7 +144,11 @@ export const AuthModal: React.FC<AuthModalProps> = ({
               </div>
             </div>
 
-            {/* Role Switcher */}
+            {/* Account role — display only. The role selector that used to live
+                here called onSignIn({ ...currentUser, role: "admin" }), which
+                let any signed-in user grant themselves the admin interface.
+                Administrators are now defined by the `admins/{uid}` collection,
+                which no client can write. */}
             <div className="p-3 bg-surface dark:bg-slate-800/90 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-bold text-on-surface dark:text-slate-200">
@@ -143,49 +156,19 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                 </span>
                 <span
                   className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-                    currentUser.role === "admin"
+                    currentUser.isAdmin
                       ? "bg-violet-100 dark:bg-violet-950/60 text-violet-700 dark:text-violet-300 border border-violet-300 dark:border-violet-700"
                       : "bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700"
                   }`}
                 >
-                  {currentUser.role === "admin" ? "🔑 Administrador" : "👤 Usuario Estándar"}
+                  {currentUser.isAdmin ? "🔑 Administrador" : "👤 Usuario Estándar"}
                 </span>
               </div>
               <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
-                {currentUser.role === "admin"
+                {currentUser.isAdmin
                   ? "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos."
                   : "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración."}
               </p>
-              <div className="grid grid-cols-2 gap-2 pt-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    onSignIn({ ...currentUser, role: "user" });
-                  }}
-                  id="role-user-btn"
-                  className={`btn-tactile py-2 px-3 rounded-xl text-xs font-bold transition-all border ${
-                    currentUser.role !== "admin"
-                      ? "bg-primary text-white border-primary shadow-xs"
-                      : "bg-surface-container dark:bg-slate-750 text-on-surface-variant dark:text-slate-300 border-outline-variant/50 hover:bg-surface-container-high"
-                  }`}
-                >
-                  👤 Persona Normal
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    onSignIn({ ...currentUser, role: "admin" });
-                  }}
-                  id="role-admin-btn"
-                  className={`btn-tactile py-2 px-3 rounded-xl text-xs font-bold transition-all border ${
-                    currentUser.role === "admin"
-                      ? "bg-violet-600 text-white border-violet-600 shadow-xs"
-                      : "bg-surface-container dark:bg-slate-750 text-on-surface-variant dark:text-slate-300 border-outline-variant/50 hover:bg-surface-container-high"
-                  }`}
-                >
-                  🔑 Administrador
-                </button>
-              </div>
             </div>
 
             {/* Sync Features List */}

--- a/src/components/TopNavBar.test.tsx
+++ b/src/components/TopNavBar.test.tsx
@@ -37,6 +37,45 @@ describe("TopNavBar Component", () => {
     expect(screen.getByText(/Planificador/i)).toBeInTheDocument();
   });
 
+  /**
+   * Regression for #19. "Panel de Control" is gated on isAdmin(currentUser), which
+   * used to return true for any user carrying role === "admin" — a value the
+   * user could set on themselves from the auth modal.
+   */
+  describe("admin navigation entry", () => {
+    const signedIn = (overrides: Partial<GoogleUser> = {}): GoogleUser => ({
+      id: "usr-1",
+      name: "Carlos Mendoza",
+      email: "carlos@example.com",
+      avatar: "https://example.com/avatar.jpg",
+      countryOfOrigin: "Colombia",
+      signedInAt: "13 ago 2026",
+      ...overrides,
+    });
+
+    const openToolsMenu = () =>
+      fireEvent.click(screen.getByRole("button", { name: /Herramientas/i }));
+
+    it("is hidden from a signed-in user with no admin entry", () => {
+      render(<TopNavBar {...defaultProps} currentUser={signedIn()} />);
+      openToolsMenu();
+      expect(screen.queryByText("Panel de Control")).not.toBeInTheDocument();
+    });
+
+    it("is hidden from a user carrying an injected admin role", () => {
+      const escalated = { ...signedIn(), role: "admin" } as GoogleUser;
+      render(<TopNavBar {...defaultProps} currentUser={escalated} />);
+      openToolsMenu();
+      expect(screen.queryByText("Panel de Control")).not.toBeInTheDocument();
+    });
+
+    it("is shown when the admins collection granted the flag", () => {
+      render(<TopNavBar {...defaultProps} currentUser={signedIn({ isAdmin: true })} />);
+      openToolsMenu();
+      expect(screen.getByText("Panel de Control")).toBeInTheDocument();
+    });
+  });
+
   it("calls setActiveTab when a navigation item or logo is clicked", () => {
     render(<TopNavBar {...defaultProps} />);
 

--- a/src/lib/authUtils.test.ts
+++ b/src/lib/authUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { isAdmin } from "./authUtils";
+import { GoogleUser } from "../types";
+
+const user = (overrides: Partial<GoogleUser> = {}): GoogleUser => ({
+  id: "usr-1",
+  name: "Carlos Mendoza",
+  email: "carlos@example.com",
+  avatar: "https://example.com/avatar.jpg",
+  countryOfOrigin: "Colombia",
+  signedInAt: "13 ago 2026",
+  ...overrides,
+});
+
+describe("isAdmin", () => {
+  it("grants admin only when the flag resolved from the admins collection is true", () => {
+    expect(isAdmin(user({ isAdmin: true }))).toBe(true);
+  });
+
+  it("denies a user with no admin entry", () => {
+    expect(isAdmin(user())).toBe(false);
+    expect(isAdmin(user({ isAdmin: false }))).toBe(false);
+  });
+
+  it("denies null and undefined", () => {
+    expect(isAdmin(null)).toBe(false);
+    expect(isAdmin(undefined)).toBe(false);
+  });
+
+  /**
+   * Regression for the privilege escalation in #19.
+   *
+   * `isAdmin()` short-circuited on `user.role === "admin"`, and `AuthModal`
+   * offered a button that called `onSignIn({ ...currentUser, role: "admin" })`.
+   * Any signed-in user could therefore hand themselves the admin interface.
+   *
+   * The role field is gone from GoogleUser, so this asserts the shape a caller
+   * could still construct at runtime — a user object carrying `role: "admin"`
+   * must not be treated as an administrator.
+   */
+  it("ignores a role field injected onto the user object", () => {
+    const escalated = { ...user(), role: "admin" } as GoogleUser;
+    expect(isAdmin(escalated)).toBe(false);
+  });
+
+  it("ignores an admin email when no admin entry backs it", () => {
+    // The check used to fall back to a hardcoded ADMIN_EMAILS list shipped in
+    // the bundle. Authority is the admins collection now, nothing else.
+    const byEmail = user({ email: "ana.izaguirre@gmail.com" });
+    expect(isAdmin(byEmail)).toBe(false);
+  });
+});

--- a/src/lib/authUtils.ts
+++ b/src/lib/authUtils.ts
@@ -1,23 +1,15 @@
 import { GoogleUser } from "../types";
 
 /**
- * List of authorized administrator emails
- */
-export const ADMIN_EMAILS: string[] = [
-  "ana.izaguirrematamoros@gmail.com",
-  "latinomigra@gmail.com",
-  "admin@latinomigra.com",
-  "ana.izaguirre@gmail.com",
-];
-
-/**
- * Checks if a given user has Administrator privileges
+ * Whether a user holds administrator privileges.
+ *
+ * The flag is set once at sign-in from the `admins/{uid}` document, which no
+ * client can write — see `isUserAdmin` in `src/lib/firebase.ts` and the
+ * `admins` rule in `firestore.rules`. This function deliberately consults
+ * nothing else: it previously short-circuited on `user.role === "admin"`, and
+ * because `users/{uid}` is writable by its owner, that let any signed-in user
+ * grant themselves the admin interface.
  */
 export function isAdmin(user: GoogleUser | null | undefined): boolean {
-  if (!user) return false;
-  if (user.role === "admin") return true;
-  if (!user.email) return false;
-
-  const normalizedEmail = user.email.trim().toLowerCase();
-  return ADMIN_EMAILS.some((adminEmail) => adminEmail.toLowerCase() === normalizedEmail);
+  return user?.isAdmin === true;
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -197,6 +197,29 @@ export async function getUserProfile(userId: string) {
   }
 }
 
+/**
+ * Whether the signed-in user is an administrator.
+ *
+ * Authority lives in `admins/{uid}`, a collection with a read-own rule and no
+ * write rule at all, so the catch-all denies every client write: entries can
+ * only be added from the Firebase console. This is the single source of truth
+ * for both the interface and `isAdmin()` in `firestore.rules`.
+ *
+ * Fails closed. A denied or failed read returns false rather than assuming
+ * privilege, and `handleFirestoreError` logs it so the failure is visible
+ * instead of silently downgrading an administrator to a normal user.
+ */
+export async function isUserAdmin(userId: string): Promise<boolean> {
+  const path = `admins/${userId}`;
+  try {
+    const snap = await getDoc(doc(db, "admins", userId));
+    return snap.exists();
+  } catch (err) {
+    handleFirestoreError(err, OperationType.GET, path);
+    return false;
+  }
+}
+
 // Sign Out Helper
 export async function signOutUser() {
   if (!auth) return;

--- a/src/lib/isUserAdmin.test.ts
+++ b/src/lib/isUserAdmin.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getDoc } from "firebase/firestore";
+import { isUserAdmin } from "./firebase";
+
+/**
+ * `isUserAdmin` is the only thing that grants administrator status now, so its
+ * failure mode matters as much as its happy path: a denied or failed read must
+ * mean "not an administrator", never "assume yes".
+ */
+describe("isUserAdmin", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is true when the admins entry exists", async () => {
+    vi.mocked(getDoc).mockResolvedValueOnce({ exists: () => true } as never);
+    await expect(isUserAdmin("uid-1")).resolves.toBe(true);
+  });
+
+  it("is false when the admins entry does not exist", async () => {
+    vi.mocked(getDoc).mockResolvedValueOnce({ exists: () => false } as never);
+    await expect(isUserAdmin("uid-1")).resolves.toBe(false);
+  });
+
+  it("fails closed when the read is denied", async () => {
+    vi.mocked(getDoc).mockRejectedValueOnce(new Error("Missing or insufficient permissions"));
+    await expect(isUserAdmin("uid-1")).resolves.toBe(false);
+  });
+
+  it("reports the failure rather than swallowing it", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getDoc).mockRejectedValueOnce(new Error("network"));
+
+    await isUserAdmin("uid-1");
+
+    // A broken admin lookup silently downgrades an administrator to a normal
+    // user, which is exactly the kind of failure this project has shipped
+    // before. It must be visible.
+    expect(logged).toHaveBeenCalled();
+    expect(String(logged.mock.calls[0]?.[1])).toContain("admins/uid-1");
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,12 @@ export interface GoogleUser {
   avatar: string;
   countryOfOrigin?: string;
   signedInAt: string;
-  role?: "admin" | "user";
+  /**
+   * Derived from the `admins/{uid}` document at sign-in. Never read from the
+   * user's own profile: `users/{uid}` is client-writable, so a role stored
+   * there is a role the user can grant themselves.
+   */
+  isAdmin?: boolean;
 }
 
 export interface MigrationPlan {


### PR DESCRIPTION
## What changes

Closes the privilege escalation in #19. Administrators are now defined by an `admins` collection that no client can write, instead of a `role` field the user controls and an email allowlist shipped in the bundle.

Refs #19 — two of its five acceptance criteria are deliberately out of scope; see below.

## Why

Any signed-in user could grant themselves the admin interface. `AuthModal` rendered a "🔑 Administrador" button calling `onSignIn({ ...currentUser, role: "admin" })`, and `isAdmin()` short-circuited on `user.role === "admin"`.

**Four paths were open, not one:**

1. **The role selector existed.** Removed — the account role is now shown as a label, not offered as a choice.
2. **`isAdmin()` trusted a client-supplied field.** It now reports only a flag resolved at sign-in from `admins/{uid}`, a collection with a read-own rule and *no write rule at all*, so the deny-all catch-all rejects every client write. Entries are added from the Firebase console.
3. **`users/{uid}` accepted any field.** `allow write` meant `role: "admin"` written directly with the SDK persisted, and `App.tsx` read it back as an authorization decision. `create` and `update` now name the six fields the app actually writes, and `App.tsx` no longer reads `role`.
4. **The demo fallback signed a fake user in as a real administrator's address** whenever the Google popup failed — including when the user simply closed it — which the email allowlist then accepted. The identity is generic now.

**Correction to the issue's evidence.** #19 states the elevation "survives sign-out". That is not accurate: no application code writes `role` (`signInWithGoogle` writes six fields, `updateUserProfile` accepts two), so via the UI the escalation was in-memory and lost on reload. The persistent path was the Firestore rule, reachable by writing the field directly. Both are closed. The issue will be corrected.

**Also found:** `AdminDashboard` had no authorization check of its own — only the nav entry was hidden. The admin tab now has a render guard, plus an effect that returns a user who loses the role to `home` (covers sign-out while the panel is open).

`ADMIN_EMAILS` is gone from the client bundle, as is the duplicate four-address list in `firestore.rules` that had to be kept in sync by hand.

## How to test

**Before deploying the rules, create the `admins` documents** — Document ID must be the user's UID from Authentication → Users, not an Auto-ID. Publishing the rules first locks the maintainer out of their own admin panel.

`firestore.rules` is not deployed by this repository; it has to be published from the Firebase console or with `firebase deploy --only firestore:rules`. After deploying, sign out and back in — the admin flag is resolved at sign-in, so an open session keeps the old value.

Automated: 79 unit tests pass (was 65), Playwright green on desktop and mobile, `lint` 0 errors, `format:check` clean.

13 new tests:
- `src/lib/authUtils.test.ts` — a `role: "admin"` injected onto the user object grants nothing; neither does an address that used to be on the allowlist
- `src/lib/isUserAdmin.test.ts` — fails closed on a denied read, and logs rather than swallowing
- `AuthModal.test.tsx` — no control changes the account role
- `TopNavBar.test.tsx` — the admin entry appears only for a user the `admins` collection granted

Manually verified against `dist/`: no administrator address remains in the built bundle.

**Not covered.** The `users` and `admins` rules have no automated verification — the project has no Firestore emulator (`firebase.json`, `@firebase/rules-unit-testing`), which also blocks #20, #22, #23 and #24. The Playwright suite never authenticates, so "a signed-in non-administrator cannot reach the admin panel" is asserted at component level only. Both recorded in `docs/testing.md`.

## Out of scope

Two of #19's acceptance criteria need Firebase Admin SDK credentials the project does not have, and are a separate piece of work:

- Move role authority to Firebase Auth custom claims
- The bundle criterion is satisfied here by removing the allowlist entirely, rather than by claims

## Checklist

- [x] Tested on mobile (375px) and desktop — Playwright runs both projects
- [x] Tests added or updated
- [x] No secrets or keys in the diff — a personal address was *removed* from the bundle
- [x] If it touches data or Firestore rules, security implications reviewed — `docs/security.md`, `docs/data.md` updated; rules require human review before deployment

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_