### PR TITLE
fix(types): install React types and enable strict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,11 @@ These are project-specific. A reasonable default would break them.
    mounting. Page CSP belongs in `vercel.json`. This has already broken the app
    once.
 
-8. **`tsc` does not currently check components.** `@types/react` is not
-   installed, so `React.FC` resolves to `any` and JSX prop checking is off
-   (#21). Until that lands, a passing `npm run lint` is not evidence that props
-   are correct. Verify manually.
+8. **Do not remove `@types/react` or turn off `strict`.** Without those types
+   `React.FC` resolves to `any` and TypeScript silently stops checking JSX
+   props — the checker keeps passing while verifying nothing, which is how a
+   prop mismatch reached production once already.
+   `src/test/typeChecking.test.ts` fails if either is undone.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,9 +171,6 @@ Listed as facts about the current code.
 
 | Area | Problem |
 |---|---|
-| Type safety | `@types/react` and `@types/react-dom` are **not installed**. `React.FC` resolves to `any`, so JSX prop checking is disabled across ~12,000 lines. `npm run lint` runs `tsc --noEmit` and passes without checking components. |
-| Type safety | `tsconfig.json` does not set `strict`. `strictNullChecks` and `noImplicitAny` are off. |
-| Authorization | `AuthModal.tsx` renders a role selector that lets any signed-in user set `role: "admin"`. `isAdmin()` returns true on that field, and `users/{uid}` is writable by its owner, so the value persists. |
 | Data rules | `forumPosts`, `forumPosts/{id}/replies` and `feedbackSuggestions` allow `create` without authentication. |
 | Data rules | `visa_guide_votes` is read and written by `firebase.ts` but has **no rule declared**, so it falls through to the deny-all catch-all. The feature has never worked against Firestore; the in-memory fallback hides it. |
 | Data integrity | The weekly sync workflow calls an endpoint that returns data and never persists it. The catalogue only updates when an admin opens the app and clicks a button. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,13 +87,16 @@ warnings**.
 **Prettier** — `.prettierrc.json`, 100-column width, double quotes, ES5 trailing
 commas. `.prettierignore` excludes build output, lockfiles and Markdown.
 
-**TypeScript 5.8** — `tsconfig.json` sets no `strict`, so `strictNullChecks` and
-`noImplicitAny` are off. `skipLibCheck` is on.
+**TypeScript 5.8** — `strict` is on, so `strictNullChecks` and `noImplicitAny`
+apply. `skipLibCheck` stays on.
 
-> `@types/react` and `@types/react-dom` are **not installed**. Without them
-> `React.FC` resolves to `any` and JSX prop checking is disabled, so
-> `npm run lint` passes without type-checking components. See
-> [architecture.md](./architecture.md#known-problems).
+`@types/react` and `@types/react-dom` are in `devDependencies`. Without them
+`React.FC` resolves to `any` and TypeScript stops checking JSX props entirely —
+`tsc --noEmit` keeps passing while verifying nothing, which is how a prop
+mismatch reached production once (#21). `src/test/typeChecking.test.ts` guards
+both the packages and the `strict` flag, and compiles a component used with a
+prop it does not accept to prove the checker is live rather than merely
+present.
 
 ## Debugging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "@testing-library/user-event": "^14.6.4",
         "@types/express": "^4.17.21",
         "@types/node": "^22.14.0",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@types/supertest": "^7.2.1",
         "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.21",
@@ -1880,6 +1882,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "license": "MIT"
@@ -3258,6 +3280,13 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@testing-library/user-event": "^14.6.4",
     "@types/express": "^4.17.21",
     "@types/node": "^22.14.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@types/supertest": "^7.2.1",
     "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.21",

--- a/src/test/typeChecking.test.ts
+++ b/src/test/typeChecking.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
+import pkg from "../../package.json";
+import tsconfig from "../../tsconfig.json";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Guards the type checker itself.
+ *
+ * `@types/react` was absent for the life of the project. Without it `React.FC`
+ * resolves to `any` and TypeScript silently stops checking JSX props, so
+ * `npm run lint` ran `tsc --noEmit` over ~12,000 lines of components and
+ * verified nothing. A real defect shipped through that gap: `FloatingChatWidget`
+ * declared props that `App.tsx` never passed, lint passed, and the button threw
+ * a TypeError at runtime.
+ *
+ * Removing the dependency again would restore that silence without failing
+ * anything — hence these tests.
+ */
+describe("TypeScript configuration", () => {
+  it("declares the React type packages", () => {
+    expect(pkg.devDependencies).toHaveProperty("@types/react");
+    expect(pkg.devDependencies).toHaveProperty("@types/react-dom");
+  });
+
+  it("resolves the React type definitions on disk", () => {
+    // Declared but not installed is the same silence as never declared.
+    // Resolved through each package's manifest: the packages restrict their
+    // `exports`, so the .d.ts files are not addressable directly.
+    for (const name of ["@types/react", "@types/react-dom"]) {
+      const manifest = require.resolve(`${name}/package.json`);
+      expect(existsSync(join(dirname(manifest), "index.d.ts")), name).toBe(true);
+    }
+  });
+
+  it("enables strict mode", () => {
+    expect(tsconfig.compilerOptions.strict).toBe(true);
+  });
+
+  /**
+   * The decisive check: proving the checker is live rather than merely present.
+   * Compiles a component used with a prop it does not accept and requires the
+   * compiler to reject it.
+   */
+  it("rejects a component prop that does not exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lm-typecheck-"));
+    const file = join(dir, "probe.tsx");
+    writeFileSync(
+      file,
+      [
+        "interface Props { label: string }",
+        "const Widget = (_: Props) => null;",
+        "export const Broken = () => <Widget nonexistentProp={42} />;",
+      ].join("\n")
+    );
+
+    let failed = false;
+    let output = "";
+    try {
+      execFileSync(
+        "npx",
+        ["tsc", "--noEmit", "--strict", "--jsx", "react-jsx", "--skipLibCheck", file],
+        { cwd: process.cwd(), encoding: "utf8", stdio: "pipe" }
+      );
+    } catch (err: any) {
+      failed = true;
+      output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(failed, "tsc accepted an unknown prop — JSX checking is off").toBe(true);
+    expect(output).toMatch(/nonexistentProp/);
+  }, 60_000);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "strict": true,
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
     "module": "ESNext",


### PR DESCRIPTION
## What changes

Installs `@types/react` and `@types/react-dom`, enables `strict`, and adds a test that fails if either is undone.

Closes #21

## Why

Without `@types/react`, `React.FC` resolves to `any` and TypeScript silently stops checking JSX props. `npm run lint` ran `tsc --noEmit` across ~12,000 lines of components and verified nothing — a green check that meant nothing. A prop mismatch in `FloatingChatWidget` shipped through that gap and threw a `TypeError` at runtime while lint stayed green.

**The cascade the issue predicted does not exist.** #21 estimates **L**, with *"fix the resulting cascade of errors — this is the slow part"*. Measured:

| Configuration | Errors |
|---|---|
| `tsc --noEmit` with the types installed | **0** |
| `tsc --noEmit --strict` | **0** |
| `--strict` restricted to `src/lib` | **0** |

77 files are checked — all of `src/`, the tests, `server.ts` and the config files. The codebase was already strict-clean; only the type packages were missing. So `strict` goes on repo-wide in one step rather than directory by directory as the issue proposed, and the real effort is **XS**.

I verified `--strict` was actually taking effect rather than being ignored: a `strictNullChecks` probe and a `noImplicitAny` probe produce 2 errors with the flag and 0 without it.

## How to test

`npm run lint` — 0 errors. 90 unit tests (was 86) and 33 Playwright tests pass. `format:check` clean, build clean.

The new `src/test/typeChecking.test.ts` fails if:
- either package leaves `devDependencies`
- either package is declared but not installed — resolved through the package manifests, since both restrict their `exports` and the `.d.ts` files are not addressable directly
- `strict` is turned off
- **the compiler accepts a component prop that does not exist**

That last one is the decisive check the issue asks for, and the one that would actually have caught the original problem: it compiles a component used with `nonexistentProp={42}` and requires `tsc` to reject it. Declaring the dependency is not the same as the checker working, and only this asserts the difference.

To confirm by hand that prop checking is live:

```tsx
// anywhere under src/
export const Probe = () => <MobileBottomNav nonsenseProp={42} />;
```

`npm run lint` now reports `TS2322: Property 'nonsenseProp' does not exist`. Before this change it passed.

## Documentation

`CLAUDE.md` constraint 8 said *"`tsc` does not currently check components … a passing `npm run lint` is not evidence that props are correct. Verify manually."* That is now false, so it is rewritten as the inverse rule: do not remove the types or turn off `strict`.

Two **Known problems** rows in `docs/architecture.md` are removed for the same reason, plus a third left behind by #19 — it still described the role selector that PR deleted.

## Checklist

- [x] Tested on mobile (375px) and desktop — no UI change; Playwright runs both projects
- [x] Tests added or updated
- [x] No secrets or keys in the diff
- [x] If it touches data or Firestore rules, security implications reviewed — n/a, no data or rules touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_