### PR TITLE
feat(preferences): persist display settings, and sync project cards from labels

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -1,0 +1,64 @@
+name: Sync project status
+
+# The Projects V2 API is GraphQL-only, and the Claude Code session that does the
+# work has REST access only: it can label an issue but cannot touch the board.
+# So the agent sets a `status:*` label and this workflow moves the card.
+#
+# ONE-TIME SETUP
+#   Create a fine-grained PAT with read/write on Projects, and save it as the
+#   repository secret PROJECT_TOKEN. The built-in GITHUB_TOKEN cannot write to
+#   Projects V2 — that is a platform limitation, not a scope you can widen here.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: startsWith(github.event.label.name, 'status:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move the card to the labelled status
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_TITLE: Product Engineering Latino Migra
+          OWNER: ${{ github.repository_owner }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "PROJECT_TOKEN is not configured — see the header of this file." >&2
+            exit 1
+          fi
+
+          # status:in-progress -> "In Progress"
+          STATUS=$(printf '%s' "${LABEL#status:}" | tr '-' ' ' \
+            | awk '{ for (i = 1; i <= NF; i++) $i = toupper(substr($i,1,1)) substr($i,2) } 1')
+          echo "Target status: ${STATUS}"
+
+          NUMBER=$(gh project list --owner "${OWNER}" --format json \
+            | jq -r --arg t "${PROJECT_TITLE}" '.projects[] | select(.title==$t) | .number')
+          [ -n "${NUMBER}" ] || { echo "Project '${PROJECT_TITLE}' not found" >&2; exit 1; }
+
+          PROJECT_ID=$(gh project view "${NUMBER}" --owner "${OWNER}" --format json | jq -r '.id')
+
+          FIELDS=$(gh project field-list "${NUMBER}" --owner "${OWNER}" --format json)
+          FIELD_ID=$(jq -r '.fields[] | select(.name=="Status") | .id' <<<"${FIELDS}")
+          OPTION_ID=$(jq -r --arg s "${STATUS}" \
+            '.fields[] | select(.name=="Status") | .options[] | select(.name==$s) | .id' <<<"${FIELDS}")
+          [ -n "${OPTION_ID}" ] || { echo "Status option '${STATUS}' does not exist" >&2; exit 1; }
+
+          # item-add returns the existing item when the issue is already on the
+          # board, so this is safe to run every time.
+          ITEM_ID=$(gh project item-add "${NUMBER}" --owner "${OWNER}" \
+            --url "${ISSUE_URL}" --format json | jq -r '.id')
+
+          gh project item-edit --id "${ITEM_ID}" --project-id "${PROJECT_ID}" \
+            --field-id "${FIELD_ID}" --single-select-option-id "${OPTION_ID}"
+
+          echo "Moved ${ISSUE_URL} to ${STATUS}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,31 @@ Understand → Inspect → Plan → Confirm scope → Implement
 
 ---
 
+## Keeping the board current
+
+The Project's Status field is the record of what is happening. Move it as you
+go, not afterwards.
+
+| When | Set the label |
+|---|---|
+| You start work on an Issue | `status:in-progress` |
+| You name the Issue you intend to take next | `status:ready` |
+| You finish and are self-reviewing the diff | `status:ai-review` |
+
+**Set the label, not the field.** Projects V2 is a GraphQL-only API and this
+session has REST access only — it can label an Issue but cannot edit the board.
+`.github/workflows/project-status.yml` watches for `status:*` labels and moves
+the card. One label per Issue: remove the previous one when you add the next.
+
+Backlog, Human Review, Blocked and Done are not set this way. The Project's own
+workflows already handle Backlog on arrival and Done on close or merge, and the
+remaining two are a human's call.
+
+If the workflow has not been configured yet, say so in the report and give the
+label you would have set, rather than leaving the board silently stale.
+
+---
+
 ## Working from a GitHub Issue
 
 Issues are the unit of work. The GitHub Project carries fields you must respect:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -43,6 +43,26 @@ input.
 > [data.md](./data.md)). The workflow reports success while the catalogue is
 > unchanged.
 
+## Project board sync
+
+`.github/workflows/project-status.yml` fires when a `status:*` label is added to
+an Issue and moves that card's Status field on the Project.
+
+It exists because Projects V2 is a GraphQL-only API and the AI session doing the
+work has REST access only: it can label an Issue but cannot edit the board. The
+label is the interface between the two.
+
+`status:in-progress` → In Progress, `status:ready` → Ready,
+`status:ai-review` → AI Review. The mapping is mechanical — the label suffix is
+title-cased with dashes turned into spaces — so a new Status option needs no
+change here beyond the option existing on the Project.
+
+**Requires the `PROJECT_TOKEN` secret**: a fine-grained PAT with read/write on
+Projects. The built-in `GITHUB_TOKEN` cannot write to Projects V2 at all, which
+is a platform limitation rather than a permission that can be widened in the
+workflow. Without the secret the job fails loudly rather than skipping, so a
+stale board is visible instead of silent.
+
 ## Merge gates
 
 CI blocks a merge to `main` when any of these fails:


### PR DESCRIPTION
Two commits. They are unrelated and would normally be separate pull requests — the board sync landed here first and the branch had to carry the feature too, since a single branch is designated for this work.

Closes #40

---

## 1. Persist display preferences (#40)

Theme, language, currency and both country choices were in memory only, so every reload reset them. The country choice is the costly one: it drives the scholarship filter, the visa guides and the consular map, and it is the most tedious thing to re-enter.

**Two backends, chosen by whether anyone is signed in:**

| Visitor | Where preferences live |
|---|---|
| Signed in | `userPreferences/{uid}` in Firestore — nothing in the browser at all |
| Anonymous | The `lm_prefs` cookie |

Signing in merges the cookie into the account and deletes it. The cookie wins per key, because those are the choices made most recently — in this session, before signing in.

This **narrows** the no-browser-storage rule rather than dropping it. For a signed-in user the guarantee is now stronger than before: their preferences follow the account to another device and leave no local trace. `localStorage` and `sessionStorage` stay forbidden for everyone, and `noBrowserStorage.test.ts` still enforces it.

The cookie holds five display preferences and nothing else — no identifier, nothing personal — so no consent banner is required for it. `SameSite=Lax`, `Secure`, one year.

Adds a **Clear my preferences** control to the preferences menu. What can be stored must be erasable.

The four existing contexts keep their shape and gain two lines each rather than being merged into one provider, which would have been a larger change than the feature earns. `specs/preferences-persistence.md` records the design and the edge cases.

### Two defects found while building it

Both are covered by tests now, and both would have been invisible without them:

- **`detachUser` wiped the cookie on every cold start.** The auth subscription fires with `null` before anyone signs in, which the store counted as a sign-out. Preferences persisted correctly and then vanished a beat after the first render — the worst kind of bug, because a quick manual check looks fine.
- **`toggleTheme` called `setPreference` inside a `setState` updater**, firing a subscriber notification during render.

The store keeps its snapshot in module state, so `src/test/setup.ts` now resets it between tests. Without that a preference set in one test beat the value the next one seeded through props, and the failure read as a component bug.

---

## 2. Sync project cards from status labels

Projects V2 is a GraphQL-only API and the session doing the work has REST access only: it can label an Issue but cannot move a card. `.github/workflows/project-status.yml` closes that gap — the agent sets `status:in-progress`, `status:ready` or `status:ai-review`, and the workflow moves the card.

Backlog and Done stay with the Project's own built-in workflows; Human Review and Blocked stay a human's call. `CLAUDE.md` gains the rule so it survives context loss.

**Needs a `PROJECT_TOKEN` secret**: a fine-grained PAT with read/write on Projects. The built-in `GITHUB_TOKEN` cannot write to Projects V2 at all, so there is no scope to widen instead. The job fails loudly when the secret is missing rather than skipping, so a stale board stays visible.

---

## How to test

Change the theme or pick a country, reload — it holds. Open the preferences menu and clear, and everything returns to defaults.

108 unit tests (was 90) and 39 Playwright tests pass; `lint` 0 errors / 35 warnings; `format:check` and build clean.

18 new unit tests cover the cookie round-trip, corrupt and partial payloads, per-key sanitising, the Firestore round-trip, the sign-in merge, sign-out, and clearing — including that clearing cancels a pending debounced write so it cannot resurrect the values. Four new E2E tests cover reload persistence for theme and country, the cookie's attributes and the continued absence of browser storage, and the clear control.

## Documentation

`CLAUDE.md` constraint 1 rewritten, plus `docs/data.md`, `docs/ux.md`, `docs/security.md`, `docs/ci-cd.md` and the new spec.

## Checklist

- [x] Tested on mobile (375px) and desktop
- [x] Tests added or updated
- [x] No secrets or keys in the diff
- [x] If it touches data or Firestore rules, security implications reviewed — writes to an existing owner-scoped collection under a `display` key; no rule change needed