### PR TITLE
fix(ui): position overlays against the viewport instead of the page

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -101,6 +101,19 @@ Recently addressed and verified by tests:
   `useBodyScrollLock` (`src/lib/`) pins the body and restores the reading
   position on close — the same mechanism the drawer already used, now shared by
   all ten overlays.
+- Overlays are positioned against the viewport, not against the page. `<main>`
+  carries `.animate-fade-in`, whose animation used to fill `both`; a filling
+  animation keeps contributing its final `transform`, and Chromium resolves the
+  keyword `none` to the identity matrix, which is still a transform. Any
+  transform makes the element the containing block for its `position: fixed`
+  descendants, so every overlay in the application was laid out against the
+  full height of the page. Measured at 375px: a filter sheet meant to sit at
+  the bottom of the screen was placed at y=3268 inside a 6583px-tall
+  "fixed inset-0" backdrop, which is why modals kept appearing far below the
+  fold on a phone. Every animation in `index.css` that touches `transform` now
+  fills `backwards`; the two opacity-only ones keep `both`, since opacity
+  creates no containing block. `tests/e2e/mobile.spec.ts` pins both the
+  position and the mechanism.
 - Overlays carry `.lm-overlay`, which gives them a scroll container. Flex
   centring clipped a panel taller than the viewport at both ends with no way to
   reach the overflow; `align-items: flex-start` plus auto margins centres it

--- a/src/index.css
+++ b/src/index.css
@@ -253,8 +253,30 @@ input[type="range"]::-moz-range-thumb {
   }
 }
 
+/*
+ * Every animation below that touches `transform` fills `backwards`, not
+ * `both`.
+ *
+ * With `both`, the animation keeps contributing its final `transform` for as
+ * long as the element lives. That value is `none` in the keyframe, but a
+ * filling animation resolves it to the identity matrix — and any transform
+ * other than the keyword `none` makes the element the containing block for
+ * its `position: fixed` descendants.
+ *
+ * `<main>` carries `.animate-fade-in`, so every overlay in the application
+ * was being positioned against the full height of the page rather than the
+ * viewport. Measured at 375px: a filter sheet meant to sit at the bottom of
+ * the screen was laid out at y=3268 inside a 6583px-tall "fixed" backdrop.
+ * That is why modals kept appearing far below the fold on a phone, and why
+ * fixing them one overlay at a time never held.
+ *
+ * `backwards` is safe here because every keyframe ends on the element's own
+ * resting style — `opacity: 1`, `transform: none` — so there is nothing for
+ * the animation to hold once it is done. The two opacity-only animations keep
+ * `both`: opacity creates no containing block.
+ */
 .animate-fade-in {
-  animation: lm-fade-in-up 0.22s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: lm-fade-in-up 0.22s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
 
 .animate-in {
@@ -262,12 +284,12 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .animate-in.slide-in-from-left {
-  animation: lm-slide-in-left 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: lm-slide-in-left 0.25s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
 
 .animate-in.slide-in-from-bottom-3,
 .animate-in.slide-in-from-bottom {
-  animation: lm-fade-in-up 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: lm-fade-in-up 0.25s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
 
 .animate-in.slide-in-from-top-2 {
@@ -275,7 +297,7 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .animate-slide-up-sheet {
-  animation: lm-slide-in-bottom 0.28s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: lm-slide-in-bottom 0.28s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -325,4 +325,69 @@ test.describe("Mobile modal chrome", () => {
 
     expect(collisions, collisions.join(" | ")).toEqual([]);
   });
+  /**
+   * Regression: `<main>` carries `.animate-fade-in`, whose animation used to
+   * fill `both`. A filling `transform` — even one whose keyframe says `none` —
+   * makes the element the containing block for its `position: fixed`
+   * descendants, so every overlay in the application was laid out against the
+   * height of the page instead of the viewport. Measured here at 375px, the
+   * scholarship filter sheet sat at y=3268 inside a 6583px-tall backdrop.
+   *
+   * This has to be an end-to-end test: it is a containing-block resolution,
+   * which only a real layout engine performs.
+   */
+  test("positions a fixed overlay against the viewport, not the page", async ({ page }) => {
+    await page.goto("/");
+    await gotoTabMobile(page, "becas");
+    await page.locator("#btn-open-mobile-filters").click();
+
+    const backdrop = page.locator("div.fixed.inset-0").last();
+    await expect(backdrop).toBeVisible();
+    const box = await backdrop.boundingBox();
+    const viewport = page.viewportSize();
+
+    expect(box, "the filter sheet backdrop should be laid out").not.toBeNull();
+    expect(viewport).not.toBeNull();
+
+    // `inset-0` on a viewport-relative fixed element covers the viewport and
+    // nothing more. A containing block elsewhere shows up as a backdrop taller
+    // than the screen, starting somewhere far off the top.
+    expect(Math.abs(box!.y)).toBeLessThanOrEqual(2);
+    expect(box!.height).toBeLessThanOrEqual(viewport!.height + 2);
+  });
+
+  /**
+   * The mechanism itself, so the next animation added to a page-level wrapper
+   * cannot quietly reintroduce it.
+   */
+  test("leaves no transform on the ancestors of a fixed overlay", async ({ page }) => {
+    await page.goto("/");
+    await gotoTabMobile(page, "becas");
+    await page.locator("#btn-open-mobile-filters").click();
+    await expect(page.locator("div.fixed.inset-0").last()).toBeVisible();
+    // Long enough for every entrance animation on the screen to have finished.
+    await page.waitForTimeout(700);
+
+    const offenders = await page.evaluate(() => {
+      const found: string[] = [];
+      for (const overlay of Array.from(document.querySelectorAll<HTMLElement>("*"))) {
+        if (getComputedStyle(overlay).position !== "fixed") continue;
+        let el = overlay.parentElement;
+        while (el && el !== document.documentElement) {
+          const transform = getComputedStyle(el).transform;
+          if (transform !== "none") {
+            const name = el.getAttribute("class") ?? el.tagName.toLowerCase();
+            found.push(`${name.slice(0, 60)} -> ${transform}`);
+          }
+          el = el.parentElement;
+        }
+      }
+      return Array.from(new Set(found));
+    });
+
+    // A transform anywhere above a fixed element redefines what "fixed" means
+    // for it: the element is positioned against that ancestor instead of the
+    // viewport. `animation-fill-mode: both` is the quiet way to acquire one.
+    expect(offenders, offenders.join(" | ")).toEqual([]);
+  });
 });


### PR DESCRIPTION
## The problem

Every modal, sheet and drawer in the application was laid out against the height of the **page** rather than the **screen**. On a phone this put them far below the fold.

Measured at 375px, with the scholarship filter sheet open:

| | before | after |
|---|---|---|
| backdrop (`fixed inset-0`) | `top: -2600`, height `6583` | `top: 0`, height `788` |
| panel (anchored to the bottom) | `top: 3268` | `top: 73` |
| viewport height | 812 | 812 |

## The cause

`<main>` carries `.animate-fade-in`, whose animation filled `both`.

A filling animation keeps contributing its final value for as long as the element lives. The keyframe says `transform: none` — but a filling animation resolves that to the identity matrix, and **any** transform other than the keyword `none` makes the element the containing block for its `position: fixed` descendants.

So `fixed` stopped meaning "relative to the viewport" for everything inside `<main>`.

This is why the modals kept coming back wrong across several rounds, and why fixing them one overlay at a time never held: the geometry was being decided above them.

## The change

Every animation in `index.css` that touches `transform` now fills `backwards` instead of `both`. That is safe here because each keyframe ends on the element's own resting style (`opacity: 1`, `transform: none`) — there is nothing for the animation to hold once it is done. The two opacity-only animations keep `both`; opacity creates no containing block.

## Tests

Two end-to-end tests in `tests/e2e/mobile.spec.ts`, because a containing block is resolved by a layout engine and jsdom has none:

- `positions a fixed overlay against the viewport, not the page` — asserts the backdrop's box matches the viewport.
- `leaves no transform on the ancestors of a fixed overlay` — walks the ancestor chain of every fixed element and fails on any transform above it, so the next animation added to a page-level wrapper cannot quietly reintroduce this.

Both were confirmed to **fail** against the previous CSS and pass with the fix.

```
42 passed (1.0m)      # full Playwright suite, Mobile Chrome + Desktop Chrome
126 passed            # vitest
lint: 0 errors, 35 warnings (at the ratchet)
```

## Documentation

`docs/ux.md` gains an entry under Navigation and states describing the mechanism and the measurements.

## Risk

Low, and visual only. The animations look identical — they already ended on the element's resting style. Rollback is reverting one commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_