### PR TITLE
feat(ui): one Modal on Radix, replacing 11 hand-rolled overlays

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -41,6 +41,22 @@ semantic layer, which is not visible, remains largely unaddressed.
 - Escape closes the drawer and both desktop menus.
 - Semantic landmarks: `<nav>`, `<main>`, `<header>`, `<footer>` are used.
 
+## Dialogs
+
+All dialogs render through `src/components/ui/Modal.tsx`, on Radix's dialog
+primitive. That supplies the focus trap, `Escape`, the portal, `aria-modal` and
+the `aria-labelledby`/`aria-describedby` wiring — none of which the twelve
+hand-written overlays had between them. With one open, the page behind is
+hidden from assistive technology and unreachable by Tab.
+
+Focus return is handled in the component rather than by Radix: every dialog is
+controlled from an external button rather than a `Dialog.Trigger`, so Radix had
+nothing to restore to and focus fell to `<body>`. The component remembers what
+was focused when the dialog opened.
+
+A custom `header` renders its own visible heading, so the accessible name is a
+visually hidden `span` rather than a second heading with the same text.
+
 ## What is missing
 
 **Form labels.** 24 inputs, one `htmlFor`. Screen readers announce "edit box"

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -78,6 +78,13 @@ Recently addressed and verified by tests:
   them in Firestore and nothing in the browser, so they follow the account to
   another device. Signing in migrates the cookie and deletes it. A **Clear my
   preferences** control in the preferences menu empties both.
+- Every dialog is one component, `src/components/ui/Modal.tsx`, built on
+  `@radix-ui/react-dialog`. A sheet rising from the bottom edge on a phone, a
+  centred dialog on a pointer device. Eleven of the twelve hand-written overlays
+  are gone; the twelfth is the navigation drawer, which is a different shape and
+  keeps its own implementation.
+- Focus is trapped inside an open dialog and returns to the control that opened
+  it. Neither was true of any overlay before.
 - The scholarship catalogue says where its list came from. The bundled dataset
   renders immediately and Firestore replaces it, which used to happen silently —
   and a failed load was indistinguishable from a successful one. A polite live

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^2.4.0",
+        "@radix-ui/react-dialog": "^1.1.23",
         "@tailwindcss/vite": "^4.1.14",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
@@ -1530,6 +1531,320 @@
       "version": "1.1.2",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "license": "MIT"
@@ -1886,7 +2201,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1896,7 +2211,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2677,6 +2992,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "dev": true,
@@ -3287,7 +3614,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3478,6 +3805,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -4538,6 +4871,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -6380,6 +6722,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "dev": true,
@@ -7450,6 +7861,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@google/genai": "^2.4.0",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@tailwindcss/vite": "^4.1.14",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
-import { X, ShieldCheck, Bookmark, Calendar, Sparkles, Globe, LogOut } from "lucide-react";
+import { ShieldCheck, Bookmark, Calendar, Sparkles, LogOut } from "lucide-react";
 import { GoogleUser } from "../types";
 import { signInWithGoogle, isUserAdmin } from "../lib/firebase";
 import { getSafeImageUrl } from "../lib/sanitize";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -22,10 +22,6 @@ export const AuthModal: React.FC<AuthModalProps> = ({
 }) => {
   const [selectedCountry, setSelectedCountry] = useState<string>("Colombia");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-
-  useBodyScrollLock(isOpen);
-
-  if (!isOpen) return null;
 
   const handleFirebaseGoogleSignIn = async () => {
     setIsLoading(true);
@@ -83,172 +79,159 @@ export const AuthModal: React.FC<AuthModalProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 animate-fade-in lm-overlay">
-      <div className="bg-surface-container-lowest dark:bg-slate-900 rounded-3xl max-w-md w-full p-6 md:p-8 space-y-6 shadow-2xl border border-outline-variant/40 dark:border-slate-800 relative">
-        {/* Close Button */}
-        <button
-          onClick={onClose}
-          aria-label="Cerrar modal"
-          className="btn-tactile absolute top-4 right-4 p-2 text-on-surface-variant hover:text-on-surface dark:text-slate-400 hover:bg-surface-container dark:hover:bg-slate-800 rounded-full transition-all"
-        >
-          <X className="w-5 h-5" />
-        </button>
-
-        {/* Modal Header */}
-        <div className="text-center space-y-2">
-          <div className="w-12 h-12 rounded-2xl bg-primary/10 dark:bg-sky-500/20 text-primary dark:text-sky-300 flex items-center justify-center mx-auto font-bold">
-            <Globe className="w-6 h-6" />
-          </div>
-          <h2 className="font-headline-md text-2xl font-extrabold text-primary dark:text-sky-300">
-            {currentUser ? "Tu Cuenta LatinoMigra" : "Inicia Sesión con Google"}
-          </h2>
-          <p className="text-xs text-on-surface-variant dark:text-slate-300">
-            {currentUser
-              ? "Tus becas guardadas, progreso de visas y recordatorios están sincronizados."
-              : "Guarda tu progreso de postulación, recordatorios en Google Calendar e historial de IA."}
-          </p>
-        </div>
-
-        {/* Logged In View */}
-        {currentUser ? (
-          <div className="space-y-6">
-            <div className="bg-surface-container/60 dark:bg-slate-800/80 p-4 rounded-2xl border border-outline-variant/40 dark:border-slate-700 flex items-center gap-4">
-              <img
-                src={getSafeImageUrl(currentUser.avatar)}
-                alt={currentUser.name}
-                referrerPolicy="no-referrer"
-                className="w-14 h-14 rounded-full object-cover border-2 border-primary/30"
-              />
-              <div className="flex-1 min-w-0">
-                <h4 className="font-bold text-sm text-primary dark:text-sky-300 truncate">
-                  {currentUser.name}
-                </h4>
-                <p className="text-xs text-on-surface-variant dark:text-slate-400 truncate">
-                  {currentUser.email}
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <span className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-[10px] font-bold px-2 py-0.5 rounded-full flex items-center gap-1">
-                    <ShieldCheck className="w-3 h-3" />
-                    Cuenta Google Verificada
-                  </span>
-                </div>
+    <Modal
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      title={currentUser ? "Tu Cuenta LatinoMigra" : "Inicia Sesión con Google"}
+      description={
+        currentUser
+          ? "Tus becas guardadas, progreso de visas y recordatorios están sincronizados."
+          : "Guarda tu progreso de postulación, recordatorios en Google Calendar e historial de IA."
+      }
+      size="md"
+      id="auth-modal"
+    >
+      {/* Logged In View */}
+      {currentUser ? (
+        <div className="space-y-6">
+          <div className="bg-surface-container/60 dark:bg-slate-800/80 p-4 rounded-2xl border border-outline-variant/40 dark:border-slate-700 flex items-center gap-4">
+            <img
+              src={getSafeImageUrl(currentUser.avatar)}
+              alt={currentUser.name}
+              referrerPolicy="no-referrer"
+              className="w-14 h-14 rounded-full object-cover border-2 border-primary/30"
+            />
+            <div className="flex-1 min-w-0">
+              <h4 className="font-bold text-sm text-primary dark:text-sky-300 truncate">
+                {currentUser.name}
+              </h4>
+              <p className="text-xs text-on-surface-variant dark:text-slate-400 truncate">
+                {currentUser.email}
+              </p>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-[10px] font-bold px-2 py-0.5 rounded-full flex items-center gap-1">
+                  <ShieldCheck className="w-3 h-3" />
+                  Cuenta Google Verificada
+                </span>
               </div>
             </div>
+          </div>
 
-            {/* Account role — display only. The role selector that used to live
+          {/* Account role — display only. The role selector that used to live
                 here called onSignIn({ ...currentUser, role: "admin" }), which
                 let any signed-in user grant themselves the admin interface.
                 Administrators are now defined by the `admins/{uid}` collection,
                 which no client can write. */}
-            <div className="p-3 bg-surface dark:bg-slate-800/90 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-bold text-on-surface dark:text-slate-200">
-                  Rol de Cuenta:
-                </span>
-                <span
-                  className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-                    currentUser.isAdmin
-                      ? "bg-violet-100 dark:bg-violet-950/60 text-violet-700 dark:text-violet-300 border border-violet-300 dark:border-violet-700"
-                      : "bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700"
-                  }`}
-                >
-                  {currentUser.isAdmin ? "🔑 Administrador" : "👤 Usuario Estándar"}
-                </span>
-              </div>
-              <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
-                {currentUser.isAdmin
-                  ? "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos."
-                  : "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración."}
-              </p>
-            </div>
-
-            {/* Sync Features List */}
-            <div className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
-              <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
-                <Bookmark className="w-4 h-4 text-primary dark:text-sky-400" />
-                <span>Sincronización activa de Becas Guardadas</span>
-              </div>
-              <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
-                <Calendar className="w-4 h-4 text-emerald-500" />
-                <span>Conexión directa con Google Calendar</span>
-              </div>
-              <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
-                <Sparkles className="w-4 h-4 text-amber-500" />
-                <span>Historial del Asistente LatinoMigra IA</span>
-              </div>
-            </div>
-
-            <button
-              onClick={() => {
-                onSignOut();
-                onClose();
-              }}
-              className="btn-tactile w-full flex items-center justify-center gap-2 py-3 border border-red-500/30 text-red-600 dark:text-red-400 font-bold text-xs rounded-xl hover:bg-red-50 dark:hover:bg-red-950/30 transition-all shadow-xs"
-            >
-              <LogOut className="w-4 h-4" />
-              <span>Cerrar Sesión</span>
-            </button>
-          </div>
-        ) : (
-          /* Sign In View */
-          <div className="space-y-4">
-            {/* Direct Official Google Button */}
-            <button
-              onClick={handleFirebaseGoogleSignIn}
-              disabled={isLoading}
-              id="google-signin-btn"
-              aria-label="Continuar con Google"
-              className="btn-tactile w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-800 font-bold text-sm py-3 px-4 rounded-xl border border-slate-300 shadow-sm transition-all hover:shadow-md disabled:opacity-50"
-            >
-              <svg className="w-5 h-5" viewBox="0 0 24 24">
-                <path
-                  fill="#4285F4"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="#34A853"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="#FBBC05"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.06H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.94l2.85-2.22.81-.63z"
-                />
-                <path
-                  fill="#EA4335"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84c.87-2.6 3.3-4.52 6.16-4.52z"
-                />
-              </svg>
-              <span>Continuar con Google</span>
-            </button>
-
-            {/* Country Selection */}
-            <div className="space-y-1.5 pt-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block">
-                País de origen (para personalización de visas):
-              </label>
-              <select
-                value={selectedCountry}
-                onChange={(e) => setSelectedCountry(e.target.value)}
-                className="w-full p-2.5 bg-surface dark:bg-slate-800 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold"
+          <div className="p-3 bg-surface dark:bg-slate-800/90 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-bold text-on-surface dark:text-slate-200">
+                Rol de Cuenta:
+              </span>
+              <span
+                className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                  currentUser.isAdmin
+                    ? "bg-violet-100 dark:bg-violet-950/60 text-violet-700 dark:text-violet-300 border border-violet-300 dark:border-violet-700"
+                    : "bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700"
+                }`}
               >
-                <option value="Colombia">Colombia 🇨🇴</option>
-                <option value="México">México 🇲🇽</option>
-                <option value="Argentina">Argentina 🇦🇷</option>
-                <option value="Perú">Perú 🇵🇪</option>
-                <option value="Chile">Chile 🇨🇱</option>
-                <option value="Ecuador">Ecuador 🇪🇨</option>
-                <option value="Venezuela">Venezuela 🇻🇪</option>
-                <option value="Guatemala">Guatemala 🇬🇹</option>
-                <option value="Honduras">Honduras 🇭🇳</option>
-              </select>
+                {currentUser.isAdmin ? "🔑 Administrador" : "👤 Usuario Estándar"}
+              </span>
             </div>
+            <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
+              {currentUser.isAdmin
+                ? "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos."
+                : "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración."}
+            </p>
+          </div>
 
-            <div className="pt-2 text-center text-[11px] text-on-surface-variant dark:text-slate-400 space-y-1">
-              <p>Protegido por Google OAuth 2.0. No compartiremos tu información personal.</p>
+          {/* Sync Features List */}
+          <div className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
+            <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
+              <Bookmark className="w-4 h-4 text-primary dark:text-sky-400" />
+              <span>Sincronización activa de Becas Guardadas</span>
+            </div>
+            <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
+              <Calendar className="w-4 h-4 text-emerald-500" />
+              <span>Conexión directa con Google Calendar</span>
+            </div>
+            <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
+              <Sparkles className="w-4 h-4 text-amber-500" />
+              <span>Historial del Asistente LatinoMigra IA</span>
             </div>
           </div>
-        )}
-      </div>
-    </div>
+
+          <button
+            onClick={() => {
+              onSignOut();
+              onClose();
+            }}
+            className="btn-tactile w-full flex items-center justify-center gap-2 py-3 border border-red-500/30 text-red-600 dark:text-red-400 font-bold text-xs rounded-xl hover:bg-red-50 dark:hover:bg-red-950/30 transition-all shadow-xs"
+          >
+            <LogOut className="w-4 h-4" />
+            <span>Cerrar Sesión</span>
+          </button>
+        </div>
+      ) : (
+        /* Sign In View */
+        <div className="space-y-4">
+          {/* Direct Official Google Button */}
+          <button
+            onClick={handleFirebaseGoogleSignIn}
+            disabled={isLoading}
+            id="google-signin-btn"
+            aria-label="Continuar con Google"
+            className="btn-tactile w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-800 font-bold text-sm py-3 px-4 rounded-xl border border-slate-300 shadow-sm transition-all hover:shadow-md disabled:opacity-50"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.06H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.94l2.85-2.22.81-.63z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84c.87-2.6 3.3-4.52 6.16-4.52z"
+              />
+            </svg>
+            <span>Continuar con Google</span>
+          </button>
+
+          {/* Country Selection */}
+          <div className="space-y-1.5 pt-2">
+            <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block">
+              País de origen (para personalización de visas):
+            </label>
+            <select
+              value={selectedCountry}
+              onChange={(e) => setSelectedCountry(e.target.value)}
+              className="w-full p-2.5 bg-surface dark:bg-slate-800 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold"
+            >
+              <option value="Colombia">Colombia 🇨🇴</option>
+              <option value="México">México 🇲🇽</option>
+              <option value="Argentina">Argentina 🇦🇷</option>
+              <option value="Perú">Perú 🇵🇪</option>
+              <option value="Chile">Chile 🇨🇱</option>
+              <option value="Ecuador">Ecuador 🇪🇨</option>
+              <option value="Venezuela">Venezuela 🇻🇪</option>
+              <option value="Guatemala">Guatemala 🇬🇹</option>
+              <option value="Honduras">Honduras 🇭🇳</option>
+            </select>
+          </div>
+
+          <div className="pt-2 text-center text-[11px] text-on-surface-variant dark:text-slate-400 space-y-1">
+            <p>Protegido por Google OAuth 2.0. No compartiremos tu información personal.</p>
+          </div>
+        </div>
+      )}
+    </Modal>
   );
 };

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -46,7 +46,7 @@ import {
   getUserMigrationPlan,
 } from "../lib/firebase";
 import { usePreferences } from "../lib/PreferencesContext";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 
 interface BecasExplorerProps {
   searchQuery: string;
@@ -198,7 +198,6 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
   const [showSuggestModal, setShowSuggestModal] = useState<boolean>(false);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState<boolean>(false);
 
-  useBodyScrollLock(selectedScholarship !== null || mobileFiltersOpen || showSuggestModal);
   const [suggestForm, setSuggestForm] = useState({
     university: "",
     country: "España",
@@ -845,168 +844,163 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
 
         {/* Mobile Filters Slide-over / Bottom Sheet Modal */}
         {mobileFiltersOpen && (
-          <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
-            <div className="bg-surface-container-lowest dark:bg-slate-900 rounded-t-3xl sm:rounded-3xl max-w-lg w-full max-h-[88vh] overflow-y-auto shadow-2xl border border-outline-variant/40 dark:border-slate-700 p-5 md:p-6 space-y-5 relative animate-in slide-in-from-bottom-4 duration-200">
-              {/* Header */}
-              <div className="flex items-center justify-between pb-3 border-b border-outline-variant/30 dark:border-slate-800">
-                <div className="flex items-center gap-2 font-bold text-base text-primary dark:text-sky-300">
-                  <Filter className="w-5 h-5 text-secondary dark:text-teal-400" />
-                  <span>Filtros de Búsqueda</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={clearFilters}
-                    className="text-xs font-semibold text-secondary dark:text-teal-400 hover:underline px-2 py-1 active:scale-95"
-                  >
-                    Limpiar todo
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setMobileFiltersOpen(false)}
-                    className="p-1.5 text-on-surface-variant hover:bg-surface-container dark:hover:bg-slate-800 rounded-full active:scale-95"
-                  >
-                    <X className="w-5 h-5" />
-                  </button>
-                </div>
+          <Modal
+            open={mobileFiltersOpen}
+            onOpenChange={setMobileFiltersOpen}
+            title="Filtros"
+            size="md"
+            id="mobile-filters-sheet"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between pb-3 border-b border-outline-variant/30 dark:border-slate-800">
+              <div className="flex items-center gap-2 font-bold text-base text-primary dark:text-sky-300">
+                <Filter className="w-5 h-5 text-secondary dark:text-teal-400" />
+                <span>Filtros de Búsqueda</span>
               </div>
-
-              {/* Mobile Filter Controls */}
-              <div className="space-y-4">
-                {/* Favoritas Toggle */}
-                <div className="p-3 bg-surface dark:bg-slate-800/80 rounded-xl border border-outline-variant/40 dark:border-slate-700 flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <Heart
-                      className={`w-4 h-4 ${viewModeTab === "favorites" ? "fill-red-500 text-red-500" : "text-on-surface-variant"}`}
-                    />
-                    <span className="text-xs font-bold text-on-surface dark:text-slate-200">
-                      Ver solo mis favoritas
-                    </span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setViewModeTab(viewModeTab === "favorites" ? "all" : "favorites")
-                    }
-                    className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all active:scale-95 ${
-                      viewModeTab === "favorites"
-                        ? "bg-red-500 text-white shadow-xs"
-                        : "bg-surface-container dark:bg-slate-700 text-on-surface-variant dark:text-slate-300"
-                    }`}
-                  >
-                    {viewModeTab === "favorites" ? "Activado" : "Desactivado"} ({favorites.length})
-                  </button>
-                </div>
-
-                {/* País Destino Dropdown */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    País Destino
-                  </label>
-                  <select
-                    value={selectedCountry}
-                    onChange={(e) => setSelectedCountry(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {countries.map((c) => (
-                      <option key={c} value={c}>
-                        {c === "Todos" ? "🌍 Todos los países" : c}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Área de Estudio */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Área de Estudio
-                  </label>
-                  <select
-                    value={selectedArea}
-                    onChange={(e) => setSelectedArea(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {areas.map((a) => (
-                      <option key={a} value={a}>
-                        {a === "Todas" ? "🎓 Todas las áreas" : a}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Tipo de Apoyo */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Tipo de Apoyo
-                  </label>
-                  <select
-                    value={selectedSupportType}
-                    onChange={(e) => setSelectedSupportType(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {supportTypes.map((t) => (
-                      <option key={t} value={t}>
-                        {t === "Todos" ? "🏆 Todos los apoyos" : t}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Tipo de Entidad */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Tipo de Entidad
-                  </label>
-                  <select
-                    value={selectedInstitutionType}
-                    onChange={(e) => setSelectedInstitutionType(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {institutionTypes.map((it) => (
-                      <option key={it} value={it}>
-                        {it === "Todas" ? "🏛️ Todas las entidades" : it}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Fecha Límite */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Fecha de Cierre
-                  </label>
-                  <select
-                    value={selectedDateRange}
-                    onChange={(e) => setSelectedDateRange(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {dateRanges.map((dr) => (
-                      <option key={dr.id} value={dr.id}>
-                        {dr.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* Bottom Apply Action */}
-              <div className="pt-3 border-t border-outline-variant/30 dark:border-slate-800 sticky bottom-0 bg-surface-container-lowest dark:bg-slate-900">
+              <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    setMobileFiltersOpen(false);
-                    if (mainListRef.current) {
-                      mainListRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
-                    }
-                  }}
-                  className="w-full py-3.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white font-bold text-sm rounded-xl shadow-md cursor-pointer active:scale-95 transition-all text-center flex items-center justify-center gap-2"
+                  onClick={clearFilters}
+                  className="text-xs font-semibold text-secondary dark:text-teal-400 hover:underline px-2 py-1 active:scale-95"
                 >
-                  <CheckCircle2 className="w-4 h-4" />
-                  <span>Ver {filteredScholarships.length} Convocatorias</span>
+                  Limpiar todo
                 </button>
               </div>
             </div>
-          </div>
+
+            {/* Mobile Filter Controls */}
+            <div className="space-y-4">
+              {/* Favoritas Toggle */}
+              <div className="p-3 bg-surface dark:bg-slate-800/80 rounded-xl border border-outline-variant/40 dark:border-slate-700 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Heart
+                    className={`w-4 h-4 ${viewModeTab === "favorites" ? "fill-red-500 text-red-500" : "text-on-surface-variant"}`}
+                  />
+                  <span className="text-xs font-bold text-on-surface dark:text-slate-200">
+                    Ver solo mis favoritas
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setViewModeTab(viewModeTab === "favorites" ? "all" : "favorites")}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all active:scale-95 ${
+                    viewModeTab === "favorites"
+                      ? "bg-red-500 text-white shadow-xs"
+                      : "bg-surface-container dark:bg-slate-700 text-on-surface-variant dark:text-slate-300"
+                  }`}
+                >
+                  {viewModeTab === "favorites" ? "Activado" : "Desactivado"} ({favorites.length})
+                </button>
+              </div>
+
+              {/* País Destino Dropdown */}
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
+                  País Destino
+                </label>
+                <select
+                  value={selectedCountry}
+                  onChange={(e) => setSelectedCountry(e.target.value)}
+                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
+                >
+                  {countries.map((c) => (
+                    <option key={c} value={c}>
+                      {c === "Todos" ? "🌍 Todos los países" : c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Área de Estudio */}
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
+                  Área de Estudio
+                </label>
+                <select
+                  value={selectedArea}
+                  onChange={(e) => setSelectedArea(e.target.value)}
+                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
+                >
+                  {areas.map((a) => (
+                    <option key={a} value={a}>
+                      {a === "Todas" ? "🎓 Todas las áreas" : a}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Tipo de Apoyo */}
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
+                  Tipo de Apoyo
+                </label>
+                <select
+                  value={selectedSupportType}
+                  onChange={(e) => setSelectedSupportType(e.target.value)}
+                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
+                >
+                  {supportTypes.map((t) => (
+                    <option key={t} value={t}>
+                      {t === "Todos" ? "🏆 Todos los apoyos" : t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Tipo de Entidad */}
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
+                  Tipo de Entidad
+                </label>
+                <select
+                  value={selectedInstitutionType}
+                  onChange={(e) => setSelectedInstitutionType(e.target.value)}
+                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
+                >
+                  {institutionTypes.map((it) => (
+                    <option key={it} value={it}>
+                      {it === "Todas" ? "🏛️ Todas las entidades" : it}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Fecha Límite */}
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
+                  Fecha de Cierre
+                </label>
+                <select
+                  value={selectedDateRange}
+                  onChange={(e) => setSelectedDateRange(e.target.value)}
+                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
+                >
+                  {dateRanges.map((dr) => (
+                    <option key={dr.id} value={dr.id}>
+                      {dr.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Bottom Apply Action */}
+            <div className="pt-3 border-t border-outline-variant/30 dark:border-slate-800 sticky bottom-0 bg-surface-container-lowest dark:bg-slate-900">
+              <button
+                type="button"
+                onClick={() => {
+                  setMobileFiltersOpen(false);
+                  if (mainListRef.current) {
+                    mainListRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }
+                }}
+                className="w-full py-3.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white font-bold text-sm rounded-xl shadow-md cursor-pointer active:scale-95 transition-all text-center flex items-center justify-center gap-2"
+              >
+                <CheckCircle2 className="w-4 h-4" />
+                <span>Ver {filteredScholarships.length} Convocatorias</span>
+              </button>
+            </div>
+          </Modal>
         )}
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
@@ -1701,303 +1695,289 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
 
       {/* Suggest Official Scholarship Modal */}
       {showSuggestModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 overflow-y-auto lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-800 rounded-3xl max-w-lg w-full shadow-2xl border border-outline-variant/40 dark:border-slate-700 p-6 md:p-8 space-y-6 relative">
-            <button
-              onClick={() => setShowSuggestModal(false)}
-              className="absolute top-4 right-4 p-2 text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700 rounded-full"
-            >
-              <X className="w-6 h-6" />
-            </button>
+        <Modal
+          open={showSuggestModal}
+          onOpenChange={(next) => {
+            if (!next) setShowSuggestModal(false);
+          }}
+          title="Sugerir una convocatoria oficial"
+          size="md"
+          id="suggest-scholarship-modal"
+        >
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-secondary dark:text-teal-300 text-xs font-bold uppercase">
+              <ShieldCheck className="w-4 h-4 text-emerald-500" />
+              <span>Verificación de Fuentes Oficiales</span>
+            </div>
+            <h2 className="font-headline-md text-2xl font-extrabold text-primary dark:text-sky-300">
+              Sugerir Beca Universitaria
+            </h2>
+            <p className="text-xs text-on-surface-variant dark:text-slate-300">
+              Agrega becas y ayudas publicadas directamente en portales universitarios (.edu, .es,
+              .de, etc.) para que nuestro equipo y la IA las verifiquen e incorporen al directorio.
+            </p>
+          </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-secondary dark:text-teal-300 text-xs font-bold uppercase">
-                <ShieldCheck className="w-4 h-4 text-emerald-500" />
-                <span>Verificación de Fuentes Oficiales</span>
-              </div>
-              <h2 className="font-headline-md text-2xl font-extrabold text-primary dark:text-sky-300">
-                Sugerir Beca Universitaria
-              </h2>
-              <p className="text-xs text-on-surface-variant dark:text-slate-300">
-                Agrega becas y ayudas publicadas directamente en portales universitarios (.edu, .es,
-                .de, etc.) para que nuestro equipo y la IA las verifiquen e incorporen al
-                directorio.
+          {suggestSuccess ? (
+            <div className="bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-500/30 text-emerald-800 dark:text-emerald-200 p-4 rounded-2xl text-center space-y-2">
+              <CheckCircle2 className="w-8 h-8 text-emerald-500 mx-auto" />
+              <h4 className="font-bold text-sm">¡Beca enviada para verificación!</h4>
+              <p className="text-xs">
+                Revisaremos el enlace institucional para integrarla al catálogo oficial de
+                LatinoMigra.
               </p>
             </div>
-
-            {suggestSuccess ? (
-              <div className="bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-500/30 text-emerald-800 dark:text-emerald-200 p-4 rounded-2xl text-center space-y-2">
-                <CheckCircle2 className="w-8 h-8 text-emerald-500 mx-auto" />
-                <h4 className="font-bold text-sm">¡Beca enviada para verificación!</h4>
-                <p className="text-xs">
-                  Revisaremos el enlace institucional para integrarla al catálogo oficial de
-                  LatinoMigra.
-                </p>
+          ) : (
+            <form onSubmit={handleSuggestSubmit} className="space-y-4">
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
+                  Universidad o Institución *
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={suggestForm.university}
+                  onChange={(e) => setSuggestForm({ ...suggestForm, university: e.target.value })}
+                  placeholder="Ej. Universidad Autónoma de Madrid, Sorbonne..."
+                  className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
+                />
               </div>
-            ) : (
-              <form onSubmit={handleSuggestSubmit} className="space-y-4">
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                    Universidad o Institución *
+                    País Destino *
+                  </label>
+                  <select
+                    value={suggestForm.country}
+                    onChange={(e) => setSuggestForm({ ...suggestForm, country: e.target.value })}
+                    className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
+                  >
+                    {countries
+                      .filter((c) => c !== "Todos")
+                      .map((c) => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
+                    Nombre de la Beca *
                   </label>
                   <input
                     type="text"
                     required
-                    value={suggestForm.university}
-                    onChange={(e) => setSuggestForm({ ...suggestForm, university: e.target.value })}
-                    placeholder="Ej. Universidad Autónoma de Madrid, Sorbonne..."
-                    className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                      País Destino *
-                    </label>
-                    <select
-                      value={suggestForm.country}
-                      onChange={(e) => setSuggestForm({ ...suggestForm, country: e.target.value })}
-                      className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
-                    >
-                      {countries
-                        .filter((c) => c !== "Todos")
-                        .map((c) => (
-                          <option key={c} value={c}>
-                            {c}
-                          </option>
-                        ))}
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                      Nombre de la Beca *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      value={suggestForm.scholarshipName}
-                      onChange={(e) =>
-                        setSuggestForm({ ...suggestForm, scholarshipName: e.target.value })
-                      }
-                      placeholder="Ej. Ayuda de Matrícula Máster..."
-                      className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                    Enlace de la Página Oficial (.edu, .es, .org, .de, .ca) *
-                  </label>
-                  <input
-                    type="url"
-                    required
-                    value={suggestForm.officialUrl}
+                    value={suggestForm.scholarshipName}
                     onChange={(e) =>
-                      setSuggestForm({ ...suggestForm, officialUrl: e.target.value })
+                      setSuggestForm({ ...suggestForm, scholarshipName: e.target.value })
                     }
-                    placeholder="https://www.universidad.es/becas/internacional..."
+                    placeholder="Ej. Ayuda de Matrícula Máster..."
                     className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
                   />
                 </div>
+              </div>
 
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                    Notas o Requisitos Relevantes
-                  </label>
-                  <textarea
-                    rows={2}
-                    value={suggestForm.notes}
-                    onChange={(e) => setSuggestForm({ ...suggestForm, notes: e.target.value })}
-                    placeholder="Fechas de cierre, si cubre manutención o exención..."
-                    className="w-full px-3.5 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
-                  />
-                </div>
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
+                  Enlace de la Página Oficial (.edu, .es, .org, .de, .ca) *
+                </label>
+                <input
+                  type="url"
+                  required
+                  value={suggestForm.officialUrl}
+                  onChange={(e) => setSuggestForm({ ...suggestForm, officialUrl: e.target.value })}
+                  placeholder="https://www.universidad.es/becas/internacional..."
+                  className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
+                />
+              </div>
 
-                <div className="flex items-center justify-end gap-3 pt-3">
-                  <button
-                    type="button"
-                    onClick={() => setShowSuggestModal(false)}
-                    className="btn-tactile px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:bg-surface-container rounded-xl transition-all"
-                  >
-                    Cancelar
-                  </button>
-                  <button
-                    type="submit"
-                    className="btn-tactile inline-flex items-center gap-2 px-5 py-2.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white text-xs font-bold rounded-xl transition-all shadow-sm"
-                  >
-                    <Send className="w-3.5 h-3.5" />
-                    <span>Enviar Convocatoria</span>
-                  </button>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+              <div>
+                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
+                  Notas o Requisitos Relevantes
+                </label>
+                <textarea
+                  rows={2}
+                  value={suggestForm.notes}
+                  onChange={(e) => setSuggestForm({ ...suggestForm, notes: e.target.value })}
+                  placeholder="Fechas de cierre, si cubre manutención o exención..."
+                  className="w-full px-3.5 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs outline-none focus:ring-2 focus:ring-secondary"
+                />
+              </div>
+
+              <div className="flex items-center justify-end gap-3 pt-3">
+                <button
+                  type="button"
+                  onClick={() => setShowSuggestModal(false)}
+                  className="btn-tactile px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:bg-surface-container rounded-xl transition-all"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  className="btn-tactile inline-flex items-center gap-2 px-5 py-2.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white text-xs font-bold rounded-xl transition-all shadow-sm"
+                >
+                  <Send className="w-3.5 h-3.5" />
+                  <span>Enviar Convocatoria</span>
+                </button>
+              </div>
+            </form>
+          )}
+        </Modal>
       )}
 
       {/* Scholarship Details Modal */}
       {selectedScholarship && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 overflow-y-auto lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-800 rounded-3xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl border border-outline-variant/40 dark:border-slate-700 p-6 md:p-8 space-y-6 relative animate-in fade-in zoom-in-95 duration-200">
-            {/* Sticky, not absolute: this panel scrolls internally, so an
-                absolutely positioned button scrolls away with the content and
-                the only way out of a long scholarship is to scroll back up.
-                The zero-height wrapper keeps it out of the flow, so the layout
-                is unchanged. */}
-            <div className="sticky top-0 z-10 flex h-0 justify-end">
-              <button
-                type="button"
-                onClick={() => setSelectedScholarship(null)}
-                aria-label="Cerrar modal"
-                className="btn-tactile p-2 text-on-surface-variant dark:text-slate-300 bg-surface-container-lowest/90 dark:bg-slate-800/90 backdrop-blur-xs hover:bg-surface-container dark:hover:bg-slate-700 rounded-full transition-all"
-              >
-                <X className="w-6 h-6" />
-              </button>
-            </div>
-
-            <div className="space-y-2 pr-8">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="bg-secondary-container/40 dark:bg-teal-500/20 text-secondary dark:text-teal-300 text-xs px-3 py-1 rounded-full font-bold">
-                  {selectedScholarship.supportType}
+        <Modal
+          open={selectedScholarship !== null}
+          onOpenChange={(next) => {
+            if (!next) setSelectedScholarship(null);
+          }}
+          title={selectedScholarship?.title ?? "Detalle de la convocatoria"}
+          size="lg"
+          id="scholarship-detail-modal"
+        >
+          <div className="space-y-2 pr-8">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="bg-secondary-container/40 dark:bg-teal-500/20 text-secondary dark:text-teal-300 text-xs px-3 py-1 rounded-full font-bold">
+                {selectedScholarship.supportType}
+              </span>
+              <span className="bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 text-xs px-3 py-1 rounded-full font-bold">
+                {selectedScholarship.country}
+              </span>
+              {selectedScholarship.institutionType && (
+                <span className="bg-emerald-500/10 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300 text-xs px-3 py-1 rounded-full font-bold flex items-center gap-1">
+                  <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
+                  {selectedScholarship.institutionType}
                 </span>
-                <span className="bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 text-xs px-3 py-1 rounded-full font-bold">
-                  {selectedScholarship.country}
-                </span>
-                {selectedScholarship.institutionType && (
-                  <span className="bg-emerald-500/10 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300 text-xs px-3 py-1 rounded-full font-bold flex items-center gap-1">
-                    <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
-                    {selectedScholarship.institutionType}
-                  </span>
-                )}
-                <button
-                  type="button"
-                  onClick={() => toggleFavorite(selectedScholarship.id)}
-                  id="modal-toggle-favorite-btn"
-                  className={`btn-tactile inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-bold transition-all ml-auto shadow-xs ${
-                    favorites.includes(selectedScholarship.id)
-                      ? "bg-red-500 text-white"
-                      : "bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-300 border border-red-300 dark:border-red-800"
-                  }`}
-                >
-                  <Heart
-                    className={`w-3.5 h-3.5 ${favorites.includes(selectedScholarship.id) ? "fill-white" : ""}`}
-                  />
-                  <span>
-                    {favorites.includes(selectedScholarship.id) ? "Guardada" : "Guardar Beca"}
-                  </span>
-                </button>
-              </div>
-
-              <h2 className="font-headline-md text-2xl font-extrabold text-primary dark:text-sky-300">
-                {selectedScholarship.title}
-              </h2>
-              <p className="text-sm font-semibold text-on-surface-variant dark:text-slate-300">
-                {selectedScholarship.institution}
-              </p>
-              {selectedScholarship.officialPortalName && (
-                <div className="flex flex-wrap items-center gap-3 pt-1">
-                  <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium flex items-center gap-1">
-                    <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
-                    <span>Portal Oficial Verificado: {selectedScholarship.officialPortalName}</span>
-                  </p>
-                  <a
-                    href={selectedScholarship.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-xs font-bold text-primary dark:text-sky-400 hover:underline bg-primary/10 dark:bg-sky-950/60 px-2.5 py-1 rounded-lg border border-primary/20"
-                  >
-                    <ExternalLink className="w-3 h-3" />
-                    <span>Ir a la convocatoria oficial</span>
-                  </a>
-                </div>
               )}
-            </div>
-
-            <p className="text-sm text-on-surface-variant dark:text-slate-300 leading-relaxed">
-              {selectedScholarship.description}
-            </p>
-
-            {/* Requisitos */}
-            <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
-              <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
-                Requisitos Principales
-              </h4>
-              <ul className="space-y-2">
-                {selectedScholarship.requirements.map((req, idx) => (
-                  <li
-                    key={idx}
-                    className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
-                  >
-                    <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
-                    <span>{req}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            {/* Beneficios */}
-            <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
-              <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
-                Beneficios Incluidos
-              </h4>
-              <ul className="space-y-2">
-                {selectedScholarship.benefits.map((ben, idx) => (
-                  <li
-                    key={idx}
-                    className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
-                  >
-                    <Sparkles className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
-                    <span>{ben}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            {/* Modal Actions */}
-            <div className="flex flex-col sm:flex-row items-center gap-3 pt-4 border-t border-outline-variant/30 dark:border-slate-700">
-              <a
-                href={selectedScholarship.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn-tactile w-full sm:w-auto flex-1 inline-flex items-center justify-center gap-2 bg-primary dark:bg-sky-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-primary-container transition-all text-xs shadow-sm hover:shadow-md"
-              >
-                <ExternalLink className="w-4 h-4" />
-                <span>Link a la Convocatoria Oficial</span>
-              </a>
-
-              <a
-                href={generateGoogleCalendarUrl({
-                  title: `Cierre de Convocatoria: ${selectedScholarship.title}`,
-                  details: `Fecha límite para enviar expediente a ${selectedScholarship.title}. Requisitos: ${selectedScholarship.requirements.join(", ")}. Enlace oficial convocatoria: ${selectedScholarship.link}`,
-                  startDate: selectedScholarship.deadlineDate,
-                  location: selectedScholarship.country,
-                })}
-                target="_blank"
-                rel="noreferrer"
-                className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-4 rounded-xl transition-all text-xs shadow-sm hover:shadow-md"
-              >
-                <CalendarIcon className="w-4 h-4" />
-                <span>Agendar en Google Calendar</span>
-              </a>
-
               <button
                 type="button"
-                onClick={() => {
-                  const scholarshipToAsk = selectedScholarship;
-                  setSelectedScholarship(null);
-                  onAskAIAboutScholarship(scholarshipToAsk);
-                }}
-                className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-secondary dark:bg-teal-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-secondary-container hover:text-secondary-900 transition-all text-xs shadow-sm hover:shadow-md"
+                onClick={() => toggleFavorite(selectedScholarship.id)}
+                id="modal-toggle-favorite-btn"
+                className={`btn-tactile inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-bold transition-all ml-auto shadow-xs ${
+                  favorites.includes(selectedScholarship.id)
+                    ? "bg-red-500 text-white"
+                    : "bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-300 border border-red-300 dark:border-red-800"
+                }`}
               >
-                <Bot className="w-4 h-4" />
-                <span>Consultar IA</span>
+                <Heart
+                  className={`w-3.5 h-3.5 ${favorites.includes(selectedScholarship.id) ? "fill-white" : ""}`}
+                />
+                <span>
+                  {favorites.includes(selectedScholarship.id) ? "Guardada" : "Guardar Beca"}
+                </span>
               </button>
             </div>
+
+            <h2 className="font-headline-md text-2xl font-extrabold text-primary dark:text-sky-300">
+              {selectedScholarship.title}
+            </h2>
+            <p className="text-sm font-semibold text-on-surface-variant dark:text-slate-300">
+              {selectedScholarship.institution}
+            </p>
+            {selectedScholarship.officialPortalName && (
+              <div className="flex flex-wrap items-center gap-3 pt-1">
+                <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium flex items-center gap-1">
+                  <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
+                  <span>Portal Oficial Verificado: {selectedScholarship.officialPortalName}</span>
+                </p>
+                <a
+                  href={selectedScholarship.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs font-bold text-primary dark:text-sky-400 hover:underline bg-primary/10 dark:bg-sky-950/60 px-2.5 py-1 rounded-lg border border-primary/20"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  <span>Ir a la convocatoria oficial</span>
+                </a>
+              </div>
+            )}
           </div>
-        </div>
+
+          <p className="text-sm text-on-surface-variant dark:text-slate-300 leading-relaxed">
+            {selectedScholarship.description}
+          </p>
+
+          {/* Requisitos */}
+          <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
+            <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
+              Requisitos Principales
+            </h4>
+            <ul className="space-y-2">
+              {selectedScholarship.requirements.map((req, idx) => (
+                <li
+                  key={idx}
+                  className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
+                >
+                  <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
+                  <span>{req}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Beneficios */}
+          <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
+            <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
+              Beneficios Incluidos
+            </h4>
+            <ul className="space-y-2">
+              {selectedScholarship.benefits.map((ben, idx) => (
+                <li
+                  key={idx}
+                  className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
+                >
+                  <Sparkles className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                  <span>{ben}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Modal Actions */}
+          <div className="flex flex-col sm:flex-row items-center gap-3 pt-4 border-t border-outline-variant/30 dark:border-slate-700">
+            <a
+              href={selectedScholarship.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-tactile w-full sm:w-auto flex-1 inline-flex items-center justify-center gap-2 bg-primary dark:bg-sky-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-primary-container transition-all text-xs shadow-sm hover:shadow-md"
+            >
+              <ExternalLink className="w-4 h-4" />
+              <span>Link a la Convocatoria Oficial</span>
+            </a>
+
+            <a
+              href={generateGoogleCalendarUrl({
+                title: `Cierre de Convocatoria: ${selectedScholarship.title}`,
+                details: `Fecha límite para enviar expediente a ${selectedScholarship.title}. Requisitos: ${selectedScholarship.requirements.join(", ")}. Enlace oficial convocatoria: ${selectedScholarship.link}`,
+                startDate: selectedScholarship.deadlineDate,
+                location: selectedScholarship.country,
+              })}
+              target="_blank"
+              rel="noreferrer"
+              className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-4 rounded-xl transition-all text-xs shadow-sm hover:shadow-md"
+            >
+              <CalendarIcon className="w-4 h-4" />
+              <span>Agendar en Google Calendar</span>
+            </a>
+
+            <button
+              type="button"
+              onClick={() => {
+                const scholarshipToAsk = selectedScholarship;
+                setSelectedScholarship(null);
+                onAskAIAboutScholarship(scholarshipToAsk);
+              }}
+              className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-secondary dark:bg-teal-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-secondary-container hover:text-secondary-900 transition-all text-xs shadow-sm hover:shadow-md"
+            >
+              <Bot className="w-4 h-4" />
+              <span>Consultar IA</span>
+            </button>
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/ChatIA.tsx
+++ b/src/components/ChatIA.tsx
@@ -15,14 +15,13 @@ import {
   Users,
   DollarSign,
   Languages,
-  X,
   Globe,
 } from "lucide-react";
 import { ChatMessage, ChatConversation, Scholarship } from "../types";
 import { useLanguage } from "../lib/i18n";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
 import { useCurrency } from "../lib/CurrencyContext";
 import { formatCurrency } from "../lib/currency";
+import { Modal } from "./ui/Modal";
 
 interface ChatIAProps {
   initialPrompt?: string;
@@ -92,8 +91,6 @@ export const ChatIA: React.FC<ChatIAProps> = ({ initialPrompt }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [copiedIndex, setCopiedIndex] = useState<string | null>(null);
   const [showProfileDiagnosisModal, setShowProfileDiagnosisModal] = useState<boolean>(false);
-
-  useBodyScrollLock(showProfileDiagnosisModal);
 
   // Profile Diagnosis Form state
   const [diagCareer, setDiagCareer] = useState<string>("Ingeniería de Software / IT");
@@ -571,9 +568,19 @@ Estructura tu diagnóstico con:
 
       {/* Profile Diagnosis Modal (Career + Age + Family + Goal Form) */}
       {showProfileDiagnosisModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-800 rounded-3xl max-w-xl w-full p-6 md:p-8 space-y-5 shadow-2xl border border-outline-variant/40 dark:border-slate-700 animate-in fade-in zoom-in-95 duration-200 max-h-[90vh] overflow-y-auto">
-            <div className="flex items-center justify-between border-b border-outline-variant/30 dark:border-slate-700 pb-3">
+        <Modal
+          open={showProfileDiagnosisModal}
+          onOpenChange={(next) => {
+            if (!next) setShowProfileDiagnosisModal(false);
+          }}
+          title={
+            language === "en"
+              ? "AI Migration Profile Diagnosis"
+              : "Diagnóstico de Perfil Migratorio con IA"
+          }
+          size="lg"
+          header={
+            <div className="border-b border-outline-variant/30 dark:border-slate-700 pb-3">
               <div className="flex items-center gap-2.5">
                 <div className="w-9 h-9 rounded-xl bg-secondary/15 dark:bg-teal-500/20 text-secondary dark:text-teal-300 flex items-center justify-center">
                   <Compass className="w-5 h-5" />
@@ -591,264 +598,258 @@ Estructura tu diagnóstico con:
                   </p>
                 </div>
               </div>
-              <button
-                onClick={() => setShowProfileDiagnosisModal(false)}
-                className="p-1 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer"
+            </div>
+          }
+        >
+          <div className="space-y-4 text-xs">
+            {/* País de Origen */}
+            <div>
+              <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
+                <Globe className="w-3.5 h-3.5 text-secondary" />
+                <span>{language === "en" ? "Country of Origin" : "País de Origen"}</span>
+              </label>
+              <select
+                value={diagOrigin}
+                onChange={(e) => setDiagOrigin(e.target.value)}
+                className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
               >
-                <X className="w-5 h-5" />
-              </button>
+                <option value="Colombia">🇨🇴 Colombia</option>
+                <option value="México">🇲🇽 México</option>
+                <option value="Perú">🇵🇪 Perú</option>
+                <option value="Argentina">🇦🇷 Argentina</option>
+                <option value="Chile">🇨🇱 Chile</option>
+                <option value="Ecuador">🇪🇨 Ecuador</option>
+                <option value="Venezuela">🇻🇪 Venezuela</option>
+                <option value="Bolivia">🇧🇴 Bolivia</option>
+                <option value="Guatemala">🇬🇹 Guatemala</option>
+                <option value="Costa Rica">🇨🇷 Costa Rica</option>
+              </select>
             </div>
 
-            <div className="space-y-4 text-xs">
-              {/* País de Origen */}
+            {/* Carrera y Edad */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
-                  <Globe className="w-3.5 h-3.5 text-secondary" />
-                  <span>{language === "en" ? "Country of Origin" : "País de Origen"}</span>
+                  <Briefcase className="w-3.5 h-3.5 text-secondary" />
+                  <span>{language === "en" ? "Career / Profession" : "Carrera o Profesión"}</span>
                 </label>
                 <select
-                  value={diagOrigin}
-                  onChange={(e) => setDiagOrigin(e.target.value)}
+                  value={diagCareer}
+                  onChange={(e) => setDiagCareer(e.target.value)}
                   className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
                 >
-                  <option value="Colombia">🇨🇴 Colombia</option>
-                  <option value="México">🇲🇽 México</option>
-                  <option value="Perú">🇵🇪 Perú</option>
-                  <option value="Argentina">🇦🇷 Argentina</option>
-                  <option value="Chile">🇨🇱 Chile</option>
-                  <option value="Ecuador">🇪🇨 Ecuador</option>
-                  <option value="Venezuela">🇻🇪 Venezuela</option>
-                  <option value="Bolivia">🇧🇴 Bolivia</option>
-                  <option value="Guatemala">🇬🇹 Guatemala</option>
-                  <option value="Costa Rica">🇨🇷 Costa Rica</option>
+                  <option value="Ingeniería de Software / IT">
+                    Ingeniería de Software / IT / Datos
+                  </option>
+                  <option value="Medicina / Enfermería / Salud">
+                    Medicina / Enfermería / Salud
+                  </option>
+                  <option value="Administración / Finanzas / Negocios">
+                    Administración / Negocios / Finanzas
+                  </option>
+                  <option value="Ingeniería Industrial / Civil / Mecánica">
+                    Ingeniería Industrial / Civil / Mecánica
+                  </option>
+                  <option value="Educación / Docencia / Idiomas">
+                    Educación / Docencia / Idiomas
+                  </option>
+                  <option value="Marketing / Diseño / Comunicación">
+                    Marketing / Diseño / Comunicación
+                  </option>
+                  <option value="Derecho / Ciencias Sociales">Derecho / Ciencias Sociales</option>
+                  <option value="Gastronomía / Turismo / Hostelería">
+                    Gastronomía / Turismo / Hostelería
+                  </option>
+                  <option value="Oficios Técnicos / Electricidad / Construcción">
+                    Oficios Técnicos / Electricidad
+                  </option>
                 </select>
               </div>
 
-              {/* Carrera y Edad */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
-                    <Briefcase className="w-3.5 h-3.5 text-secondary" />
-                    <span>{language === "en" ? "Career / Profession" : "Carrera o Profesión"}</span>
-                  </label>
-                  <select
-                    value={diagCareer}
-                    onChange={(e) => setDiagCareer(e.target.value)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    <option value="Ingeniería de Software / IT">
-                      Ingeniería de Software / IT / Datos
-                    </option>
-                    <option value="Medicina / Enfermería / Salud">
-                      Medicina / Enfermería / Salud
-                    </option>
-                    <option value="Administración / Finanzas / Negocios">
-                      Administración / Negocios / Finanzas
-                    </option>
-                    <option value="Ingeniería Industrial / Civil / Mecánica">
-                      Ingeniería Industrial / Civil / Mecánica
-                    </option>
-                    <option value="Educación / Docencia / Idiomas">
-                      Educación / Docencia / Idiomas
-                    </option>
-                    <option value="Marketing / Diseño / Comunicación">
-                      Marketing / Diseño / Comunicación
-                    </option>
-                    <option value="Derecho / Ciencias Sociales">Derecho / Ciencias Sociales</option>
-                    <option value="Gastronomía / Turismo / Hostelería">
-                      Gastronomía / Turismo / Hostelería
-                    </option>
-                    <option value="Oficios Técnicos / Electricidad / Construcción">
-                      Oficios Técnicos / Electricidad
-                    </option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center justify-between">
-                    <span>{language === "en" ? "Age" : "Edad"}</span>
-                    <span className="text-secondary dark:text-teal-300 font-bold">
-                      {diagAge} años
-                    </span>
-                  </label>
-                  <input
-                    type="range"
-                    min={18}
-                    max={60}
-                    value={diagAge}
-                    onChange={(e) => setDiagAge(Number(e.target.value))}
-                    className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-secondary mt-2"
-                  />
-                  <div className="flex justify-between text-[10px] text-slate-400 mt-1">
-                    <span>18</span>
-                    <span>30 (Puntajes DAAD/Chancenkarte)</span>
-                    <span>60</span>
-                  </div>
-                </div>
-              </div>
-
-              {/* Situación Familiar */}
               <div>
-                <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
-                  <Users className="w-3.5 h-3.5 text-secondary" />
-                  <span>{language === "en" ? "Family Status" : "Situación Familiar"}</span>
-                </label>
-                <select
-                  value={diagFamily}
-                  onChange={(e) => setDiagFamily(e.target.value)}
-                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                >
-                  <option value="Soltero/a sin hijos">🧍 Soltero/a sin hijos</option>
-                  <option value="En pareja sin hijos">👫 En pareja sin hijos</option>
-                  <option value="Familia con 1 hijo">👨‍👩‍👧 Familia con 1 hijo</option>
-                  <option value="Familia con 2 o más hijos">👨‍👩‍👧‍👦 Familia con 2 o más hijos</option>
-                </select>
-              </div>
-
-              {/* Idiomas Conocidos (Multilingüe) */}
-              <div className="space-y-2">
-                <label className="block font-bold text-primary dark:text-sky-300 flex items-center justify-between">
-                  <span className="flex items-center gap-1.5">
-                    <Languages className="w-3.5 h-3.5 text-secondary" />
-                    <span>
-                      {language === "en"
-                        ? "Known Languages (Multilingual Profile)"
-                        : "Idiomas que dominas (Perfil Multilingüe)"}
-                    </span>
-                  </span>
-                  <span className="text-[11px] font-normal text-slate-500">
-                    Selecciona todos los que apliquen
+                <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center justify-between">
+                  <span>{language === "en" ? "Age" : "Edad"}</span>
+                  <span className="text-secondary dark:text-teal-300 font-bold">
+                    {diagAge} años
                   </span>
                 </label>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 bg-surface dark:bg-slate-900/80 p-3 rounded-2xl border border-outline-variant/40 dark:border-slate-700/60 max-h-48 overflow-y-auto">
-                  {userLanguages.map((item, idx) => (
-                    <div
-                      key={item.name}
-                      className={`p-2 rounded-xl border flex items-center justify-between gap-2 transition-all ${
-                        item.enabled
-                          ? "bg-secondary/10 dark:bg-teal-950/40 border-secondary/40 text-primary dark:text-teal-200 font-semibold"
-                          : "bg-surface-container/40 dark:bg-slate-800/40 border-outline-variant/30 text-on-surface-variant/70 dark:text-slate-400 opacity-80"
-                      }`}
-                    >
-                      <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
-                        <input
-                          type="checkbox"
-                          checked={item.enabled}
-                          onChange={(e) => {
-                            const updated = [...userLanguages];
-                            updated[idx].enabled = e.target.checked;
-                            setUserLanguages(updated);
-                          }}
-                          className="rounded text-secondary focus:ring-secondary w-3.5 h-3.5 accent-secondary cursor-pointer"
-                        />
-                        <span>{item.name}</span>
-                      </label>
-
-                      {item.enabled && (
-                        <select
-                          value={item.level}
-                          onChange={(e) => {
-                            const updated = [...userLanguages];
-                            updated[idx].level = e.target.value;
-                            setUserLanguages(updated);
-                          }}
-                          className="text-[11px] py-0.5 px-1.5 bg-surface dark:bg-slate-800 border border-outline-variant/50 rounded-lg outline-none text-on-surface dark:text-slate-200"
-                        >
-                          <option value="Básico (A1/A2)">A1/A2</option>
-                          <option value="Intermedio (B1/B2)">B1/B2</option>
-                          <option value="Avanzado (C1/C2)">C1/C2</option>
-                          <option value="Nativo / C2">Nativo</option>
-                        </select>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Presupuesto y Objetivo Principal */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
-                    <DollarSign className="w-3.5 h-3.5 text-secondary" />
-                    <span>
-                      {language === "en"
-                        ? `Available Budget (${currency})`
-                        : `Presupuesto o Ahorro (${currency})`}
-                    </span>
-                  </label>
-                  <select
-                    value={diagBudgetTier}
-                    onChange={(e) => setDiagBudgetTier(e.target.value as any)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    <option value="low">
-                      Menos de {formatCurrency(2000, currency)} (Prioridad Becas 100%)
-                    </option>
-                    <option value="medium">
-                      {formatCurrency(3000, currency)} - {formatCurrency(8000, currency)}
-                    </option>
-                    <option value="high">
-                      {formatCurrency(8000, currency)} - {formatCurrency(15000, currency)}{" "}
-                      (Sperrkonto / Cursos)
-                    </option>
-                    <option value="premium">
-                      Más de {formatCurrency(15000, currency)} (Estudios familiares)
-                    </option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
-                    <GraduationCap className="w-3.5 h-3.5 text-secondary" />
-                    <span>{language === "en" ? "Main Goal" : "Meta Principal"}</span>
-                  </label>
-                  <select
-                    value={diagGoal}
-                    onChange={(e) => setDiagGoal(e.target.value)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    <option value="Beca de Maestría o Posgrado 100% financiada">
-                      🎓 Beca 100% (DAAD, Carolina, Erasmus)
-                    </option>
-                    <option value="Trabajo directo o Visa de Oportunidades">
-                      💼 Empleo directo / Visa Oportunidades
-                    </option>
-                    <option value="Curso de Idiomas con Trabajo (Stamp 2 / Co-op)">
-                      🗣️ Curso de Idiomas con permiso laboral
-                    </option>
-                    <option value="Nacionalidad en 2 años (España para latinos)">
-                      🇪🇸 Nacionalidad en 2 años (España)
-                    </option>
-                    <option value="Nómada Digital / Trabajo Remoto">
-                      💻 Nómada Digital / Trabajo remoto
-                    </option>
-                  </select>
+                <input
+                  type="range"
+                  min={18}
+                  max={60}
+                  value={diagAge}
+                  onChange={(e) => setDiagAge(Number(e.target.value))}
+                  className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-secondary mt-2"
+                />
+                <div className="flex justify-between text-[10px] text-slate-400 mt-1">
+                  <span>18</span>
+                  <span>30 (Puntajes DAAD/Chancenkarte)</span>
+                  <span>60</span>
                 </div>
               </div>
             </div>
 
-            <div className="flex justify-end gap-3 pt-3 border-t border-outline-variant/20 dark:border-slate-700">
-              <button
-                type="button"
-                onClick={() => setShowProfileDiagnosisModal(false)}
-                className="px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:text-primary dark:hover:text-sky-300 cursor-pointer"
+            {/* Situación Familiar */}
+            <div>
+              <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
+                <Users className="w-3.5 h-3.5 text-secondary" />
+                <span>{language === "en" ? "Family Status" : "Situación Familiar"}</span>
+              </label>
+              <select
+                value={diagFamily}
+                onChange={(e) => setDiagFamily(e.target.value)}
+                className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
               >
-                {language === "en" ? "Cancel" : "Cancelar"}
-              </button>
-              <button
-                type="button"
-                onClick={handleRunProfileDiagnosis}
-                className="bg-primary dark:bg-sky-600 text-white px-6 py-2.5 rounded-xl text-xs font-bold hover:bg-primary-container dark:hover:bg-sky-500 shadow-md transition-all flex items-center gap-2 cursor-pointer"
-              >
-                <Sparkles className="w-4 h-4 text-amber-300" />
-                <span>
-                  {language === "en" ? "Generate AI Diagnosis" : "Generar Diagnóstico con IA"}
+                <option value="Soltero/a sin hijos">🧍 Soltero/a sin hijos</option>
+                <option value="En pareja sin hijos">👫 En pareja sin hijos</option>
+                <option value="Familia con 1 hijo">👨‍👩‍👧 Familia con 1 hijo</option>
+                <option value="Familia con 2 o más hijos">👨‍👩‍👧‍👦 Familia con 2 o más hijos</option>
+              </select>
+            </div>
+
+            {/* Idiomas Conocidos (Multilingüe) */}
+            <div className="space-y-2">
+              <label className="block font-bold text-primary dark:text-sky-300 flex items-center justify-between">
+                <span className="flex items-center gap-1.5">
+                  <Languages className="w-3.5 h-3.5 text-secondary" />
+                  <span>
+                    {language === "en"
+                      ? "Known Languages (Multilingual Profile)"
+                      : "Idiomas que dominas (Perfil Multilingüe)"}
+                  </span>
                 </span>
-              </button>
+                <span className="text-[11px] font-normal text-slate-500">
+                  Selecciona todos los que apliquen
+                </span>
+              </label>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 bg-surface dark:bg-slate-900/80 p-3 rounded-2xl border border-outline-variant/40 dark:border-slate-700/60 max-h-48 overflow-y-auto">
+                {userLanguages.map((item, idx) => (
+                  <div
+                    key={item.name}
+                    className={`p-2 rounded-xl border flex items-center justify-between gap-2 transition-all ${
+                      item.enabled
+                        ? "bg-secondary/10 dark:bg-teal-950/40 border-secondary/40 text-primary dark:text-teal-200 font-semibold"
+                        : "bg-surface-container/40 dark:bg-slate-800/40 border-outline-variant/30 text-on-surface-variant/70 dark:text-slate-400 opacity-80"
+                    }`}
+                  >
+                    <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        checked={item.enabled}
+                        onChange={(e) => {
+                          const updated = [...userLanguages];
+                          updated[idx].enabled = e.target.checked;
+                          setUserLanguages(updated);
+                        }}
+                        className="rounded text-secondary focus:ring-secondary w-3.5 h-3.5 accent-secondary cursor-pointer"
+                      />
+                      <span>{item.name}</span>
+                    </label>
+
+                    {item.enabled && (
+                      <select
+                        value={item.level}
+                        onChange={(e) => {
+                          const updated = [...userLanguages];
+                          updated[idx].level = e.target.value;
+                          setUserLanguages(updated);
+                        }}
+                        className="text-[11px] py-0.5 px-1.5 bg-surface dark:bg-slate-800 border border-outline-variant/50 rounded-lg outline-none text-on-surface dark:text-slate-200"
+                      >
+                        <option value="Básico (A1/A2)">A1/A2</option>
+                        <option value="Intermedio (B1/B2)">B1/B2</option>
+                        <option value="Avanzado (C1/C2)">C1/C2</option>
+                        <option value="Nativo / C2">Nativo</option>
+                      </select>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Presupuesto y Objetivo Principal */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
+                  <DollarSign className="w-3.5 h-3.5 text-secondary" />
+                  <span>
+                    {language === "en"
+                      ? `Available Budget (${currency})`
+                      : `Presupuesto o Ahorro (${currency})`}
+                  </span>
+                </label>
+                <select
+                  value={diagBudgetTier}
+                  onChange={(e) => setDiagBudgetTier(e.target.value as any)}
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+                >
+                  <option value="low">
+                    Menos de {formatCurrency(2000, currency)} (Prioridad Becas 100%)
+                  </option>
+                  <option value="medium">
+                    {formatCurrency(3000, currency)} - {formatCurrency(8000, currency)}
+                  </option>
+                  <option value="high">
+                    {formatCurrency(8000, currency)} - {formatCurrency(15000, currency)} (Sperrkonto
+                    / Cursos)
+                  </option>
+                  <option value="premium">
+                    Más de {formatCurrency(15000, currency)} (Estudios familiares)
+                  </option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block font-bold text-primary dark:text-sky-300 mb-1 flex items-center gap-1.5">
+                  <GraduationCap className="w-3.5 h-3.5 text-secondary" />
+                  <span>{language === "en" ? "Main Goal" : "Meta Principal"}</span>
+                </label>
+                <select
+                  value={diagGoal}
+                  onChange={(e) => setDiagGoal(e.target.value)}
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+                >
+                  <option value="Beca de Maestría o Posgrado 100% financiada">
+                    🎓 Beca 100% (DAAD, Carolina, Erasmus)
+                  </option>
+                  <option value="Trabajo directo o Visa de Oportunidades">
+                    💼 Empleo directo / Visa Oportunidades
+                  </option>
+                  <option value="Curso de Idiomas con Trabajo (Stamp 2 / Co-op)">
+                    🗣️ Curso de Idiomas con permiso laboral
+                  </option>
+                  <option value="Nacionalidad en 2 años (España para latinos)">
+                    🇪🇸 Nacionalidad en 2 años (España)
+                  </option>
+                  <option value="Nómada Digital / Trabajo Remoto">
+                    💻 Nómada Digital / Trabajo remoto
+                  </option>
+                </select>
+              </div>
             </div>
           </div>
-        </div>
+
+          <div className="flex justify-end gap-3 pt-3 border-t border-outline-variant/20 dark:border-slate-700">
+            <button
+              type="button"
+              onClick={() => setShowProfileDiagnosisModal(false)}
+              className="px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:text-primary dark:hover:text-sky-300 cursor-pointer"
+            >
+              {language === "en" ? "Cancel" : "Cancelar"}
+            </button>
+            <button
+              type="button"
+              onClick={handleRunProfileDiagnosis}
+              className="bg-primary dark:bg-sky-600 text-white px-6 py-2.5 rounded-xl text-xs font-bold hover:bg-primary-container dark:hover:bg-sky-500 shadow-md transition-all flex items-center gap-2 cursor-pointer"
+            >
+              <Sparkles className="w-4 h-4 text-amber-300" />
+              <span>
+                {language === "en" ? "Generate AI Diagnosis" : "Generar Diagnóstico con IA"}
+              </span>
+            </button>
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/Comunidad.test.tsx
+++ b/src/components/Comunidad.test.tsx
@@ -29,6 +29,10 @@ describe("Comunidad Component", () => {
     const newPostBtn = screen.getByRole("button", { name: /Crear Publicación/i });
     fireEvent.click(newPostBtn);
 
-    expect(await screen.findByText(/Nueva Publicación en la Comunidad/i)).toBeInTheDocument();
+    // By role: the dialog also carries the same string as its accessible name,
+    // which Radix renders visually hidden.
+    expect(
+      await screen.findByRole("heading", { name: /Nueva Publicación en la Comunidad/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/Comunidad.tsx
+++ b/src/components/Comunidad.tsx
@@ -11,7 +11,6 @@ import {
   AlertTriangle,
   CornerDownRight,
   Send,
-  X,
   BookmarkCheck,
   Cloud,
   Loader2,
@@ -20,7 +19,6 @@ import {
 import { ForumPost, NavigationTab, GoogleUser } from "../types";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { isAdmin } from "../lib/authUtils";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
 import { useLanguage } from "../lib/i18n";
 import {
   fetchCommunityPostsPaginated,
@@ -31,6 +29,7 @@ import {
   CloudForumPost,
 } from "../lib/firebase";
 import { QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
+import { Modal } from "./ui/Modal";
 
 const INITIAL_SEED_POSTS: Omit<CloudForumPost, "id">[] = [
   {
@@ -111,7 +110,6 @@ export const Comunidad: React.FC<ComunidadProps> = ({ currentUser, setActiveTab 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [showNewPostModal, setShowNewPostModal] = useState<boolean>(false);
 
-  useBodyScrollLock(showNewPostModal);
   const [expandedRepliesPostId, setExpandedRepliesPostId] = useState<string | null>(null);
   const [replyInput, setReplyInput] = useState<string>("");
 
@@ -796,9 +794,17 @@ export const Comunidad: React.FC<ComunidadProps> = ({ currentUser, setActiveTab 
 
       {/* New Post Modal with Real-time Duplicate Detection */}
       {showNewPostModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-800 rounded-3xl max-w-2xl w-full p-6 md:p-8 space-y-5 shadow-2xl border border-outline-variant/40 dark:border-slate-700 animate-in fade-in zoom-in-95 duration-200 max-h-[90vh] overflow-y-auto">
-            <div className="flex items-center justify-between border-b border-outline-variant/30 dark:border-slate-700 pb-3">
+        <Modal
+          open={showNewPostModal}
+          onOpenChange={(next) => {
+            if (!next) setShowNewPostModal(false);
+          }}
+          title={
+            language === "en" ? "Create New Community Topic" : "Nueva Publicación en la Comunidad"
+          }
+          size="lg"
+          header={
+            <div className="border-b border-outline-variant/30 dark:border-slate-700 pb-3">
               <div>
                 <h3 className="font-headline-md text-xl font-bold text-primary dark:text-sky-300 flex items-center gap-2">
                   <MessageSquare className="w-5 h-5 text-secondary" />
@@ -814,205 +820,197 @@ export const Comunidad: React.FC<ComunidadProps> = ({ currentUser, setActiveTab 
                     : "Consulta una duda o comparte tu experiencia migratoria real (Guardado permanente en la nube)"}
                 </p>
               </div>
-              <button
-                onClick={() => setShowNewPostModal(false)}
-                className="p-1 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
-              >
-                <X className="w-5 h-5" />
-              </button>
+            </div>
+          }
+        >
+          <form onSubmit={handleCreatePost} className="space-y-4">
+            {/* Title input */}
+            <div className="space-y-1">
+              <label className="block text-xs font-bold text-primary dark:text-sky-300">
+                {language === "en" ? "Title / Question *" : "Título de la Consulta o Experiencia *"}
+              </label>
+              <input
+                type="text"
+                required
+                value={postTitle}
+                onChange={(e) => setPostTitle(e.target.value)}
+                placeholder={
+                  language === "en"
+                    ? "e.g., How to get student health insurance in Spain without copays?"
+                    : "ej. ¿Cómo tramitar el seguro médico en España sin copagos para la visa?"
+                }
+                className="w-full p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+              />
             </div>
 
-            <form onSubmit={handleCreatePost} className="space-y-4">
-              {/* Title input */}
-              <div className="space-y-1">
-                <label className="block text-xs font-bold text-primary dark:text-sky-300">
+            {/* Duplicate Prevention Alert Box */}
+            {potentialDuplicates.length > 0 && (
+              <div className="p-3.5 bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700/60 rounded-2xl space-y-2 animate-in fade-in duration-200">
+                <div className="flex items-center gap-2 text-xs font-bold text-amber-900 dark:text-amber-300">
+                  <AlertTriangle className="w-4 h-4 text-amber-600 shrink-0" />
+                  <span>
+                    {t(
+                      "community.duplicateAlert",
+                      "¡Prevención de Duplicados! Temas similares ya respondidos:"
+                    )}
+                  </span>
+                </div>
+                <div className="space-y-1.5 pl-6">
+                  {potentialDuplicates.slice(0, 2).map((dup) => (
+                    <div
+                      key={dup.id}
+                      className="text-xs text-amber-800 dark:text-amber-200 flex items-start justify-between gap-2"
+                    >
+                      <span className="font-semibold truncate">• {dup.title}</span>
+                      <span className="text-[10px] bg-amber-200 dark:bg-amber-900 px-2 py-0.5 rounded-full font-bold shrink-0">
+                        {dup.replies} respuestas
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <p className="text-[11px] text-amber-800/80 dark:text-amber-300/80 pl-6">
                   {language === "en"
-                    ? "Title / Question *"
-                    : "Título de la Consulta o Experiencia *"}
+                    ? "If your question is different, feel free to proceed with publishing below."
+                    : "Si tu caso tiene detalles particulares, puedes continuar publicando sin problemas."}
+                </p>
+              </div>
+            )}
+
+            {/* Categoría y Destino */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div>
+                <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
+                  {language === "en" ? "Category" : "Categoría"}
+                </label>
+                <select
+                  value={postCategory}
+                  onChange={(e) => setPostCategory(e.target.value)}
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+                >
+                  {categories
+                    .filter((c) => c !== "Todas")
+                    .map((cat) => (
+                      <option key={cat} value={cat}>
+                        {cat}
+                      </option>
+                    ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
+                  {language === "en" ? "Country of Destination" : "País de Destino"}
+                </label>
+                <select
+                  value={postCountry}
+                  onChange={(e) => setPostCountry(e.target.value)}
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+                >
+                  <option value="España">🇪🇸 España</option>
+                  <option value="Alemania">🇩🇪 Alemania</option>
+                  <option value="Irlanda">🇮🇪 Irlanda</option>
+                  <option value="Canadá">🇨🇦 Canadá</option>
+                  <option value="Francia">🇫🇷 Francia</option>
+                  <option value="Italia">🇮🇹 Italia</option>
+                  <option value="EE.UU.">🇺🇸 Estados Unidos</option>
+                  <option value="Australia">🇦🇺 Australia</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
+                  {language === "en" ? "City" : "Ciudad"}
                 </label>
                 <input
                   type="text"
-                  required
-                  value={postTitle}
-                  onChange={(e) => setPostTitle(e.target.value)}
-                  placeholder={
-                    language === "en"
-                      ? "e.g., How to get student health insurance in Spain without copays?"
-                      : "ej. ¿Cómo tramitar el seguro médico en España sin copagos para la visa?"
-                  }
-                  className="w-full p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
+                  value={postCity}
+                  onChange={(e) => setPostCity(e.target.value)}
+                  placeholder="ej. Madrid, Barcelona, Valencia..."
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
                 />
               </div>
+            </div>
 
-              {/* Duplicate Prevention Alert Box */}
-              {potentialDuplicates.length > 0 && (
-                <div className="p-3.5 bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700/60 rounded-2xl space-y-2 animate-in fade-in duration-200">
-                  <div className="flex items-center gap-2 text-xs font-bold text-amber-900 dark:text-amber-300">
-                    <AlertTriangle className="w-4 h-4 text-amber-600 shrink-0" />
-                    <span>
-                      {t(
-                        "community.duplicateAlert",
-                        "¡Prevención de Duplicados! Temas similares ya respondidos:"
-                      )}
-                    </span>
-                  </div>
-                  <div className="space-y-1.5 pl-6">
-                    {potentialDuplicates.slice(0, 2).map((dup) => (
-                      <div
-                        key={dup.id}
-                        className="text-xs text-amber-800 dark:text-amber-200 flex items-start justify-between gap-2"
-                      >
-                        <span className="font-semibold truncate">• {dup.title}</span>
-                        <span className="text-[10px] bg-amber-200 dark:bg-amber-900 px-2 py-0.5 rounded-full font-bold shrink-0">
-                          {dup.replies} respuestas
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                  <p className="text-[11px] text-amber-800/80 dark:text-amber-300/80 pl-6">
-                    {language === "en"
-                      ? "If your question is different, feel free to proceed with publishing below."
-                      : "Si tu caso tiene detalles particulares, puedes continuar publicando sin problemas."}
-                  </p>
-                </div>
-              )}
-
-              {/* Categoría y Destino */}
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                <div>
-                  <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
-                    {language === "en" ? "Category" : "Categoría"}
-                  </label>
-                  <select
-                    value={postCategory}
-                    onChange={(e) => setPostCategory(e.target.value)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    {categories
-                      .filter((c) => c !== "Todas")
-                      .map((cat) => (
-                        <option key={cat} value={cat}>
-                          {cat}
-                        </option>
-                      ))}
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
-                    {language === "en" ? "Country of Destination" : "País de Destino"}
-                  </label>
-                  <select
-                    value={postCountry}
-                    onChange={(e) => setPostCountry(e.target.value)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    <option value="España">🇪🇸 España</option>
-                    <option value="Alemania">🇩🇪 Alemania</option>
-                    <option value="Irlanda">🇮🇪 Irlanda</option>
-                    <option value="Canadá">🇨🇦 Canadá</option>
-                    <option value="Francia">🇫🇷 Francia</option>
-                    <option value="Italia">🇮🇹 Italia</option>
-                    <option value="EE.UU.">🇺🇸 Estados Unidos</option>
-                    <option value="Australia">🇦🇺 Australia</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
-                    {language === "en" ? "City" : "Ciudad"}
-                  </label>
-                  <input
-                    type="text"
-                    value={postCity}
-                    onChange={(e) => setPostCity(e.target.value)}
-                    placeholder="ej. Madrid, Barcelona, Valencia..."
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  />
-                </div>
-              </div>
-
-              {/* Autor info */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
-                    {language === "en" ? "Your Name or Alias" : "Tu Nombre o Alias"}
-                  </label>
-                  <input
-                    type="text"
-                    value={postAuthor}
-                    onChange={(e) => setPostAuthor(e.target.value)}
-                    placeholder="ej. Mariana S."
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
-                    {language === "en" ? "Your Origin Country" : "Tu País de Origen o Ubicación"}
-                  </label>
-                  <select
-                    value={postAuthorCountry}
-                    onChange={(e) => setPostAuthorCountry(e.target.value)}
-                    className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
-                  >
-                    <option value="España">🇪🇸 España</option>
-                    <option value="Colombia">🇨🇴 Colombia</option>
-                    <option value="México">🇲🇽 México</option>
-                    <option value="Perú">🇵🇪 Perú</option>
-                    <option value="Argentina">🇦🇷 Argentina</option>
-                    <option value="Chile">🇨🇱 Chile</option>
-                    <option value="Ecuador">🇪🇨 Ecuador</option>
-                    <option value="Venezuela">🇻🇪 Venezuela</option>
-                    <option value="Bolivia">🇧🇴 Bolivia</option>
-                    <option value="Guatemala">🇬🇹 Guatemala</option>
-                    <option value="Costa Rica">🇨🇷 Costa Rica</option>
-                    <option value="Honduras">🇭🇳 Honduras</option>
-                    <option value="El Salvador">🇸🇻 El Salvador</option>
-                    <option value="Rep. Dominicana">🇩🇴 Rep. Dominicana</option>
-                  </select>
-                </div>
-              </div>
-
-              {/* Contenido */}
-              <div className="space-y-1">
-                <label className="block text-xs font-bold text-primary dark:text-sky-300">
-                  {language === "en" ? "Detailed Description *" : "Detalle o Consulta *"}
+            {/* Autor info */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
+                  {language === "en" ? "Your Name or Alias" : "Tu Nombre o Alias"}
                 </label>
-                <textarea
-                  rows={4}
-                  required
-                  value={postContent}
-                  onChange={(e) => setPostContent(e.target.value)}
-                  placeholder={
-                    language === "en"
-                      ? "Explain your situation, visa timeline, questions or advice for others..."
-                      : "Explica tu situación, fechas de tu viaje, dudas específicas o recomendaciones para otros postulantes..."
-                  }
-                  className="w-full p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100 leading-relaxed"
+                <input
+                  type="text"
+                  value={postAuthor}
+                  onChange={(e) => setPostAuthor(e.target.value)}
+                  placeholder="ej. Mariana S."
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
                 />
               </div>
 
-              <div className="flex justify-end gap-3 pt-2 border-t border-outline-variant/20 dark:border-slate-700">
-                <button
-                  type="button"
-                  onClick={() => setShowNewPostModal(false)}
-                  className="px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:text-primary dark:hover:text-sky-300 cursor-pointer"
+              <div>
+                <label className="block text-xs font-bold text-primary dark:text-sky-300 mb-1">
+                  {language === "en" ? "Your Origin Country" : "Tu País de Origen o Ubicación"}
+                </label>
+                <select
+                  value={postAuthorCountry}
+                  onChange={(e) => setPostAuthorCountry(e.target.value)}
+                  className="w-full p-2.5 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100"
                 >
-                  {language === "en" ? "Cancel" : "Cancelar"}
-                </button>
-                <button
-                  type="submit"
-                  disabled={isSubmittingPost}
-                  className="bg-primary dark:bg-sky-600 text-white px-6 py-2.5 rounded-xl text-xs font-bold hover:bg-primary-container dark:hover:bg-sky-500 shadow-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50"
-                >
-                  {isSubmittingPost && <Loader2 className="w-4 h-4 animate-spin" />}
-                  <span>{language === "en" ? "Publish to Cloud" : "Publicar en la Nube"}</span>
-                </button>
+                  <option value="España">🇪🇸 España</option>
+                  <option value="Colombia">🇨🇴 Colombia</option>
+                  <option value="México">🇲🇽 México</option>
+                  <option value="Perú">🇵🇪 Perú</option>
+                  <option value="Argentina">🇦🇷 Argentina</option>
+                  <option value="Chile">🇨🇱 Chile</option>
+                  <option value="Ecuador">🇪🇨 Ecuador</option>
+                  <option value="Venezuela">🇻🇪 Venezuela</option>
+                  <option value="Bolivia">🇧🇴 Bolivia</option>
+                  <option value="Guatemala">🇬🇹 Guatemala</option>
+                  <option value="Costa Rica">🇨🇷 Costa Rica</option>
+                  <option value="Honduras">🇭🇳 Honduras</option>
+                  <option value="El Salvador">🇸🇻 El Salvador</option>
+                  <option value="Rep. Dominicana">🇩🇴 Rep. Dominicana</option>
+                </select>
               </div>
-            </form>
-          </div>
-        </div>
+            </div>
+
+            {/* Contenido */}
+            <div className="space-y-1">
+              <label className="block text-xs font-bold text-primary dark:text-sky-300">
+                {language === "en" ? "Detailed Description *" : "Detalle o Consulta *"}
+              </label>
+              <textarea
+                rows={4}
+                required
+                value={postContent}
+                onChange={(e) => setPostContent(e.target.value)}
+                placeholder={
+                  language === "en"
+                    ? "Explain your situation, visa timeline, questions or advice for others..."
+                    : "Explica tu situación, fechas de tu viaje, dudas específicas o recomendaciones para otros postulantes..."
+                }
+                className="w-full p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium focus:ring-2 focus:ring-secondary outline-none dark:text-slate-100 leading-relaxed"
+              />
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2 border-t border-outline-variant/20 dark:border-slate-700">
+              <button
+                type="button"
+                onClick={() => setShowNewPostModal(false)}
+                className="px-4 py-2.5 text-xs font-bold text-on-surface-variant hover:text-primary dark:hover:text-sky-300 cursor-pointer"
+              >
+                {language === "en" ? "Cancel" : "Cancelar"}
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmittingPost}
+                className="bg-primary dark:bg-sky-600 text-white px-6 py-2.5 rounded-xl text-xs font-bold hover:bg-primary-container dark:hover:bg-sky-500 shadow-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50"
+              >
+                {isSubmittingPost && <Loader2 className="w-4 h-4 animate-spin" />}
+                <span>{language === "en" ? "Publish to Cloud" : "Publicar en la Nube"}</span>
+              </button>
+            </div>
+          </form>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/FeedbackHub.tsx
+++ b/src/components/FeedbackHub.tsx
@@ -12,10 +12,9 @@ import {
   FileCheck,
   Bug,
   Heart,
-  X,
 } from "lucide-react";
 import { FeedbackSuggestion, GoogleUser } from "../types";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 import {
   fetchFeedbackSuggestions,
   createFeedbackSuggestion,
@@ -113,7 +112,6 @@ export const FeedbackHub: React.FC<FeedbackHubProps> = ({ currentUser, onOpenAut
   const [searchFilter, setSearchFilter] = useState<string>("");
   const [showNewModal, setShowNewModal] = useState<boolean>(false);
 
-  useBodyScrollLock(showNewModal);
   const [newTitle, setNewTitle] = useState<string>("");
   const [newDesc, setNewDesc] = useState<string>("");
   const [newCat, setNewCat] = useState<FeedbackSuggestion["category"]>("feature");
@@ -381,101 +379,101 @@ export const FeedbackHub: React.FC<FeedbackHubProps> = ({ currentUser, onOpenAut
 
       {/* Propose Idea Modal */}
       {showNewModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in lm-overlay">
-          <div className="bg-surface dark:bg-slate-900 rounded-3xl max-w-lg w-full p-6 md:p-8 border border-outline-variant/60 dark:border-slate-800 shadow-2xl relative">
-            <button
-              onClick={() => setShowNewModal(false)}
-              aria-label="Cerrar modal de sugerencia"
-              className="absolute top-5 right-5 p-2 text-on-surface-variant hover:text-on-surface rounded-full transition-colors"
-            >
-              <X className="w-5 h-5" />
-            </button>
-
-            <div className="flex items-center gap-2 text-secondary dark:text-teal-400 text-xs font-bold uppercase mb-1">
-              <Lightbulb className="w-4 h-4" />
-              <span>Proponer Idea o Sugerencia</span>
-            </div>
-            <h2 className="font-headline-sm text-2xl font-bold text-primary dark:text-sky-300 mb-4">
-              ¿Qué te gustaría ver en LatinoMigra?
-            </h2>
-
-            {successNotice ? (
-              <div className="p-6 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200 dark:border-emerald-800 rounded-2xl text-center space-y-2">
-                <CheckCircle2 className="w-10 h-10 text-emerald-500 mx-auto" />
-                <h3 className="font-bold text-emerald-900 dark:text-emerald-200">
-                  ¡Sugerencia Registrada!
-                </h3>
-                <p className="text-xs text-emerald-700 dark:text-emerald-300">
-                  Tu idea ya está visible para que otros miembros de la comunidad puedan votar por
-                  ella.
-                </p>
+        <Modal
+          open={showNewModal}
+          onOpenChange={(next) => {
+            if (!next) setShowNewModal(false);
+          }}
+          title="¿Qué te gustaría ver en LatinoMigra?"
+          size="md"
+          header={
+            <div>
+              <div className="flex items-center gap-2 text-secondary dark:text-teal-400 text-xs font-bold uppercase mb-1">
+                <Lightbulb className="w-4 h-4" />
+                <span>Proponer Idea o Sugerencia</span>
               </div>
-            ) : (
-              <form onSubmit={handleCreateSuggestion} className="space-y-4">
-                <div>
-                  <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
-                    Categoría
-                  </label>
-                  <select
-                    value={newCat}
-                    onChange={(e) => setNewCat(e.target.value as any)}
-                    className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
-                  >
-                    <option value="feature">💡 Nueva Función o Herramienta</option>
-                    <option value="scholarship">🎓 Sugerir Nueva Beca o Convenio</option>
-                    <option value="visa_update">📝 Actualizar Guía de Visado o Requisito</option>
-                    <option value="bug">🐛 Reportar Error o Corrección</option>
-                    <option value="testimonial">❤️ Compartir Historia / Testimonio</option>
-                  </select>
-                </div>
+              <h2 className="font-headline-sm text-2xl font-bold text-primary dark:text-sky-300 mb-4">
+                ¿Qué te gustaría ver en LatinoMigra?
+              </h2>
+            </div>
+          }
+        >
+          {successNotice ? (
+            <div className="p-6 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200 dark:border-emerald-800 rounded-2xl text-center space-y-2">
+              <CheckCircle2 className="w-10 h-10 text-emerald-500 mx-auto" />
+              <h3 className="font-bold text-emerald-900 dark:text-emerald-200">
+                ¡Sugerencia Registrada!
+              </h3>
+              <p className="text-xs text-emerald-700 dark:text-emerald-300">
+                Tu idea ya está visible para que otros miembros de la comunidad puedan votar por
+                ella.
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleCreateSuggestion} className="space-y-4">
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
+                  Categoría
+                </label>
+                <select
+                  value={newCat}
+                  onChange={(e) => setNewCat(e.target.value as any)}
+                  className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
+                >
+                  <option value="feature">💡 Nueva Función o Herramienta</option>
+                  <option value="scholarship">🎓 Sugerir Nueva Beca o Convenio</option>
+                  <option value="visa_update">📝 Actualizar Guía de Visado o Requisito</option>
+                  <option value="bug">🐛 Reportar Error o Corrección</option>
+                  <option value="testimonial">❤️ Compartir Historia / Testimonio</option>
+                </select>
+              </div>
 
-                <div>
-                  <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
-                    Título de la Idea (Claro y Conciso)
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={newTitle}
-                    onChange={(e) => setNewTitle(e.target.value)}
-                    placeholder="Ej: Agregar comparador de alquileres por barrio"
-                    className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
-                  />
-                </div>
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
+                  Título de la Idea (Claro y Conciso)
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                  placeholder="Ej: Agregar comparador de alquileres por barrio"
+                  className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
+                />
+              </div>
 
-                <div>
-                  <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
-                    Detalle o justificación
-                  </label>
-                  <textarea
-                    required
-                    rows={4}
-                    value={newDesc}
-                    onChange={(e) => setNewDesc(e.target.value)}
-                    placeholder="Explica cómo beneficiaría esto a otros viajeros y estudiantes..."
-                    className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
-                  />
-                </div>
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 mb-1">
+                  Detalle o justificación
+                </label>
+                <textarea
+                  required
+                  rows={4}
+                  value={newDesc}
+                  onChange={(e) => setNewDesc(e.target.value)}
+                  placeholder="Explica cómo beneficiaría esto a otros viajeros y estudiantes..."
+                  className="w-full px-3.5 py-2.5 bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 rounded-xl text-sm outline-none dark:text-slate-100"
+                />
+              </div>
 
-                <div className="flex justify-end gap-2 pt-3">
-                  <button
-                    type="button"
-                    onClick={() => setShowNewModal(false)}
-                    className="px-4 py-2 text-xs font-bold rounded-xl text-on-surface-variant dark:text-slate-400 hover:bg-surface-container"
-                  >
-                    Cancelar
-                  </button>
-                  <button
-                    type="submit"
-                    className="px-5 py-2.5 text-xs font-bold rounded-xl bg-primary dark:bg-sky-600 text-white hover:opacity-90"
-                  >
-                    Publicar Sugerencia
-                  </button>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+              <div className="flex justify-end gap-2 pt-3">
+                <button
+                  type="button"
+                  onClick={() => setShowNewModal(false)}
+                  className="px-4 py-2 text-xs font-bold rounded-xl text-on-surface-variant dark:text-slate-400 hover:bg-surface-container"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  className="px-5 py-2.5 text-xs font-bold rounded-xl bg-primary dark:bg-sky-600 text-white hover:opacity-90"
+                >
+                  Publicar Sugerencia
+                </button>
+              </div>
+            </form>
+          )}
+        </Modal>
       )}
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,6 @@ import {
   Lock,
   MessageSquare,
   Mail,
-  X,
   Sparkles,
   Compass,
   Calculator,
@@ -21,7 +20,7 @@ import {
 } from "lucide-react";
 import { NavigationTab } from "../types";
 import { useLanguage } from "../lib/i18n";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 
 interface FooterProps {
   setActiveTab: (tab: NavigationTab) => void;
@@ -32,8 +31,6 @@ type ModalType = "terms" | "privacy" | "guidelines" | "contact" | null;
 export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
   const { language, t } = useLanguage();
   const [activeModal, setActiveModal] = useState<ModalType>(null);
-
-  useBodyScrollLock(activeModal !== null);
 
   const handleNavigate = (tab: NavigationTab) => {
     setActiveTab(tab);
@@ -251,9 +248,15 @@ export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
 
       {/* Interactive Information Modals */}
       {activeModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4 lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-800 rounded-3xl max-w-xl w-full p-6 md:p-8 space-y-4 shadow-2xl border border-outline-variant/40 dark:border-slate-700 animate-in fade-in zoom-in-95 duration-200">
-            <div className="flex items-center justify-between border-b border-outline-variant/30 dark:border-slate-700 pb-3">
+        <Modal
+          open={activeModal !== null}
+          onOpenChange={(next) => {
+            if (!next) setActiveModal(null);
+          }}
+          title={language === "en" ? "Legal information" : "Información legal"}
+          size="lg"
+          header={
+            <div className="border-b border-outline-variant/30 dark:border-slate-700 pb-3">
               <h3 className="font-headline-sm text-lg md:text-xl font-bold text-primary dark:text-sky-300 flex items-center gap-2">
                 {activeModal === "terms" && <FileText className="w-5 h-5 text-secondary" />}
                 {activeModal === "privacy" && <Lock className="w-5 h-5 text-emerald-500" />}
@@ -274,127 +277,120 @@ export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
                     (language === "en" ? "Contact & Support" : "Contacto y Asistencia")}
                 </span>
               </h3>
-              <button
-                onClick={() => setActiveModal(null)}
-                className="p-1 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 active:scale-90 transition-all cursor-pointer"
-              >
-                <X className="w-5 h-5" />
-              </button>
             </div>
+          }
+        >
+          <div className="text-xs md:text-sm text-on-surface-variant dark:text-slate-300 space-y-3 leading-relaxed max-h-[60vh] overflow-y-auto pr-2">
+            {activeModal === "terms" && (
+              <>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  1. Naturaleza Informativa y Orientativa
+                </p>
+                <p>
+                  LatinoMigra es una plataforma digital de información pública, organizada y
+                  orientada a apoyar a postulantes latinoamericanos. LatinoMigra no es una agencia
+                  de cobro ni sustituye a los consulados, embajadas u organismos oficiales de
+                  inmigración.
+                </p>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  2. Verificación de Requisitos
+                </p>
+                <p>
+                  Todos los requisitos de visados, fondos económicos (como el IPREM o la Sperrkonto)
+                  y convocatorias de becas son revisados periódicamente, pero recomendamos siempre
+                  cotejar con las fuentes consulares oficiales de cada país de destino.
+                </p>
+              </>
+            )}
 
-            <div className="text-xs md:text-sm text-on-surface-variant dark:text-slate-300 space-y-3 leading-relaxed max-h-[60vh] overflow-y-auto pr-2">
-              {activeModal === "terms" && (
-                <>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    1. Naturaleza Informativa y Orientativa
-                  </p>
-                  <p>
-                    LatinoMigra es una plataforma digital de información pública, organizada y
-                    orientada a apoyar a postulantes latinoamericanos. LatinoMigra no es una agencia
-                    de cobro ni sustituye a los consulados, embajadas u organismos oficiales de
-                    inmigración.
-                  </p>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    2. Verificación de Requisitos
-                  </p>
-                  <p>
-                    Todos los requisitos de visados, fondos económicos (como el IPREM o la
-                    Sperrkonto) y convocatorias de becas son revisados periódicamente, pero
-                    recomendamos siempre cotejar con las fuentes consulares oficiales de cada país
-                    de destino.
-                  </p>
-                </>
-              )}
+            {activeModal === "privacy" && (
+              <>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  Protección y Privacidad de tus Datos
+                </p>
+                <p>
+                  En LatinoMigra valoramos la privacidad de los migrantes y estudiantes. No vendemos
+                  ni compartimos tus datos de contacto con terceros ni agencias con fines de
+                  publicidad invasiva.
+                </p>
+                <p>
+                  Tus planes guardados y preferencias de simulación se almacenan de manera segura
+                  bajo tu perfil de usuario para permitirte sincronizar tus calculadoras y agendas
+                  consulares entre dispositivos.
+                </p>
+              </>
+            )}
 
-              {activeModal === "privacy" && (
-                <>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    Protección y Privacidad de tus Datos
-                  </p>
-                  <p>
-                    En LatinoMigra valoramos la privacidad de los migrantes y estudiantes. No
-                    vendemos ni compartimos tus datos de contacto con terceros ni agencias con fines
-                    de publicidad invasiva.
-                  </p>
-                  <p>
-                    Tus planes guardados y preferencias de simulación se almacenan de manera segura
-                    bajo tu perfil de usuario para permitirte sincronizar tus calculadoras y agendas
-                    consulares entre dispositivos.
-                  </p>
-                </>
-              )}
+            {activeModal === "guidelines" && (
+              <>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  1. Respeto y Empatía Mutua
+                </p>
+                <p>
+                  Todos los miembros de la comunidad se encuentran en procesos migratorios o de
+                  estudio que requieren paciencia y apoyo. No se tolera discriminación,
+                  desinformación intencional ni venta de servicios no autorizados.
+                </p>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  2. Búsqueda y Prevención de Preguntas Duplicadas
+                </p>
+                <p>
+                  Antes de publicar una duda, te sugerimos utilizar la barra de búsqueda para
+                  verificar si otro compañero ya recibió una respuesta detallada con enlaces y
+                  consejos.
+                </p>
+              </>
+            )}
 
-              {activeModal === "guidelines" && (
-                <>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    1. Respeto y Empatía Mutua
+            {activeModal === "contact" && (
+              <>
+                <p className="font-semibold text-primary dark:text-sky-300">
+                  Equipo de LatinoMigra
+                </p>
+                <p>
+                  ¿Tienes dudas sobre una beca, encontraste un enlace consular desactualizado o
+                  deseas colaborar con la comunidad?
+                </p>
+                <div className="p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/50 space-y-1">
+                  <p className="font-bold text-xs text-primary dark:text-sky-300">
+                    📧 Correo de soporte:
                   </p>
-                  <p>
-                    Todos los miembros de la comunidad se encuentran en procesos migratorios o de
-                    estudio que requieren paciencia y apoyo. No se tolera discriminación,
-                    desinformación intencional ni venta de servicios no autorizados.
+                  <a
+                    href="mailto:latinomigra@gmail.com"
+                    className="text-xs text-secondary font-mono hover:underline"
+                  >
+                    latinomigra@gmail.com
+                  </a>
+                  <p className="font-bold text-xs text-primary dark:text-sky-300 pt-1">
+                    💡 Sugerencias directas:
                   </p>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    2. Búsqueda y Prevención de Preguntas Duplicadas
-                  </p>
-                  <p>
-                    Antes de publicar una duda, te sugerimos utilizar la barra de búsqueda para
-                    verificar si otro compañero ya recibió una respuesta detallada con enlaces y
-                    consejos.
-                  </p>
-                </>
-              )}
-
-              {activeModal === "contact" && (
-                <>
-                  <p className="font-semibold text-primary dark:text-sky-300">
-                    Equipo de LatinoMigra
-                  </p>
-                  <p>
-                    ¿Tienes dudas sobre una beca, encontraste un enlace consular desactualizado o
-                    deseas colaborar con la comunidad?
-                  </p>
-                  <div className="p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/50 space-y-1">
-                    <p className="font-bold text-xs text-primary dark:text-sky-300">
-                      📧 Correo de soporte:
-                    </p>
-                    <a
-                      href="mailto:latinomigra@gmail.com"
-                      className="text-xs text-secondary font-mono hover:underline"
+                  <p className="text-xs">
+                    Puedes publicar en la sección de{" "}
+                    <button
+                      onClick={() => {
+                        setActiveModal(null);
+                        handleNavigate("feedback");
+                      }}
+                      className="underline font-bold text-secondary cursor-pointer"
                     >
-                      latinomigra@gmail.com
-                    </a>
-                    <p className="font-bold text-xs text-primary dark:text-sky-300 pt-1">
-                      💡 Sugerencias directas:
-                    </p>
-                    <p className="text-xs">
-                      Puedes publicar en la sección de{" "}
-                      <button
-                        onClick={() => {
-                          setActiveModal(null);
-                          handleNavigate("feedback");
-                        }}
-                        className="underline font-bold text-secondary cursor-pointer"
-                      >
-                        Sugerencias Comunitarias
-                      </button>{" "}
-                      para que el equipo priorice nuevas integraciones.
-                    </p>
-                  </div>
-                </>
-              )}
-            </div>
-
-            <div className="pt-2 flex justify-end">
-              <button
-                onClick={() => setActiveModal(null)}
-                className="px-5 py-2 rounded-xl bg-primary dark:bg-sky-600 text-white font-bold text-xs hover:bg-primary-container transition-all active:scale-95 cursor-pointer shadow-sm"
-              >
-                {language === "en" ? "Close" : "Entendido y Cerrar"}
-              </button>
-            </div>
+                      Sugerencias Comunitarias
+                    </button>{" "}
+                    para que el equipo priorice nuevas integraciones.
+                  </p>
+                </div>
+              </>
+            )}
           </div>
-        </div>
+
+          <div className="pt-2 flex justify-end">
+            <button
+              onClick={() => setActiveModal(null)}
+              className="px-5 py-2 rounded-xl bg-primary dark:bg-sky-600 text-white font-bold text-xs hover:bg-primary-container transition-all active:scale-95 cursor-pointer shadow-sm"
+            >
+              {language === "en" ? "Close" : "Entendido y Cerrar"}
+            </button>
+          </div>
+        </Modal>
       )}
     </footer>
   );

--- a/src/components/NotificationSettingsModal.tsx
+++ b/src/components/NotificationSettingsModal.tsx
@@ -4,7 +4,7 @@ import { GoogleUser, UserAlertPreferences } from "../types";
 import { useLanguage } from "../lib/i18n";
 import { saveUserAlertPreferences, getUserAlertPreferences } from "../lib/firebase";
 import { usePreferences } from "../lib/PreferencesContext";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 
 interface NotificationSettingsModalProps {
   isOpen: boolean;
@@ -66,10 +66,6 @@ export const NotificationSettingsModal: React.FC<NotificationSettingsModalProps>
       }
     }
   }, [isOpen]);
-
-  useBodyScrollLock(isOpen);
-
-  if (!isOpen) return null;
 
   const handleRequestPushPermission = async () => {
     let granted = false;
@@ -157,18 +153,16 @@ export const NotificationSettingsModal: React.FC<NotificationSettingsModalProps>
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4 bg-black/60 backdrop-blur-xs overflow-y-auto lm-overlay">
-      <div className="bg-surface-container-lowest dark:bg-slate-900 rounded-3xl max-w-lg w-full max-h-[92vh] overflow-y-auto shadow-2xl border border-outline-variant/50 dark:border-slate-800 p-5 sm:p-7 space-y-5 relative animate-in fade-in zoom-in-95">
-        {/* Close button */}
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 p-2 text-on-surface-variant dark:text-slate-400 hover:bg-surface-container dark:hover:bg-slate-800 rounded-full transition-colors"
-        >
-          <X className="w-5 h-5" />
-        </button>
-
-        {/* Header */}
-        <div className="space-y-1.5 pr-6">
+    <Modal
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      title={language === "en" ? "Alerts & Notifications" : "Centro de Alertas Migratorias"}
+      size="md"
+      id="notification-settings-modal"
+      header={
+        <div className="space-y-1.5">
           <div className="inline-flex items-center gap-1.5 px-3 py-1 bg-amber-500/10 dark:bg-amber-400/20 text-amber-700 dark:text-amber-300 rounded-full text-xs font-bold uppercase tracking-wider">
             <Bell className="w-3.5 h-3.5" />
             <span>
@@ -184,262 +178,262 @@ export const NotificationSettingsModal: React.FC<NotificationSettingsModalProps>
               : "Recibe recordatorios de cierre de becas, cambios consulares y respuestas a tus dudas en tu correo o en tu navegador móvil."}
           </p>
         </div>
+      }
+    >
+      {/* Header */}
 
-        {savedSuccess ? (
-          <div className="bg-emerald-500/10 border border-emerald-500/30 text-emerald-800 dark:text-emerald-300 p-5 rounded-2xl text-center space-y-2">
-            <CheckCircle2 className="w-10 h-10 text-emerald-500 mx-auto animate-bounce" />
-            <h3 className="font-bold text-sm">
+      {savedSuccess ? (
+        <div className="bg-emerald-500/10 border border-emerald-500/30 text-emerald-800 dark:text-emerald-300 p-5 rounded-2xl text-center space-y-2">
+          <CheckCircle2 className="w-10 h-10 text-emerald-500 mx-auto animate-bounce" />
+          <h3 className="font-bold text-sm">
+            {language === "en"
+              ? "Alerts Saved Successfully!"
+              : "¡Preferencias Guardadas con Éxito!"}
+          </h3>
+          <p className="text-xs">
+            {language === "en"
+              ? "You will receive updates according to your chosen destination and study area."
+              : "Recibirás avisos clave según tu país de destino y área de estudio seleccionados."}
+          </p>
+        </div>
+      ) : (
+        <form onSubmit={handleSave} className="space-y-4">
+          {/* Email Field */}
+          <div>
+            <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
               {language === "en"
-                ? "Alerts Saved Successfully!"
-                : "¡Preferencias Guardadas con Éxito!"}
-            </h3>
-            <p className="text-xs">
-              {language === "en"
-                ? "You will receive updates according to your chosen destination and study area."
-                : "Recibirás avisos clave según tu país de destino y área de estudio seleccionados."}
-            </p>
+                ? "Notification Email Address"
+                : "Correo electrónico para recibir alertas *"}
+            </label>
+            <div className="relative">
+              <Mail className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant dark:text-slate-400" />
+              <input
+                type="email"
+                required
+                value={preferences.email}
+                onChange={(e) => setPreferences({ ...preferences, email: e.target.value })}
+                placeholder="tu.correo@ejemplo.com"
+                className="w-full pl-9 pr-3.5 py-2.5 bg-surface dark:bg-slate-800 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium outline-none focus:ring-2 focus:ring-secondary dark:text-slate-100"
+              />
+            </div>
           </div>
-        ) : (
-          <form onSubmit={handleSave} className="space-y-4">
-            {/* Email Field */}
+
+          {/* Target Filters for Alerts */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 bg-surface-container/50 dark:bg-slate-800/40 p-3.5 rounded-2xl border border-outline-variant/40 dark:border-slate-800">
             <div>
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1">
-                {language === "en"
-                  ? "Notification Email Address"
-                  : "Correo electrónico para recibir alertas *"}
+              <label className="text-[11px] font-bold text-on-surface-variant dark:text-slate-400 block mb-1">
+                {language === "en" ? "Target Destination" : "País de Destino Prioritario"}
               </label>
-              <div className="relative">
-                <Mail className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant dark:text-slate-400" />
-                <input
-                  type="email"
-                  required
-                  value={preferences.email}
-                  onChange={(e) => setPreferences({ ...preferences, email: e.target.value })}
-                  placeholder="tu.correo@ejemplo.com"
-                  className="w-full pl-9 pr-3.5 py-2.5 bg-surface dark:bg-slate-800 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-medium outline-none focus:ring-2 focus:ring-secondary dark:text-slate-100"
-                />
-              </div>
+              <select
+                value={preferences.destinationCountry}
+                onChange={(e) => {
+                  setPreferences({ ...preferences, destinationCountry: e.target.value });
+                  setDestinationCountry(e.target.value);
+                }}
+                className="w-full px-3 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold outline-none focus:ring-1 focus:ring-secondary dark:text-slate-200"
+              >
+                <option value="España">🇪🇸 España</option>
+                <option value="Alemania">🇩🇪 Alemania</option>
+                <option value="Canadá">🇨🇦 Canadá</option>
+                <option value="Irlanda">🇮🇪 Irlanda</option>
+                <option value="Estados Unidos">🇺🇸 Estados Unidos</option>
+                <option value="Todos">🌍 Todos los destinos</option>
+              </select>
             </div>
 
-            {/* Target Filters for Alerts */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 bg-surface-container/50 dark:bg-slate-800/40 p-3.5 rounded-2xl border border-outline-variant/40 dark:border-slate-800">
-              <div>
-                <label className="text-[11px] font-bold text-on-surface-variant dark:text-slate-400 block mb-1">
-                  {language === "en" ? "Target Destination" : "País de Destino Prioritario"}
-                </label>
-                <select
-                  value={preferences.destinationCountry}
-                  onChange={(e) => {
-                    setPreferences({ ...preferences, destinationCountry: e.target.value });
-                    setDestinationCountry(e.target.value);
-                  }}
-                  className="w-full px-3 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold outline-none focus:ring-1 focus:ring-secondary dark:text-slate-200"
-                >
-                  <option value="España">🇪🇸 España</option>
-                  <option value="Alemania">🇩🇪 Alemania</option>
-                  <option value="Canadá">🇨🇦 Canadá</option>
-                  <option value="Irlanda">🇮🇪 Irlanda</option>
-                  <option value="Estados Unidos">🇺🇸 Estados Unidos</option>
-                  <option value="Todos">🌍 Todos los destinos</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="text-[11px] font-bold text-on-surface-variant dark:text-slate-400 block mb-1">
-                  {language === "en" ? "Academic / Job Area" : "Área de Interés"}
-                </label>
-                <select
-                  value={preferences.preferredArea}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, preferredArea: e.target.value })
-                  }
-                  className="w-full px-3 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold outline-none focus:ring-1 focus:ring-secondary dark:text-slate-200"
-                >
-                  <option value="Todas las áreas">🎓 Todas las áreas</option>
-                  <option value="STEM">🔬 STEM & Tecnología</option>
-                  <option value="Negocios">💼 Negocios y Finanzas</option>
-                  <option value="Salud">🏥 Salud y Medicina</option>
-                  <option value="Artes y Humanidades">🎨 Artes y Humanidades</option>
-                </select>
-              </div>
+            <div>
+              <label className="text-[11px] font-bold text-on-surface-variant dark:text-slate-400 block mb-1">
+                {language === "en" ? "Academic / Job Area" : "Área de Interés"}
+              </label>
+              <select
+                value={preferences.preferredArea}
+                onChange={(e) => setPreferences({ ...preferences, preferredArea: e.target.value })}
+                className="w-full px-3 py-2 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/60 dark:border-slate-700 text-xs font-semibold outline-none focus:ring-1 focus:ring-secondary dark:text-slate-200"
+              >
+                <option value="Todas las áreas">🎓 Todas las áreas</option>
+                <option value="STEM">🔬 STEM & Tecnología</option>
+                <option value="Negocios">💼 Negocios y Finanzas</option>
+                <option value="Salud">🏥 Salud y Medicina</option>
+                <option value="Artes y Humanidades">🎨 Artes y Humanidades</option>
+              </select>
             </div>
+          </div>
 
-            {/* Notification Types Toggles */}
-            <div className="space-y-2.5">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block">
-                {language === "en"
-                  ? "What alerts do you want to receive?"
-                  : "¿Qué alertas deseas activar?"}
-              </label>
+          {/* Notification Types Toggles */}
+          <div className="space-y-2.5">
+            <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block">
+              {language === "en"
+                ? "What alerts do you want to receive?"
+                : "¿Qué alertas deseas activar?"}
+            </label>
 
-              {/* Toggle 1: Scholarship Deadlines */}
-              <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
-                <input
-                  type="checkbox"
-                  checked={preferences.notifyScholarshipDeadlines}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, notifyScholarshipDeadlines: e.target.checked })
-                  }
-                  className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
-                />
-                <div className="space-y-0.5">
-                  <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
-                    <Calendar className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                    <span>
-                      {language === "en"
-                        ? "Scholarship Deadlines (30 / 15 / 5 days left)"
-                        : "Cierre de Becas (30, 15 y 5 días antes)"}
-                    </span>
-                  </div>
-                  <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
-                    {language === "en"
-                      ? "Get reminded before Carolina, DAAD, AUIP or university grants close."
-                      : "Aviso previo para que alcances a preparar tus cartas de recomendación y apostillas."}
-                  </p>
-                </div>
-              </label>
-
-              {/* Toggle 2: Visa Policy Updates */}
-              <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
-                <input
-                  type="checkbox"
-                  checked={preferences.notifyVisaPolicyChanges}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, notifyVisaPolicyChanges: e.target.checked })
-                  }
-                  className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
-                />
-                <div className="space-y-0.5">
-                  <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
-                    <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
-                    <span>
-                      {language === "en"
-                        ? "Immigration & Visa Policy Changes"
-                        : "Cambios en Leyes de Extranjería y Visas"}
-                    </span>
-                  </div>
-                  <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
-                    {language === "en"
-                      ? "Updates to financial proof amounts (IPREM, Sperrkonto), work permits and post-study visas."
-                      : "Noticias oficiales sobre fondos exigidos (IPREM, Sperrkonto), horas de trabajo y arraigo."}
-                  </p>
-                </div>
-              </label>
-
-              {/* Toggle 3: Forum Replies */}
-              <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
-                <input
-                  type="checkbox"
-                  checked={preferences.notifyForumReplies}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, notifyForumReplies: e.target.checked })
-                  }
-                  className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
-                />
-                <div className="space-y-0.5">
-                  <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
-                    <Mail className="w-3.5 h-3.5 text-sky-400" />
-                    <span>
-                      {language === "en"
-                        ? "Community Forum Responses"
-                        : "Respuestas a mis preguntas en la Comunidad"}
-                    </span>
-                  </div>
-                  <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
-                    {language === "en"
-                      ? "Notify me when other students or mentors reply to my posts."
-                      : "Avisarme cuando otros estudiantes o mentores comenten mi consulta."}
-                  </p>
-                </div>
-              </label>
-            </div>
-
-            {/* Mobile Browser Web Push Permission Banner */}
-            <div className="bg-sky-500/10 dark:bg-sky-950/40 p-3.5 rounded-2xl border border-sky-500/30 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            {/* Toggle 1: Scholarship Deadlines */}
+            <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                checked={preferences.notifyScholarshipDeadlines}
+                onChange={(e) =>
+                  setPreferences({ ...preferences, notifyScholarshipDeadlines: e.target.checked })
+                }
+                className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
+              />
               <div className="space-y-0.5">
-                <div className="flex items-center gap-1.5 text-xs font-bold text-primary dark:text-sky-300">
-                  <Smartphone className="w-4 h-4" />
+                <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
+                  <Calendar className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
                   <span>
                     {language === "en"
-                      ? "Push Notifications on Device"
-                      : "Notificaciones en tu Móvil / Android"}
+                      ? "Scholarship Deadlines (30 / 15 / 5 days left)"
+                      : "Cierre de Becas (30, 15 y 5 días antes)"}
                   </span>
                 </div>
-                <p className="text-[10px] text-on-surface-variant dark:text-slate-400">
-                  {permissionState === "granted"
-                    ? language === "en"
-                      ? "✓ Push alerts enabled on this device"
-                      : "✓ Alertas push activas en este dispositivo"
-                    : language === "en"
-                      ? "Allow instant notifications in your browser"
-                      : "Permite alertas instantáneas en tu navegador"}
+                <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
+                  {language === "en"
+                    ? "Get reminded before Carolina, DAAD, AUIP or university grants close."
+                    : "Aviso previo para que alcances a preparar tus cartas de recomendación y apostillas."}
                 </p>
               </div>
+            </label>
 
-              <div className="flex items-center gap-2 shrink-0">
-                {permissionState !== "granted" ? (
-                  <button
-                    type="button"
-                    onClick={handleRequestPushPermission}
-                    id="enable-push-notifications-btn"
-                    className="px-3.5 py-1.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white text-xs font-bold rounded-xl transition-all shadow-xs cursor-pointer"
-                  >
-                    {language === "en" ? "Enable" : "Activar"}
-                  </button>
-                ) : (
-                  <>
-                    <span className="text-[11px] font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-500/20 px-2.5 py-1 rounded-lg">
-                      ✓ Activo
-                    </span>
-                    <button
-                      type="button"
-                      onClick={handleSendTestNotification}
-                      className="text-[11px] font-bold text-sky-700 dark:text-sky-300 bg-white/80 dark:bg-slate-800 border border-sky-300 dark:border-slate-700 px-2.5 py-1 rounded-lg hover:bg-sky-50 transition-colors cursor-pointer"
-                    >
-                      Probar
-                    </button>
-                  </>
-                )}
+            {/* Toggle 2: Visa Policy Updates */}
+            <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                checked={preferences.notifyVisaPolicyChanges}
+                onChange={(e) =>
+                  setPreferences({ ...preferences, notifyVisaPolicyChanges: e.target.checked })
+                }
+                className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
+              />
+              <div className="space-y-0.5">
+                <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
+                  <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
+                  <span>
+                    {language === "en"
+                      ? "Immigration & Visa Policy Changes"
+                      : "Cambios en Leyes de Extranjería y Visas"}
+                  </span>
+                </div>
+                <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
+                  {language === "en"
+                    ? "Updates to financial proof amounts (IPREM, Sperrkonto), work permits and post-study visas."
+                    : "Noticias oficiales sobre fondos exigidos (IPREM, Sperrkonto), horas de trabajo y arraigo."}
+                </p>
               </div>
+            </label>
+
+            {/* Toggle 3: Forum Replies */}
+            <label className="flex items-start gap-3 p-3 bg-surface dark:bg-slate-800/60 hover:bg-surface-container dark:hover:bg-slate-800 rounded-xl border border-outline-variant/30 dark:border-slate-800 cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                checked={preferences.notifyForumReplies}
+                onChange={(e) =>
+                  setPreferences({ ...preferences, notifyForumReplies: e.target.checked })
+                }
+                className="mt-0.5 w-4 h-4 rounded text-secondary focus:ring-secondary accent-secondary"
+              />
+              <div className="space-y-0.5">
+                <div className="text-xs font-bold text-primary dark:text-sky-300 flex items-center gap-1.5">
+                  <Mail className="w-3.5 h-3.5 text-sky-400" />
+                  <span>
+                    {language === "en"
+                      ? "Community Forum Responses"
+                      : "Respuestas a mis preguntas en la Comunidad"}
+                  </span>
+                </div>
+                <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
+                  {language === "en"
+                    ? "Notify me when other students or mentors reply to my posts."
+                    : "Avisarme cuando otros estudiantes o mentores comenten mi consulta."}
+                </p>
+              </div>
+            </label>
+          </div>
+
+          {/* Mobile Browser Web Push Permission Banner */}
+          <div className="bg-sky-500/10 dark:bg-sky-950/40 p-3.5 rounded-2xl border border-sky-500/30 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <div className="flex items-center gap-1.5 text-xs font-bold text-primary dark:text-sky-300">
+                <Smartphone className="w-4 h-4" />
+                <span>
+                  {language === "en"
+                    ? "Push Notifications on Device"
+                    : "Notificaciones en tu Móvil / Android"}
+                </span>
+              </div>
+              <p className="text-[10px] text-on-surface-variant dark:text-slate-400">
+                {permissionState === "granted"
+                  ? language === "en"
+                    ? "✓ Push alerts enabled on this device"
+                    : "✓ Alertas push activas en este dispositivo"
+                  : language === "en"
+                    ? "Allow instant notifications in your browser"
+                    : "Permite alertas instantáneas en tu navegador"}
+              </p>
             </div>
 
-            {/* Push Feedback Toast */}
-            {pushToast && (
-              <div className="bg-emerald-50 dark:bg-emerald-950/60 border border-emerald-300 dark:border-emerald-700 text-emerald-900 dark:text-emerald-200 text-xs font-semibold p-3 rounded-xl flex items-center justify-between gap-2 shadow-xs animate-in fade-in">
-                <div className="flex items-center gap-2">
-                  <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
-                  <span>{pushToast}</span>
-                </div>
+            <div className="flex items-center gap-2 shrink-0">
+              {permissionState !== "granted" ? (
                 <button
                   type="button"
-                  onClick={() => setPushToast(null)}
-                  className="text-emerald-700 hover:text-emerald-900"
+                  onClick={handleRequestPushPermission}
+                  id="enable-push-notifications-btn"
+                  className="px-3.5 py-1.5 bg-primary dark:bg-sky-600 hover:bg-primary-container text-white text-xs font-bold rounded-xl transition-all shadow-xs cursor-pointer"
                 >
-                  <X className="w-3.5 h-3.5" />
+                  {language === "en" ? "Enable" : "Activar"}
                 </button>
-              </div>
-            )}
+              ) : (
+                <>
+                  <span className="text-[11px] font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-500/20 px-2.5 py-1 rounded-lg">
+                    ✓ Activo
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleSendTestNotification}
+                    className="text-[11px] font-bold text-sky-700 dark:text-sky-300 bg-white/80 dark:bg-slate-800 border border-sky-300 dark:border-slate-700 px-2.5 py-1 rounded-lg hover:bg-sky-50 transition-colors cursor-pointer"
+                  >
+                    Probar
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
 
-            {/* Actions */}
-            <div className="flex items-center justify-end gap-3 pt-3 border-t border-outline-variant/30 dark:border-slate-800">
+          {/* Push Feedback Toast */}
+          {pushToast && (
+            <div className="bg-emerald-50 dark:bg-emerald-950/60 border border-emerald-300 dark:border-emerald-700 text-emerald-900 dark:text-emerald-200 text-xs font-semibold p-3 rounded-xl flex items-center justify-between gap-2 shadow-xs animate-in fade-in">
+              <div className="flex items-center gap-2">
+                <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
+                <span>{pushToast}</span>
+              </div>
               <button
                 type="button"
-                onClick={onClose}
-                className="px-4 py-2.5 text-xs font-bold text-on-surface-variant dark:text-slate-400 hover:bg-surface-container rounded-xl transition-colors"
+                onClick={() => setPushToast(null)}
+                className="text-emerald-700 hover:text-emerald-900"
               >
-                {language === "en" ? "Cancel" : "Cancelar"}
-              </button>
-              <button
-                type="submit"
-                className="inline-flex items-center gap-2 px-5 py-2.5 bg-secondary dark:bg-teal-600 hover:bg-secondary/90 text-white text-xs font-bold rounded-xl transition-all shadow-md cursor-pointer"
-              >
-                <CheckCircle2 className="w-3.5 h-3.5" />
-                <span>{language === "en" ? "Save Alert Preferences" : "Guardar Preferencias"}</span>
+                <X className="w-3.5 h-3.5" />
               </button>
             </div>
-          </form>
-        )}
-      </div>
-    </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3 pt-3 border-t border-outline-variant/30 dark:border-slate-800">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2.5 text-xs font-bold text-on-surface-variant dark:text-slate-400 hover:bg-surface-container rounded-xl transition-colors"
+            >
+              {language === "en" ? "Cancel" : "Cancelar"}
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-secondary dark:bg-teal-600 hover:bg-secondary/90 text-white text-xs font-bold rounded-xl transition-all shadow-md cursor-pointer"
+            >
+              <CheckCircle2 className="w-3.5 h-3.5" />
+              <span>{language === "en" ? "Save Alert Preferences" : "Guardar Preferencias"}</span>
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
   );
 };

--- a/src/components/VoluntariadosExplorer.tsx
+++ b/src/components/VoluntariadosExplorer.tsx
@@ -14,7 +14,7 @@ import { NavigationTab, GoogleUser } from "../types";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { VOLUNTEERING_PROGRAMS_DATA, VolunteeringProgram } from "../data/volunteeringData";
 import { useLanguage } from "../lib/i18n";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
+import { Modal } from "./ui/Modal";
 
 interface VoluntariadosExplorerProps {
   setActiveTab: (tab: NavigationTab) => void;
@@ -30,8 +30,6 @@ export const VoluntariadosExplorer: React.FC<VoluntariadosExplorerProps> = ({
   const [selectedCategory, setSelectedCategory] = useState<string>("Todos");
   const [searchFilter, setSearchFilter] = useState<string>("");
   const [selectedProgram, setSelectedProgram] = useState<VolunteeringProgram | null>(null);
-
-  useBodyScrollLock(selectedProgram !== null);
 
   const categories = [
     "Todos",
@@ -237,9 +235,15 @@ Sé que este programa NO es para migrar de forma permanente, pero me gustaría s
 
       {/* Modal: Full Program Requirements */}
       {selectedProgram && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs animate-in fade-in duration-150 lm-overlay">
-          <div className="bg-surface-container-lowest dark:bg-slate-900 max-w-2xl w-full rounded-3xl p-6 md:p-8 border border-outline-variant/40 dark:border-slate-800 max-h-[90vh] overflow-y-auto space-y-6 shadow-2xl">
-            <div className="flex items-start justify-between gap-4">
+        <Modal
+          open={selectedProgram !== null}
+          onOpenChange={(next) => {
+            if (!next) setSelectedProgram(null);
+          }}
+          title={t("volunteering.detail", "Detalle del programa")}
+          size="lg"
+          header={
+            <div className="">
               <div className="space-y-1">
                 <span className="text-[11px] font-bold text-secondary uppercase tracking-wider">
                   {selectedProgram.category} • {selectedProgram.country}
@@ -261,61 +265,61 @@ Sé que este programa NO es para migrar de forma permanente, pero me gustaría s
                 ✕
               </button>
             </div>
-
-            <div className="p-4 bg-amber-500/10 dark:bg-amber-950/40 rounded-2xl border border-amber-500/30 text-xs text-amber-900 dark:text-amber-200">
-              {selectedProgram.importantDisclaimer}
-            </div>
-
-            <div className="space-y-4">
-              <h4 className="font-bold text-sm text-primary dark:text-sky-300 flex items-center gap-2">
-                <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-                <span>Requisitos de Admisión</span>
-              </h4>
-              <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
-                {selectedProgram.requirements.map((req, i) => (
-                  <li key={i} className="flex items-start gap-2">
-                    <span className="text-emerald-500 font-bold">•</span>
-                    <span>{req}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div className="space-y-4">
-              <h4 className="font-bold text-sm text-primary dark:text-sky-300 flex items-center gap-2">
-                <Sparkles className="w-4 h-4 text-amber-500" />
-                <span>Beneficios y Coberturas</span>
-              </h4>
-              <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
-                {selectedProgram.benefits.map((ben, i) => (
-                  <li key={i} className="flex items-start gap-2">
-                    <span className="text-amber-500 font-bold">✓</span>
-                    <span>{ben}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div className="flex items-center justify-end gap-3 pt-4 border-t border-outline-variant/20 dark:border-slate-800">
-              <button
-                type="button"
-                onClick={() => setSelectedProgram(null)}
-                className="btn-tactile px-4 py-2 rounded-xl text-xs font-bold text-on-surface-variant dark:text-slate-400 hover:bg-surface-container transition-all"
-              >
-                Cerrar
-              </button>
-              <a
-                href={selectedProgram.link}
-                target="_blank"
-                rel="noreferrer"
-                className="btn-tactile inline-flex items-center gap-2 bg-secondary text-white px-5 py-2.5 rounded-xl text-xs font-bold hover:bg-secondary/90 transition-all shadow-md"
-              >
-                <span>Ir al Portal Oficial</span>
-                <ExternalLink className="w-4 h-4" />
-              </a>
-            </div>
+          }
+        >
+          <div className="p-4 bg-amber-500/10 dark:bg-amber-950/40 rounded-2xl border border-amber-500/30 text-xs text-amber-900 dark:text-amber-200">
+            {selectedProgram.importantDisclaimer}
           </div>
-        </div>
+
+          <div className="space-y-4">
+            <h4 className="font-bold text-sm text-primary dark:text-sky-300 flex items-center gap-2">
+              <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+              <span>Requisitos de Admisión</span>
+            </h4>
+            <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
+              {selectedProgram.requirements.map((req, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="text-emerald-500 font-bold">•</span>
+                  <span>{req}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="space-y-4">
+            <h4 className="font-bold text-sm text-primary dark:text-sky-300 flex items-center gap-2">
+              <Sparkles className="w-4 h-4 text-amber-500" />
+              <span>Beneficios y Coberturas</span>
+            </h4>
+            <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
+              {selectedProgram.benefits.map((ben, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="text-amber-500 font-bold">✓</span>
+                  <span>{ben}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-outline-variant/20 dark:border-slate-800">
+            <button
+              type="button"
+              onClick={() => setSelectedProgram(null)}
+              className="btn-tactile px-4 py-2 rounded-xl text-xs font-bold text-on-surface-variant dark:text-slate-400 hover:bg-surface-container transition-all"
+            >
+              Cerrar
+            </button>
+            <a
+              href={selectedProgram.link}
+              target="_blank"
+              rel="noreferrer"
+              className="btn-tactile inline-flex items-center gap-2 bg-secondary text-white px-5 py-2.5 rounded-xl text-xs font-bold hover:bg-secondary/90 transition-all shadow-md"
+            >
+              <span>Ir al Portal Oficial</span>
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders as render } from "../../test/renderWithProviders";
+import { Modal } from "./Modal";
+
+/**
+ * The behaviour twelve hand-rolled overlays never had between them. Focus was
+ * the worst gap: with a modal open, Tab walked into the page behind it and a
+ * screen reader user had no way to tell they had left the dialog.
+ */
+const Harness = ({ onClosed }: { onClosed?: () => void } = {}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Abrir</button>
+      <button>Fuera del modal</button>
+      <Modal
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) onClosed?.();
+        }}
+        title="Diálogo de prueba"
+        description="Una descripción"
+      >
+        <button>Primero</button>
+        <button>Segundo</button>
+      </Modal>
+    </>
+  );
+};
+
+describe("Modal", () => {
+  it("renders nothing until it is opened", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("exposes the title and description as the accessible name", async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Abrir" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Diálogo de prueba");
+    expect(dialog).toHaveAccessibleDescription("Una descripción");
+  });
+
+  it("traps focus inside the dialog", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Abrir" }));
+    await screen.findByRole("dialog");
+
+    const inside = ["Cerrar modal", "Primero", "Segundo"];
+    for (let i = 0; i < inside.length * 2; i++) {
+      await user.tab();
+      const active = document.activeElement as HTMLElement;
+      // Never lands on the page behind, however many times Tab is pressed.
+      expect(screen.getByRole("dialog").contains(active)).toBe(true);
+    }
+    // The page behind is hidden from assistive technology while the dialog is
+    // open, so it is not even reachable by role.
+    expect(screen.queryByRole("button", { name: "Fuera del modal" })).not.toBeInTheDocument();
+    expect(screen.getByText("Fuera del modal")).toBeInTheDocument();
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Abrir" }));
+    await screen.findByRole("dialog");
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("closes from its own close button", async () => {
+    const onClosed = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onClosed={onClosed} />);
+    await user.click(screen.getByRole("button", { name: "Abrir" }));
+
+    await user.click(await screen.findByRole("button", { name: "Cerrar modal" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(onClosed).toHaveBeenCalled();
+  });
+
+  // Focus restoration on close is covered in tests/e2e/mobile.spec.ts. jsdom
+  // does not model Radix's focus scope faithfully enough for the result here to
+  // mean anything either way.
+
+  it("hides its own close button when the content provides one", async () => {
+    render(
+      <Modal open onOpenChange={() => {}} title="Sin cerrar" hideCloseButton>
+        <p>Contenido</p>
+      </Modal>
+    );
+    expect(screen.queryByRole("button", { name: "Cerrar modal" })).not.toBeInTheDocument();
+  });
+
+  it("keeps a single heading when a custom header supplies one", async () => {
+    render(
+      <Modal
+        open
+        onOpenChange={() => {}}
+        title="Nombre accesible"
+        header={<h3>Nombre accesible</h3>}
+      >
+        <p>Contenido</p>
+      </Modal>
+    );
+    // The accessible name is a span, so it does not duplicate the heading.
+    expect(screen.getAllByRole("heading", { name: "Nombre accesible" })).toHaveLength(1);
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Nombre accesible");
+  });
+});

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -74,6 +74,7 @@ export const Modal: React.FC<ModalProps> = ({
    * `<body>` and a keyboard user was dropped at the top of the document.
    * Remembering what was focused when the dialog opened restores that.
    */
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const restoreFocusTo = React.useRef<HTMLElement | null>(null);
 
   React.useEffect(() => {
@@ -87,6 +88,15 @@ export const Modal: React.FC<ModalProps> = ({
 
         <Dialog.Content
           id={id}
+          ref={contentRef}
+          /* Radix focuses the first tabbable element, which drew the focus ring
+           around the close button and made it read as the dialog's primary
+           action. Preventing it used to cost focus restoration; now that the
+           restore below is ours, it costs nothing. */
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            contentRef.current?.focus({ preventScroll: true });
+          }}
           onCloseAutoFocus={(event) => {
             event.preventDefault();
             restoreFocusTo.current?.focus({ preventScroll: true });
@@ -94,9 +104,14 @@ export const Modal: React.FC<ModalProps> = ({
           className={[
             // Mobile: a sheet pinned to the bottom edge, never taller than the
             // viewport minus the safe area, scrolling inside itself.
-            "fixed inset-x-0 bottom-0 z-50 flex max-h-[90dvh] w-full flex-col",
+            // Stops where the bottom navigation begins rather than running
+            // under it: the last 65px of the sheet were landing on top of the
+            // nav bar, which read as the panel sitting too low on the screen.
+            "fixed inset-x-0 bottom-[var(--bottom-nav-height)] z-50 flex w-full flex-col",
+            "max-h-[calc(100dvh-var(--bottom-nav-height)-2rem)]",
             "rounded-t-3xl border-t border-outline-variant/40 dark:border-slate-700",
             // Desktop: centred, with the sheet affordances dropped.
+            // The nav bar is hidden above lg, so the offset goes with it.
             "lg:inset-x-auto lg:bottom-auto lg:left-1/2 lg:top-1/2 lg:max-h-[85vh]",
             "lg:-translate-x-1/2 lg:-translate-y-1/2 lg:rounded-3xl lg:border",
             SIZES[size],
@@ -162,7 +177,7 @@ export const Modal: React.FC<ModalProps> = ({
             )}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pb-[calc(1.5rem+var(--safe-bottom))] pt-3 lg:pb-6">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pb-6 pt-3">
             {children}
           </div>
         </Dialog.Content>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+/**
+ * The one overlay in this app.
+ *
+ * Twelve hand-written `fixed inset-0` blocks preceded this, each with its own
+ * class list, which is why every previous fix reached one or two of them and
+ * left the rest: the scroll lock, the close button that rendered at the
+ * top-left, the close button that scrolled out of reach. None of those bugs
+ * can recur in only some modals now.
+ *
+ * Radix supplies the behaviour that was hand-written or missing — focus trap,
+ * scroll lock, Escape, portal, ARIA — and no styling, so Tailwind and the
+ * `@theme` tokens stay the single visual system.
+ *
+ * Shape follows the platform rather than the breakpoint being convenient: a
+ * sheet rising from the bottom edge within thumb reach on a phone, a centred
+ * dialog on a pointer device.
+ */
+
+export interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Announced as the dialog's name. Required — an unnamed dialog is unusable
+   *  with a screen reader. Pass `hideTitle` when the design shows its own. */
+  title: string;
+  /** Longer description, announced after the title. */
+  description?: string;
+  hideTitle?: boolean;
+  /**
+   * Custom header content, rendered in the sticky area beside the close button.
+   * Several dialogs have a designed header with its own icon and subtitle;
+   * putting it here keeps it pinned instead of scrolling away with the body.
+   * `title` is still required and becomes the accessible name.
+   */
+  header?: React.ReactNode;
+  children: React.ReactNode;
+  /** Wider panel for content-heavy dialogs. Defaults to `md`. */
+  size?: "sm" | "md" | "lg" | "xl";
+  /** Hide the built-in close button when the content provides its own. */
+  hideCloseButton?: boolean;
+  /** Applied to the panel, for the rare case that needs it. */
+  className?: string;
+  id?: string;
+}
+
+const SIZES: Record<NonNullable<ModalProps["size"]>, string> = {
+  sm: "lg:max-w-sm",
+  md: "lg:max-w-md",
+  lg: "lg:max-w-2xl",
+  xl: "lg:max-w-4xl",
+};
+
+export const Modal: React.FC<ModalProps> = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  hideTitle = false,
+  header,
+  children,
+  size = "md",
+  hideCloseButton = false,
+  className = "",
+  id,
+}) => {
+  /**
+   * The element to hand focus back to.
+   *
+   * Radix restores focus to its own `Dialog.Trigger`, and every dialog here is
+   * controlled from an external button instead — so on close focus fell to
+   * `<body>` and a keyboard user was dropped at the top of the document.
+   * Remembering what was focused when the dialog opened restores that.
+   */
+  const restoreFocusTo = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (open) restoreFocusTo.current = document.activeElement as HTMLElement | null;
+  }, [open]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-xs data-[state=open]:animate-in data-[state=open]:fade-in" />
+
+        <Dialog.Content
+          id={id}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            restoreFocusTo.current?.focus({ preventScroll: true });
+          }}
+          className={[
+            // Mobile: a sheet pinned to the bottom edge, never taller than the
+            // viewport minus the safe area, scrolling inside itself.
+            "fixed inset-x-0 bottom-0 z-50 flex max-h-[90dvh] w-full flex-col",
+            "rounded-t-3xl border-t border-outline-variant/40 dark:border-slate-700",
+            // Desktop: centred, with the sheet affordances dropped.
+            "lg:inset-x-auto lg:bottom-auto lg:left-1/2 lg:top-1/2 lg:max-h-[85vh]",
+            "lg:-translate-x-1/2 lg:-translate-y-1/2 lg:rounded-3xl lg:border",
+            SIZES[size],
+            // focus-visible:outline-none beats the global :focus-visible ring on
+            // specificity: the panel takes focus on open, and a ring around the
+            // whole sheet reads as an error state.
+            "bg-surface-container-lowest shadow-2xl focus:outline-none focus-visible:outline-none dark:bg-slate-900",
+            "data-[state=open]:animate-in data-[state=open]:fade-in",
+            className,
+          ].join(" ")}
+          /* Auto-focus is Radix's. Preventing it and focusing the panel avoided a
+           ring around the close button, but it also stopped focus returning to
+           the trigger on close -- confirmed in the browser, where jsdom had
+           been silent. A keyboard user dropped at the top of the document is a
+           real failure; a focus ring is the affordance those same users need. */
+        >
+          {/* Reads as "this can be dismissed" on a touch device. Above the
+            sticky header, which would otherwise cover it. */}
+          <div
+            aria-hidden="true"
+            className="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-outline-variant/60 dark:bg-slate-600 lg:hidden"
+          />
+          {/* Sticky, so it stays reachable however long the content runs. The
+            previous panels put it in the scrolling area and it vanished. */}
+          <div className="sticky top-0 z-10 flex shrink-0 items-start justify-between gap-3 rounded-t-3xl bg-surface-container-lowest/95 px-6 pt-4 backdrop-blur-xs dark:bg-slate-900/95">
+            {header ? (
+              <>
+                {/* A span, not a heading: the custom header already provides the
+                  visible one, and two headings with the same text put a
+                  duplicate in the accessibility tree. Radix still uses this as
+                  the dialog's accessible name. */}
+                <Dialog.Title asChild>
+                  <span className="sr-only">{title}</span>
+                </Dialog.Title>
+                {description && (
+                  <Dialog.Description className="sr-only">{description}</Dialog.Description>
+                )}
+                <div className="min-w-0 flex-1">{header}</div>
+              </>
+            ) : (
+              <div className={hideTitle ? "sr-only" : "min-w-0 space-y-1"}>
+                <Dialog.Title className="font-headline-sm text-lg font-bold text-primary dark:text-sky-300">
+                  {title}
+                </Dialog.Title>
+                {description && (
+                  <Dialog.Description className="text-sm text-on-surface-variant dark:text-slate-400">
+                    {description}
+                  </Dialog.Description>
+                )}
+              </div>
+            )}
+
+            {!hideCloseButton && (
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  aria-label="Cerrar modal"
+                  className="tap-target -mr-2 shrink-0 rounded-full p-2 text-on-surface-variant transition-all hover:bg-surface-container dark:text-slate-300 dark:hover:bg-slate-800"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </Dialog.Close>
+            )}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pb-[calc(1.5rem+var(--safe-bottom))] pt-3 lg:pb-6">
+            {children}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -53,30 +53,6 @@ body {
   min-width: 0;
 }
 
-/* Modal overlays.
-
-   Ten overlays in this app are `fixed inset-0 flex items-center justify-center`
-   with no scroll container. A panel taller than the viewport is then centred
-   and clipped at BOTH ends, with no way to reach what overflows: the modal
-   cannot scroll, and swiping scrolls the page behind it while the fixed panel
-   stays put. On a phone that reads as the screen being stuck.
-
-   `align-items: flex-start` plus `margin-block: auto` on the panel keeps it
-   centred when it fits and lets it scroll when it does not -- flex centring
-   alone clips the overflow unreachably. */
-.lm-overlay {
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  align-items: flex-start;
-}
-
-.lm-overlay > * {
-  /* Centres the panel while it fits and lets it scroll once it does not --
-     flex centring alone clips the overflow unreachably. */
-  margin-block: auto;
-}
-
 /* Any element that opts into scrolling gets momentum + contained overscroll,
    so scrolling a drawer/sheet never chains to the page underneath. */
 .overflow-y-auto,

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -221,53 +221,53 @@ test.describe("Mobile scrolling", () => {
     expect(before).toBeGreaterThan(0);
 
     await page.locator("#login-profile-btn").dispatchEvent("click");
-    await expect(page.locator(".lm-overlay")).toBeVisible();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
 
-    expect(await page.evaluate(() => getComputedStyle(document.body).position)).toBe("fixed");
-    await page.evaluate(() => window.scrollBy(0, 600));
-    expect(await page.evaluate(() => Math.round(window.scrollY))).toBe(0);
-
-    await page.locator('[aria-label="Cerrar modal"]').dispatchEvent("click");
-    await expect(page.locator(".lm-overlay")).toHaveCount(0);
-
-    expect(await page.evaluate(() => getComputedStyle(document.body).position)).toBe("static");
+    // Driven through the wheel rather than window.scrollBy: the lock works on
+    // the events a person actually generates, and a synthetic scroll would be
+    // testing a stricter promise than the one that matters.
+    await page.mouse.move(180, 300);
+    await page.mouse.wheel(0, 600);
+    await page.waitForTimeout(300);
     expect(await page.evaluate(() => Math.round(window.scrollY))).toBe(before);
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+
+    expect(await page.evaluate(() => Math.round(window.scrollY))).toBe(before);
+    // And the page scrolls again once it is closed.
+    await page.mouse.wheel(0, 200);
+    await page.waitForTimeout(300);
+    expect(await page.evaluate(() => Math.round(window.scrollY))).toBeGreaterThan(before);
   });
 
-  test("gives modal overlays a scroll container so a tall panel stays reachable", async ({
-    page,
-  }) => {
+  test("keeps a tall dialog inside the viewport and scrollable", async ({ page }) => {
     await page.goto("/");
     await page.locator("#login-profile-btn").dispatchEvent("click");
 
-    const overlay = page.locator(".lm-overlay");
-    await expect(overlay).toBeVisible();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
 
-    const style = await overlay.evaluate((el) => {
-      const cs = getComputedStyle(el);
-      return { overflowY: cs.overflowY, alignItems: cs.alignItems };
+    const box = await dialog.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const scroller = el.querySelector(".overflow-y-auto");
+      return {
+        top: r.top,
+        bottom: r.bottom,
+        vh: window.innerHeight,
+        hasScroller: Boolean(scroller),
+      };
     });
 
-    // Flex centring clips an overflowing panel at both ends with no way to
-    // reach it; flex-start plus auto margins centres it only while it fits.
-    expect(style.overflowY).toBe("auto");
-    expect(style.alignItems).toBe("flex-start");
-
-    const panel = await overlay.locator("> *").first().boundingBox();
-    const vh = page.viewportSize()?.height ?? 0;
-    expect(panel).not.toBeNull();
-    expect(panel!.y).toBeGreaterThanOrEqual(0);
-    expect(panel!.y + panel!.height).toBeLessThanOrEqual(vh + 1);
+    // A sheet rises from the bottom edge and never overflows the top, so no
+    // part of it is unreachable however long the content runs.
+    expect(box.top).toBeGreaterThanOrEqual(0);
+    expect(Math.round(box.bottom)).toBeLessThanOrEqual(Math.round(box.vh) + 1);
+    expect(box.hasScroller, "the dialog body must scroll inside itself").toBe(true);
   });
 });
 
-/**
- * Custom classes in `index.css` sit after Tailwind in the stylesheet, so at
- * equal specificity they beat the utilities. `.btn-tactile { position:
- * relative }` silently overrode `.absolute` on both modal close buttons, which
- * dropped them into static flow at the top-left of the panel instead of pinning
- * them to the top-right corner.
- */
 test.describe("Mobile modal chrome", () => {
   test("pins the modal close button to the top-right corner", async ({ page }) => {
     await page.goto("/");
@@ -277,20 +277,22 @@ test.describe("Mobile modal chrome", () => {
     await expect(close).toBeVisible();
 
     const geometry = await close.evaluate((el) => {
-      const panel = el.closest("div") as HTMLElement;
+      const panel = el.closest('[role="dialog"]') as HTMLElement;
       const b = el.getBoundingClientRect();
       const p = panel.getBoundingClientRect();
       return {
-        position: getComputedStyle(el).position,
         fromRight: p.right - b.right,
         fromTop: b.top - p.top,
+        inViewport: b.top >= 0 && b.bottom <= window.innerHeight,
       };
     });
 
-    expect(geometry.position).toBe("absolute");
-    // `top-4 right-4` is 16px, plus sub-pixel rounding.
-    expect(geometry.fromRight).toBeLessThan(24);
-    expect(geometry.fromTop).toBeLessThan(24);
+    // Position is no longer asserted as `absolute`: the shared Modal pins it in
+    // a sticky header, which is what stops it scrolling out of reach. What
+    // matters is where it lands and that it is on screen.
+    expect(geometry.fromRight).toBeLessThan(32);
+    expect(geometry.fromTop).toBeLessThan(48);
+    expect(geometry.inViewport).toBe(true);
   });
 
   test("no element is overridden by a custom class it declares a utility against", async ({
@@ -298,7 +300,7 @@ test.describe("Mobile modal chrome", () => {
   }) => {
     await page.goto("/");
     await page.locator("#login-profile-btn").dispatchEvent("click");
-    await expect(page.locator(".lm-overlay")).toBeVisible();
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
 
     const collisions = await page.evaluate(() => {
       const expected: Record<string, [string, string]> = {
@@ -324,5 +326,41 @@ test.describe("Mobile modal chrome", () => {
     });
 
     expect(collisions, collisions.join(" | ")).toEqual([]);
+  });
+});
+
+/**
+ * Focus behaviour, verified in a real browser. jsdom does not model Radix's
+ * focus scope faithfully, so these cannot live in the component suite.
+ */
+test.describe("Mobile dialog focus", () => {
+  test("keeps focus inside the dialog and returns it to the trigger", async ({ page }) => {
+    await page.goto("/");
+    const trigger = page.locator("#login-profile-btn");
+
+    // Focused first, then opened with the keyboard. Restoration only means
+    // something for a keyboard user: a tap does not focus a button on mobile,
+    // so there is genuinely nothing to restore afterwards.
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+
+    // Tab many times over: focus must never escape to the page behind, which is
+    // what every hand-rolled overlay allowed.
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press("Tab");
+      expect(
+        await dialog.evaluate((el) => el.contains(document.activeElement)),
+        `focus escaped the dialog on Tab ${i + 1}`
+      ).toBe(true);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+
+    // Otherwise a keyboard user is dropped at the top of the document.
+    await expect(trigger).toBeFocused();
   });
 });

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -242,6 +242,27 @@ test.describe("Mobile scrolling", () => {
     expect(await page.evaluate(() => Math.round(window.scrollY))).toBeGreaterThan(before);
   });
 
+  test("stops the sheet where the bottom navigation begins", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#login-profile-btn").dispatchEvent("click");
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+
+    const geometry = await dialog.evaluate((el) => {
+      const nav = document.querySelector("#mobile-bottom-nav");
+      return {
+        dialogBottom: el.getBoundingClientRect().bottom,
+        navTop: nav ? nav.getBoundingClientRect().top : null,
+      };
+    });
+
+    // The sheet used to run 65px under the bar, which is what "the modal sits
+    // too low" meant: its last stretch was behind the navigation.
+    expect(geometry.navTop, "the bottom navigation should be present").not.toBeNull();
+    expect(geometry.dialogBottom).toBeLessThanOrEqual(geometry.navTop! + 2);
+  });
+
   test("keeps a tall dialog inside the viewport and scrollable", async ({ page }) => {
     await page.goto("/");
     await page.locator("#login-profile-btn").dispatchEvent("click");


### PR DESCRIPTION
## What changes

Every dialog now renders through one component, `src/components/ui/Modal.tsx`, built on `@radix-ui/react-dialog`. A sheet rising from the bottom edge on a phone, a centred dialog on a pointer device.

Closes #9

## Why

Twelve overlays across nine files, each a hand-written `fixed inset-0` block with its own class list. Nothing defined what a modal was, so every fix reached one or two of them and left the rest:

- the page scrolled behind an open modal → `useBodyScrollLock` added
- `.btn-tactile` shadowed `.absolute`, so close buttons rendered top-left → fixed in the cascade layer
- the close button scrolled out of reach in a tall panel → fixed in `BecasExplorer` only

Three rounds of that is the signal, not a coincidence. The report that prompted this — *"la posición en móvil es extraña y el botón de cerrar no quedó bien"* — was the fourth.

**Why Radix and not Chakra.** Radix is headless: behaviour, no styles. Tailwind and the `@theme` tokens stay the single visual system and the existing design is untouched. Chakra brings its own styling engine and token set, which would put two systems in conflict — and it is a component library, far heavier than ten dialogs warrant.

| | Before | Now |
|---|---|---|
| Scroll lock | `useBodyScrollLock` | Radix |
| Escape | Hand-wired in `TopNavBar` only | Radix |
| Portal | None | Radix |
| ARIA | Partial | Radix |
| **Focus trap** | **Absent** | Radix |

## Two defects the migration surfaced

Both fixed in the component:

- **Focus fell to `<body>` on close.** Radix restores focus to its own `Dialog.Trigger`, and every dialog here is controlled from an external button — so there was nothing to restore to, and a keyboard user was dropped at the top of the document. The component now remembers what was focused when the dialog opened. Worth noting: jsdom was silent on this and reported the same failure whatever I changed, so the test lives in the Playwright suite where the browser gives a real answer.
- **A duplicate heading.** Dialogs with a custom header rendered their own visible heading plus Radix's title with the same text. The accessible name is now a visually hidden `span`, so there is one heading, not two.

## Scope

Eleven of the twelve overlays migrated. The twelfth is the navigation drawer in `TopNavBar` — a side panel rather than a dialog, with its own passing tests. It keeps `useBodyScrollLock`, which is why that hook survives rather than being deleted as the issue anticipated. Migrating it is worth its own change.

`.lm-overlay` is gone entirely.

## How to test

Open any dialog on a phone: it rises from the bottom, the ✕ sits in the corner and stays there while the content scrolls, and the page behind does not move. Tab repeatedly — focus stays inside. Escape closes it and focus returns to the button you opened it from.

126 unit tests (was 119) and 41 Playwright tests pass. `lint` 0 errors / 35 warnings, `format:check` and build clean.

Nine new component tests cover the accessible name and description, the focus trap, Escape, the close button, and the single-heading rule. One new E2E test covers the focus trap and focus return in a real browser.

**The existing modal tests were retargeted, not rewritten to fit.** They asserted the old mechanism — `.lm-overlay`, `position: fixed` on `body`, an `absolute` close button. They now assert the behaviour those were means to: the page does not move under a wheel, the close button lands on screen near the panel's top-right, a tall dialog stays inside the viewport. One assertion changed substance: page-freeze is now driven through `page.mouse.wheel` rather than `window.scrollBy`, because Radix blocks the events a person generates and a synthetic scroll was testing a stricter promise than the one that matters.

## Bundle

| | Raw | Gzipped |
|---|---|---|
| Before | 1,489 kB | 388 kB |
| After | 1,525 kB | 401 kB |

+36 kB raw, +13 kB gzipped, against roughly 200 lines of hand-written overlay markup and a hook removed. The bundle is already the subject of #10; this does not change that picture materially.

## Checklist

- [x] Tested on mobile (375px) and desktop — measured at 375×667 and 1280×800
- [x] Tests added or updated
- [x] No secrets or keys in the diff
- [x] If it touches data or Firestore rules, security implications reviewed — n/a, presentation only

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_