### PR TITLE
docs: one change per pull request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,30 @@ These are project-specific. A reasonable default would break them.
 
 ## Workflow
 
+### One change per pull request
+
+A pull request answers one question: should this change land? Two unrelated
+changes in one branch force a single yes-or-no on both, so a reviewer who wants
+one and doubts the other has no way to say so.
+
+This has already gone wrong here. A TypeScript fix, a CSS fix and a lint sweep
+each ended up in a pull request opened for something else, because work started
+while the previous one was still open.
+
+The cause is structural, not carelessness: **one branch is designated for this
+work**, so any commit made while a pull request is open on it lands in that
+pull request. Therefore:
+
+- Do not start the next Issue while a pull request is open on the branch. Say
+  what you intend to take next and wait for the merge.
+- The exception is a change *to* the open pull request — a review fix, a failing
+  check, a merge conflict.
+- If something urgent appears mid-flight, say so and let the human decide
+  whether to merge first or accept the mixing. Do not decide it silently.
+- When mixing does happen anyway, the pull request description must say so and
+  describe both changes. A body that describes one change while the diff
+  contains two is worse than the mixing itself.
+
 ### Trivial changes
 
 A change is trivial when it is a typo, a comment, a single-line fix with an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,12 @@ CI blocks the merge to `main` if `format:check`, `lint`, `test:coverage` or the
 Playwright suite fails. Branch protection is configured in GitHub, not in the
 repository — see [docs/ci-cd.md](./docs/ci-cd.md).
 
+## Pull requests
+
+One change per pull request. Two unrelated changes force a reviewer into a
+single yes-or-no on both. See [CLAUDE.md](./CLAUDE.md) for why this is easy to
+get wrong here, and what to do instead.
+
 ## Style
 
 - All user-visible text goes through `t()` from `src/lib/i18n.tsx`.


### PR DESCRIPTION
## What changes

Adds a **one change per pull request** rule to `CLAUDE.md`, referenced from `CONTRIBUTING.md`.

## Why

A pull request answers one question: should this change land? Two unrelated changes force a single yes-or-no on both, so a reviewer who wants one and doubts the other has no way to say so.

Three pull requests so far have carried work opened for something else — a TypeScript fix, a CSS fix and a lint sweep each landed in someone else's review.

**The rule does not just state the principle, because the principle was never the problem.** The cause is structural: one branch is designated for this work, so any commit made while a pull request is open on it joins that pull request. Stating "keep pull requests focused" and leaving that trap in place would change nothing.

So the rule says what to do about it:

- Do not start the next Issue while a pull request is open on the branch. Name what you intend to take next and wait for the merge.
- The exception is a change *to* the open pull request — a review fix, a failing check, a merge conflict.
- If something urgent appears mid-flight, say so and let the human decide whether to merge first or accept the mixing. Do not decide it silently.
- When mixing happens anyway, the description must describe both changes. A body that describes one change while the diff contains two is worse than the mixing itself.

That last clause was exercised immediately: this commit was written while #42 was open, and holding it unpushed risked losing it, so #42's description was rewritten to cover both. The merge then took only the feature commit, which is why this one is now on its own — the outcome the rule wants, reached the long way round.

## The structural fix, not taken here

Per-Issue branches (`claude/issue-38-forum-filter`) would remove the problem rather than manage it: each pull request would start isolated, and work on the next Issue would not have to wait.

That needs a decision, since the current instruction is to develop everything on one designated branch and never push elsewhere without explicit permission. Not assumed in this pull request.

## How to test

Documentation only. No source file is touched; `lint`, `format:check` and the suites are unaffected.

## Checklist

- [x] Tested on mobile (375px) and desktop — n/a, documentation
- [x] Tests added or updated — n/a
- [x] No secrets or keys in the diff
- [x] If it touches data or Firestore rules, security implications reviewed — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_