### PR TITLE
fix(becas): make the scholarship filters honest and usable on a phone

### DIFF
--- a/src/components/BecasExplorer.test.tsx
+++ b/src/components/BecasExplorer.test.tsx
@@ -335,14 +335,18 @@ describe("BecasExplorer Component", () => {
       const { container } = render(<BecasExplorer {...defaultProps} />);
 
       fireEvent.click(container.querySelector("#btn-open-mobile-filters")!);
-      const sheet = screen.getByText(/Filtros de Búsqueda/i).closest("div[class*='rounded-t-3xl']");
-      expect(sheet).not.toBeNull();
+      // The sheet is the shared `Modal`, so it is addressed by its role
+      // rather than by a class the panel happens to carry.
+      const sheet = screen.getByRole("dialog");
 
       // A phone's own picker cannot show how many results an option leads to,
       // and with most combinations empty that count is the point.
-      expect(within(sheet as HTMLElement).queryByRole("combobox")).toBeNull();
-      expect((sheet as HTMLElement).querySelectorAll("select")).toHaveLength(0);
-      expect(chip(container, "sheet-country-España")).toBeInTheDocument();
+      expect(within(sheet).queryByRole("combobox")).toBeNull();
+      expect(sheet.querySelectorAll("select")).toHaveLength(0);
+      expect(sheet).toHaveAccessibleName(/Filtros de Búsqueda/i);
+      // The sheet is portalled to `document.body`, so it is outside the
+      // render container that the other assertions use.
+      expect(sheet.querySelector("#sheet-country-España")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/BecasExplorer.test.tsx
+++ b/src/components/BecasExplorer.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { renderWithProviders as render } from "../test/renderWithProviders";
 import { BecasExplorer } from "./BecasExplorer";
 import * as firebase from "../lib/firebase";
@@ -219,6 +219,130 @@ describe("BecasExplorer Component", () => {
       render(<BecasExplorer {...defaultProps} />);
 
       await waitFor(() => expect(screen.getByText(/No pudimos cargar/i)).toBeInTheDocument());
+    });
+  });
+  /**
+   * The filters worked; the interface lied about what they would give. Counts
+   * were computed against the whole catalogue while the list was filtered, so
+   * "Alemania" showed 1 result and "Doctorado" still advertised 4 — and
+   * picking both returned nothing. With 22 scholarships across 12 countries,
+   * 30 of the 48 country x level combinations are empty.
+   */
+  describe("filters", () => {
+    const chip = (container: HTMLElement, id: string) =>
+      container.querySelector<HTMLButtonElement>(`#${id}`);
+
+    /** The number shown in a chip's count badge. */
+    const chipCount = (container: HTMLElement, id: string) => {
+      const el = chip(container, id);
+      if (!el) throw new Error(`missing chip #${id}`);
+      return Number(el.textContent?.match(/(\d+)\s*$/)?.[1]);
+    };
+
+    it("puts the country filter before the education level", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      const country = chip(container, "country-chip-Todos");
+      const level = chip(container, "edu-level-chip-todos");
+      expect(country).toBeInTheDocument();
+      expect(level).toBeInTheDocument();
+      // The destination is the decision people arrive with, and it is what
+      // makes the level counts mean anything.
+      expect(country!.compareDocumentPosition(level!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+
+    it("re-counts the education levels when a country is picked", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      const before = chipCount(container, "edu-level-chip-postgrado");
+      fireEvent.click(chip(container, "country-chip-Alemania")!);
+      const after = chipCount(container, "edu-level-chip-postgrado");
+
+      expect(after).toBeLessThan(before);
+      // Alemania has a single scholarship, so no level can promise more.
+      expect(chipCount(container, "country-chip-Alemania")).toBe(1);
+      expect(after).toBeLessThanOrEqual(1);
+    });
+
+    it("disables an option that would give no results instead of hiding it", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      fireEvent.click(chip(container, "country-chip-Alemania")!);
+
+      // Every level that Alemania has nothing for is a dead end, and says so.
+      const deadEnds = ["pregrado", "doctorado", "postdoctorado"].filter(
+        (id) => chipCount(container, `edu-level-chip-${id}`) === 0
+      );
+      expect(deadEnds.length).toBeGreaterThan(0);
+      deadEnds.forEach((id) => {
+        const el = chip(container, `edu-level-chip-${id}`)!;
+        // Still on screen: hiding it would make the list of levels shift
+        // underneath the reader every time the country changed.
+        expect(el).toBeInTheDocument();
+        expect(el).toBeDisabled();
+      });
+    });
+
+    it("counts every option against the catalogue, not against nothing", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      // 22 scholarships in the bundled dataset.
+      expect(chipCount(container, "country-chip-Todos")).toBe(22);
+      expect(chipCount(container, "edu-level-chip-todos")).toBe(22);
+      expect(chipCount(container, "country-chip-España")).toBe(7);
+    });
+
+    describe("deadline filter", () => {
+      beforeEach(() => {
+        // The dataset carries fixed deadlines, so the clock has to be fixed
+        // too or the expected counts drift with the calendar.
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-10-01T12:00:00Z"));
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      /**
+       * Regression: the filter read `daysLeft`, which no scholarship carries.
+       * "Cierra en 90 días" and "Más de 90 días" therefore matched the entire
+       * catalogue — two of the three options did nothing at all.
+       */
+      it("narrows the list rather than matching everything", () => {
+        const { container } = render(<BecasExplorer {...defaultProps} />);
+
+        const total = chipCount(container, "sidebar-deadline-Todas");
+        expect(chipCount(container, "sidebar-deadline-semester")).toBeLessThan(total);
+        expect(chipCount(container, "sidebar-deadline-later")).toBeLessThan(total);
+        expect(chipCount(container, "sidebar-deadline-urgent")).toBeLessThan(total);
+      });
+
+      it("splits the catalogue between the three ranges", () => {
+        const { container } = render(<BecasExplorer {...defaultProps} />);
+
+        // Counted by hand from the bundled deadlines against 2026-10-01:
+        // one call already closed (2026-09-11), three close within 30 days,
+        // nine within 90, and the remaining twelve later than that.
+        expect(chipCount(container, "sidebar-deadline-Todas")).toBe(22);
+        expect(chipCount(container, "sidebar-deadline-urgent")).toBe(3);
+        expect(chipCount(container, "sidebar-deadline-semester")).toBe(9);
+        expect(chipCount(container, "sidebar-deadline-later")).toBe(12);
+      });
+    });
+
+    it("offers no native select on the mobile filter sheet", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      fireEvent.click(container.querySelector("#btn-open-mobile-filters")!);
+      const sheet = screen.getByText(/Filtros de Búsqueda/i).closest("div[class*='rounded-t-3xl']");
+      expect(sheet).not.toBeNull();
+
+      // A phone's own picker cannot show how many results an option leads to,
+      // and with most combinations empty that count is the point.
+      expect(within(sheet as HTMLElement).queryByRole("combobox")).toBeNull();
+      expect((sheet as HTMLElement).querySelectorAll("select")).toHaveLength(0);
+      expect(chip(container, "sheet-country-España")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
   Search,
   Filter,
@@ -46,6 +46,7 @@ import {
   getUserMigrationPlan,
 } from "../lib/firebase";
 import { usePreferences } from "../lib/PreferencesContext";
+import { FilterChipGroup } from "./ui/FilterChipGroup";
 import { useBodyScrollLock } from "../lib/useBodyScrollLock";
 
 interface BecasExplorerProps {
@@ -55,6 +56,20 @@ interface BecasExplorerProps {
   onAskAIAboutScholarship: (scholarship: Scholarship) => void;
   currentUser?: GoogleUser | null;
   onOpenAuthModal?: () => void;
+}
+
+/**
+ * Days from today to a deadline, or null when the date cannot be read.
+ *
+ * The dataset carries `deadlineDate` and never `daysLeft`, which the filters
+ * had been reading — so the deadline options silently matched everything.
+ */
+function daysUntil(deadline: string): number | null {
+  const target = new Date(deadline);
+  if (Number.isNaN(target.getTime())) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.round((target.getTime() - today.getTime()) / 86_400_000);
 }
 
 /** Long enough for a slow connection, short enough to not look frozen. */
@@ -231,14 +246,22 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     "Australia",
   ];
 
+  // Labels are short because they are read on a phone, inside a chip.
   const educationLevels = [
-    { id: "todos", label: "🎓 Todos los niveles" },
-    { id: "pregrado", label: "📚 Pregrado / Grado" },
+    { id: "todos", label: "🎓 Todos" },
+    { id: "pregrado", label: "📚 Pregrado" },
     { id: "postgrado", label: "🎯 Postgrado / Máster" },
-    { id: "doctorado", label: "🔬 Doctorado / PhD" },
-    { id: "postdoctorado", label: "🏛️ Post Doctorado / Estancias" },
+    { id: "doctorado", label: "🔬 Doctorado" },
+    { id: "postdoctorado", label: "🏛️ Postdoctorado" },
   ];
   const areas = ["Todas", "STEM", "Artes y Humanidades", "Salud", "Negocios", "Todas las áreas"];
+  // "Todas" clears the area filter; "Todas las áreas" is a value scholarships
+  // actually carry, meaning the call is open to any field. Two options reading
+  // "Todas las áreas" were indistinguishable, so the labels say which is which.
+  const areaLabels: Record<string, string> = {
+    Todas: "✨ Todas",
+    "Todas las áreas": "Abierta a cualquier área",
+  };
   const supportTypes = ["Todos", "Beca Completa", "Beca Parcial", "Manutención"];
   const institutionTypes = [
     "Todas",
@@ -248,10 +271,10 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     "Fundación",
   ];
   const dateRanges = [
-    { id: "Todas", label: "Todas las fechas" },
-    { id: "urgent", label: "⚡ Próximos 30 días (Cierre Urgente)" },
-    { id: "semester", label: "📅 Próximos 90 días (Semestre actual)" },
-    { id: "later", label: "⏳ Más de 90 días / Anuales" },
+    { id: "Todas", label: "📆 Todas" },
+    { id: "urgent", label: "⚡ Cierra en 30 días" },
+    { id: "semester", label: "📅 Cierra en 90 días" },
+    { id: "later", label: "⏳ Más de 90 días" },
   ];
 
   const handleSyncScholarships = async () => {
@@ -309,53 +332,251 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     setVisibleCount(itemsPerPage > 0 ? itemsPerPage : 6);
   };
 
+  /**
+   * One definition of "does this scholarship match the filters", shared by the
+   * list and by the counts beside each option.
+   *
+   * They used to be written twice: the list filtered on every active filter
+   * while the counts were computed against the whole catalogue. So "Alemania"
+   * showed 1 result and "Doctorado" still advertised 4, and picking both
+   * returned nothing. With 22 scholarships across 12 countries, 30 of the 48
+   * country x level combinations are empty — the filters worked, and the
+   * interface walked people into dead ends without warning.
+   *
+   * `overrides` lets a count ask "how many would there be if this one option
+   * changed", which is what makes the numbers cascade.
+   */
+  const matchesFilters = useCallback(
+    (
+      item: Scholarship,
+      overrides: Partial<{
+        country: string;
+        educationLevel: string;
+        area: string;
+        supportType: string;
+        institutionType: string;
+        dateRange: string;
+      }> = {}
+    ) => {
+      const country = overrides.country ?? selectedCountry;
+      const educationLevel = overrides.educationLevel ?? selectedEducationLevel;
+      const area = overrides.area ?? selectedArea;
+      const supportType = overrides.supportType ?? selectedSupportType;
+      const institutionType = overrides.institutionType ?? selectedInstitutionType;
+      const dateRange = overrides.dateRange ?? selectedDateRange;
+
+      const q = searchQuery.toLowerCase();
+      const matchesSearch =
+        item.title.toLowerCase().includes(q) ||
+        item.institution.toLowerCase().includes(q) ||
+        item.description.toLowerCase().includes(q) ||
+        item.country.toLowerCase().includes(q) ||
+        (item.officialPortalName ?? "").toLowerCase().includes(q);
+
+      const matchesCountry = country === "Todos" || item.country === country;
+      const matchesEducation =
+        educationLevel === "todos" ||
+        item.educationLevel === educationLevel ||
+        (educationLevel === "postgrado" && !item.educationLevel);
+      const matchesArea = area === "Todas" || item.area === area || item.area === "Todas las áreas";
+      const matchesSupport = supportType === "Todos" || item.supportType === supportType;
+      const matchesInstType =
+        institutionType === "Todas" || item.institutionType === institutionType;
+
+      // `daysLeft` is absent from every scholarship in the dataset, so the
+      // deadline is read from `deadlineDate` instead. Reading `daysLeft` made
+      // "this semester" and "later" return the entire catalogue: two of the
+      // three options did nothing at all.
+      //
+      // The `isUrgent` flag is not consulted: it is written once when a record
+      // is created and never recomputed, so it says a call is closing soon long
+      // after it has closed. The deadline itself is the only thing that stays
+      // true, and an already-closed call is not "closing in 30 days".
+      let matchesDate = true;
+      if (dateRange !== "Todas") {
+        const days = daysUntil(item.deadlineDate);
+        if (days === null) matchesDate = false;
+        else if (dateRange === "urgent") matchesDate = days >= 0 && days <= 30;
+        else if (dateRange === "semester") matchesDate = days >= 0 && days <= 90;
+        else if (dateRange === "later") matchesDate = days > 90;
+      }
+
+      return (
+        matchesSearch &&
+        matchesCountry &&
+        matchesEducation &&
+        matchesArea &&
+        matchesSupport &&
+        matchesInstType &&
+        matchesDate
+      );
+    },
+    [
+      searchQuery,
+      selectedCountry,
+      selectedEducationLevel,
+      selectedArea,
+      selectedSupportType,
+      selectedInstitutionType,
+      selectedDateRange,
+    ]
+  );
+
+  /**
+   * How many results an option would give, with every other filter left as it
+   * is. A zero here means the option is a dead end, and the interface says so
+   * instead of letting someone walk into an empty list.
+   */
+  const countWith = useCallback(
+    (overrides: Parameters<typeof matchesFilters>[1]) =>
+      scholarshipsList.filter(
+        (item) =>
+          (viewModeTab !== "favorites" || favorites.includes(item.id)) &&
+          matchesFilters(item, overrides)
+      ).length,
+    [scholarshipsList, matchesFilters, viewModeTab, favorites]
+  );
+
+  /**
+   * Every filter option with the number of results it would give, with the
+   * other filters left as they are. Built from `countWith`, so the numbers
+   * cascade: narrowing the country immediately re-counts the levels, the
+   * areas and the rest.
+   */
+  const countryOptions = useMemo(
+    () =>
+      countries.map((c) => ({
+        id: c,
+        label: c === "Todos" ? "🌍 Todos" : c,
+        count: countWith({ country: c }),
+      })),
+    // `countries` is a constant list defined in this component.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  const educationOptions = useMemo(
+    () => educationLevels.map((l) => ({ ...l, count: countWith({ educationLevel: l.id }) })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  const areaOptions = useMemo(
+    () => areas.map((a) => ({ id: a, label: areaLabels[a] ?? a, count: countWith({ area: a }) })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  const supportOptions = useMemo(
+    () =>
+      supportTypes.map((t) => ({
+        id: t,
+        label: t === "Todos" ? "🏆 Todos" : t,
+        count: countWith({ supportType: t }),
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  const institutionOptions = useMemo(
+    () =>
+      institutionTypes.map((t) => ({
+        id: t,
+        label: t === "Todas" ? "🏛️ Todas" : t,
+        count: countWith({ institutionType: t }),
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  const dateOptions = useMemo(
+    () => dateRanges.map((r) => ({ ...r, count: countWith({ dateRange: r.id }) })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countWith]
+  );
+
+  /** Filters that are not on their default, for the "Limpiar" affordances. */
+  const advancedFilterCount =
+    (selectedArea !== "Todas" ? 1 : 0) +
+    (selectedSupportType !== "Todos" ? 1 : 0) +
+    (selectedInstitutionType !== "Todas" ? 1 : 0) +
+    (selectedDateRange !== "Todas" ? 1 : 0) +
+    (viewModeTab === "favorites" ? 1 : 0);
+
+  const activeFilterCount =
+    advancedFilterCount +
+    (selectedCountry !== "Todos" ? 1 : 0) +
+    (selectedEducationLevel !== "todos" ? 1 : 0);
+
+  /**
+   * The whole filter set, rendered identically in the desktop sidebar and the
+   * mobile sheet. Both can be in the DOM at once, so each copy scopes its
+   * element ids.
+   */
+  const renderFilterGroups = (scope: "sidebar" | "sheet") => (
+    <>
+      <FilterChipGroup
+        label="País Destino"
+        icon={<Globe2 className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={countryOptions}
+        value={selectedCountry}
+        onChange={setSelectedCountry}
+        idPrefix={`${scope}-country`}
+        layout="wrap"
+      />
+      <FilterChipGroup
+        label="Nivel Educativo"
+        icon={<GraduationCap className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={educationOptions}
+        value={selectedEducationLevel}
+        onChange={setSelectedEducationLevel}
+        idPrefix={`${scope}-education`}
+        layout="wrap"
+      />
+      <FilterChipGroup
+        label="Área de Estudio"
+        icon={<BookOpen className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={areaOptions}
+        value={selectedArea}
+        onChange={setSelectedArea}
+        idPrefix={`${scope}-area`}
+        layout="wrap"
+      />
+      <FilterChipGroup
+        label="Tipo de Apoyo"
+        icon={<Award className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={supportOptions}
+        value={selectedSupportType}
+        onChange={setSelectedSupportType}
+        idPrefix={`${scope}-support`}
+        layout="wrap"
+      />
+      <FilterChipGroup
+        label="Tipo de Entidad"
+        icon={<Building2 className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={institutionOptions}
+        value={selectedInstitutionType}
+        onChange={setSelectedInstitutionType}
+        idPrefix={`${scope}-institution`}
+        layout="wrap"
+      />
+      <FilterChipGroup
+        label="Fecha de Cierre"
+        icon={<CalendarIcon className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />}
+        options={dateOptions}
+        value={selectedDateRange}
+        onChange={setSelectedDateRange}
+        idPrefix={`${scope}-deadline`}
+        layout="wrap"
+      />
+    </>
+  );
+
   const filteredScholarships = useMemo(() => {
     return scholarshipsList
       .filter((item) => {
-        // If we are in "favorites" tab, only include favorited scholarships
-        if (viewModeTab === "favorites" && !favorites.includes(item.id)) {
-          return false;
-        }
-
-        const matchesSearch =
-          item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          item.institution.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          item.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          item.country.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (item.officialPortalName &&
-            item.officialPortalName.toLowerCase().includes(searchQuery.toLowerCase()));
-
-        const matchesCountry = selectedCountry === "Todos" || item.country === selectedCountry;
-        const matchesEducation =
-          selectedEducationLevel === "todos" ||
-          item.educationLevel === selectedEducationLevel ||
-          (selectedEducationLevel === "postgrado" && !item.educationLevel);
-        const matchesArea =
-          selectedArea === "Todas" || item.area === selectedArea || item.area === "Todas las áreas";
-        const matchesSupport =
-          selectedSupportType === "Todos" || item.supportType === selectedSupportType;
-        const matchesInstType =
-          selectedInstitutionType === "Todas" || item.institutionType === selectedInstitutionType;
-
-        // Date Range Match
-        let matchesDate = true;
-        if (selectedDateRange === "urgent") {
-          matchesDate = (item.daysLeft !== undefined && item.daysLeft <= 30) || !!item.isUrgent;
-        } else if (selectedDateRange === "semester") {
-          matchesDate = item.daysLeft !== undefined ? item.daysLeft <= 90 : true;
-        } else if (selectedDateRange === "later") {
-          matchesDate = item.daysLeft !== undefined ? item.daysLeft > 90 : true;
-        }
-
-        return (
-          matchesSearch &&
-          matchesCountry &&
-          matchesEducation &&
-          matchesArea &&
-          matchesSupport &&
-          matchesInstType &&
-          matchesDate
-        );
+        if (viewModeTab === "favorites" && !favorites.includes(item.id)) return false;
+        return matchesFilters(item);
       })
       .sort((a, b) => {
         if (sortBy === "deadline-asc") {
@@ -372,19 +593,9 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         }
         return a.title.localeCompare(b.title);
       });
-  }, [
-    scholarshipsList,
-    viewModeTab,
-    favorites,
-    searchQuery,
-    selectedCountry,
-    selectedEducationLevel,
-    selectedArea,
-    selectedSupportType,
-    selectedInstitutionType,
-    selectedDateRange,
-    sortBy,
-  ]);
+    // `matchesFilters` already closes over every filter, so listing them here
+    // as well only risks the two lists drifting apart.
+  }, [scholarshipsList, viewModeTab, favorites, matchesFilters, sortBy]);
 
   // Reset pagination when viewModeTab, filters, sort or pageSize change
   useEffect(() => {
@@ -695,65 +906,10 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
           </div>
         )}
 
-        {/* Quick Education Level Selector Chips Bar (User Request: Pregrado, Postgrado, Doctorado, Post doctorado) */}
-        <div className="bg-surface-container-lowest dark:bg-slate-800 p-3.5 md:p-4 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-2.5">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <GraduationCap className="w-4 h-4 text-secondary dark:text-teal-400" />
-              <span className="text-xs font-bold uppercase tracking-wider text-on-surface-variant dark:text-slate-400">
-                Nivel Educativo
-              </span>
-            </div>
-            {selectedEducationLevel !== "todos" && (
-              <button
-                type="button"
-                onClick={() => setSelectedEducationLevel("todos")}
-                className="text-xs font-semibold text-secondary dark:text-teal-400 hover:underline cursor-pointer active:scale-95 transition-transform"
-              >
-                Ver todos
-              </button>
-            )}
-          </div>
-
-          {/* Scrollable on mobile, grid on tablets and desktop */}
-          <div className="flex sm:grid sm:grid-cols-3 lg:grid-cols-5 gap-2 overflow-x-auto no-scrollbar pb-1 sm:pb-0">
-            {educationLevels.map((lvl) => {
-              const count = scholarshipsList.filter((s) =>
-                lvl.id === "todos"
-                  ? true
-                  : s.educationLevel === lvl.id || (lvl.id === "postgrado" && !s.educationLevel)
-              ).length;
-              const isSelected = selectedEducationLevel === lvl.id;
-              return (
-                <button
-                  key={lvl.id}
-                  type="button"
-                  onClick={() => setSelectedEducationLevel(lvl.id)}
-                  id={`edu-level-chip-${lvl.id}`}
-                  className={`shrink-0 sm:shrink flex items-center justify-between gap-2 min-h-[44px] px-3 py-2 sm:py-2.5 rounded-xl font-bold text-xs transition-all cursor-pointer select-none active:scale-95 ${
-                    isSelected
-                      ? "bg-primary text-white dark:bg-sky-600 shadow-sm ring-2 ring-primary/30"
-                      : "bg-surface dark:bg-slate-900 text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/60 border border-outline-variant/30 dark:border-slate-700"
-                  }`}
-                >
-                  <span className="whitespace-nowrap">{lvl.label}</span>
-                  <span
-                    className={`text-[11px] px-2 py-0.5 rounded-full font-mono ${
-                      isSelected
-                        ? "bg-white/20 text-white"
-                        : "bg-surface-container dark:bg-slate-800 text-on-surface-variant dark:text-slate-400"
-                    }`}
-                  >
-                    {count}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Mobile Quick Filters Bar (Visible on screens < lg) */}
-        <div className="lg:hidden bg-surface-container-lowest dark:bg-slate-800 p-3.5 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-3">
+        {/* Mobile quick filters. Country comes before education level: the
+            destination is the decision people arrive with, and fixing it first
+            is what makes the level counts mean anything. */}
+        <div className="lg:hidden bg-surface-container-lowest dark:bg-slate-800 p-3.5 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-3.5">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-1.5 font-bold text-xs text-primary dark:text-sky-300">
               <SlidersHorizontal className="w-4 h-4 text-secondary dark:text-teal-400" />
@@ -761,13 +917,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
             </div>
 
             <div className="flex items-center gap-2">
-              {(selectedCountry !== "Todos" ||
-                selectedEducationLevel !== "todos" ||
-                selectedArea !== "Todas" ||
-                selectedSupportType !== "Todos" ||
-                selectedInstitutionType !== "Todas" ||
-                selectedDateRange !== "Todas" ||
-                viewModeTab === "favorites") && (
+              {activeFilterCount > 0 && (
                 <button
                   type="button"
                   onClick={clearFilters}
@@ -785,62 +935,38 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
               >
                 <Filter className="w-3.5 h-3.5" />
                 <span>Más Filtros</span>
-                {(selectedCountry !== "Todos" ? 1 : 0) +
-                  (selectedArea !== "Todas" ? 1 : 0) +
-                  (selectedSupportType !== "Todos" ? 1 : 0) +
-                  (selectedInstitutionType !== "Todas" ? 1 : 0) +
-                  (selectedDateRange !== "Todas" ? 1 : 0) +
-                  (viewModeTab === "favorites" ? 1 : 0) >
-                  0 && (
-                  <span className="bg-white/20 text-white text-[10px] px-1.5 py-0.2 rounded-full font-bold">
-                    {(selectedCountry !== "Todos" ? 1 : 0) +
-                      (selectedArea !== "Todas" ? 1 : 0) +
-                      (selectedSupportType !== "Todos" ? 1 : 0) +
-                      (selectedInstitutionType !== "Todas" ? 1 : 0) +
-                      (selectedDateRange !== "Todas" ? 1 : 0) +
-                      (viewModeTab === "favorites" ? 1 : 0)}
+                {advancedFilterCount > 0 && (
+                  <span className="bg-white/20 text-white text-[10px] px-1.5 py-0.5 rounded-full font-bold">
+                    {advancedFilterCount}
                   </span>
                 )}
               </button>
             </div>
           </div>
 
-          {/* Quick Select dropdowns for mobile */}
-          <div className="grid grid-cols-2 gap-2">
-            <div>
-              <label className="text-[10px] font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider block mb-1">
-                País
-              </label>
-              <select
-                value={selectedCountry}
-                onChange={(e) => setSelectedCountry(e.target.value)}
-                className="w-full bg-surface dark:bg-slate-900 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl px-2.5 py-2 outline-none focus:ring-2 focus:ring-secondary"
-              >
-                {countries.map((c) => (
-                  <option key={c} value={c}>
-                    {c === "Todos" ? "🌍 Todos los países" : c}
-                  </option>
-                ))}
-              </select>
-            </div>
+          <FilterChipGroup
+            label="País Destino"
+            icon={<Globe2 className="w-4 h-4 text-secondary dark:text-teal-400" />}
+            options={countryOptions}
+            value={selectedCountry}
+            onChange={setSelectedCountry}
+            idPrefix="country-chip"
+            onClear={selectedCountry !== "Todos" ? () => setSelectedCountry("Todos") : undefined}
+          />
 
-            <div>
-              <label className="text-[10px] font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider block mb-1">
-                Tipo de Apoyo
-              </label>
-              <select
-                value={selectedSupportType}
-                onChange={(e) => setSelectedSupportType(e.target.value)}
-                className="w-full bg-surface dark:bg-slate-900 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl px-2.5 py-2 outline-none focus:ring-2 focus:ring-secondary"
-              >
-                {supportTypes.map((t) => (
-                  <option key={t} value={t}>
-                    {t === "Todos" ? "🏆 Todos los apoyos" : t}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
+          <FilterChipGroup
+            label="Nivel Educativo"
+            icon={<GraduationCap className="w-4 h-4 text-secondary dark:text-teal-400" />}
+            options={educationOptions}
+            value={selectedEducationLevel}
+            onChange={setSelectedEducationLevel}
+            idPrefix="edu-level-chip"
+            onClear={
+              selectedEducationLevel !== "todos"
+                ? () => setSelectedEducationLevel("todos")
+                : undefined
+            }
+          />
         </div>
 
         {/* Mobile Filters Slide-over / Bottom Sheet Modal */}
@@ -898,95 +1024,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                   </button>
                 </div>
 
-                {/* País Destino Dropdown */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    País Destino
-                  </label>
-                  <select
-                    value={selectedCountry}
-                    onChange={(e) => setSelectedCountry(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {countries.map((c) => (
-                      <option key={c} value={c}>
-                        {c === "Todos" ? "🌍 Todos los países" : c}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Área de Estudio */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Área de Estudio
-                  </label>
-                  <select
-                    value={selectedArea}
-                    onChange={(e) => setSelectedArea(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {areas.map((a) => (
-                      <option key={a} value={a}>
-                        {a === "Todas" ? "🎓 Todas las áreas" : a}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Tipo de Apoyo */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Tipo de Apoyo
-                  </label>
-                  <select
-                    value={selectedSupportType}
-                    onChange={(e) => setSelectedSupportType(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {supportTypes.map((t) => (
-                      <option key={t} value={t}>
-                        {t === "Todos" ? "🏆 Todos los apoyos" : t}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Tipo de Entidad */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Tipo de Entidad
-                  </label>
-                  <select
-                    value={selectedInstitutionType}
-                    onChange={(e) => setSelectedInstitutionType(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {institutionTypes.map((it) => (
-                      <option key={it} value={it}>
-                        {it === "Todas" ? "🏛️ Todas las entidades" : it}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Fecha Límite */}
-                <div>
-                  <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                    Fecha de Cierre
-                  </label>
-                  <select
-                    value={selectedDateRange}
-                    onChange={(e) => setSelectedDateRange(e.target.value)}
-                    className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                  >
-                    {dateRanges.map((dr) => (
-                      <option key={dr.id} value={dr.id}>
-                        {dr.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                {renderFilterGroups("sheet")}
               </div>
 
               {/* Bottom Apply Action */}
@@ -1027,32 +1065,6 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
               </button>
             </div>
 
-            {/* Nivel Educativo en Sidebar */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <GraduationCap className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>Nivel Educativo</span>
-              </label>
-              <div className="space-y-1">
-                {educationLevels.map((lvl) => (
-                  <button
-                    key={lvl.id}
-                    onClick={() => setSelectedEducationLevel(lvl.id)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedEducationLevel === lvl.id
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{lvl.label}</span>
-                    {selectedEducationLevel === lvl.id && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
             {/* Quick Filter for Favorites inside sidebar */}
             <div className="p-3 bg-surface dark:bg-slate-900 rounded-xl border border-outline-variant/40 dark:border-slate-700 space-y-2">
               <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider block">
@@ -1080,135 +1092,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
               </button>
             </div>
 
-            {/* Fecha Límite de Aplicación */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <CalendarIcon className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>Fecha de Aplicación</span>
-              </label>
-              <div className="space-y-1">
-                {dateRanges.map((range) => (
-                  <button
-                    key={range.id}
-                    onClick={() => setSelectedDateRange(range.id)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedDateRange === range.id
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{range.label}</span>
-                    {selectedDateRange === range.id && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Tipo de Emisor / Entidad */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <Building2 className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>Tipo de Entidad</span>
-              </label>
-              <div className="space-y-1">
-                {institutionTypes.map((type) => (
-                  <button
-                    key={type}
-                    onClick={() => setSelectedInstitutionType(type)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedInstitutionType === type
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{type}</span>
-                    {selectedInstitutionType === type && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* País Destino */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <Globe2 className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>País Destino</span>
-              </label>
-              <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
-                {countries.map((country) => (
-                  <button
-                    key={country}
-                    onClick={() => setSelectedCountry(country)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedCountry === country
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{country}</span>
-                    {selectedCountry === country && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Área de Estudio */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <GraduationCap className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>Área de Estudio</span>
-              </label>
-              <div className="space-y-1">
-                {areas.map((area) => (
-                  <button
-                    key={area}
-                    onClick={() => setSelectedArea(area)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedArea === area
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{area}</span>
-                    {selectedArea === area && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Tipo de Apoyo */}
-            <div className="space-y-2">
-              <label className="text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider flex items-center gap-1.5">
-                <Award className="w-3.5 h-3.5 text-secondary dark:text-teal-400" />
-                <span>Tipo de Apoyo</span>
-              </label>
-              <div className="space-y-1">
-                {supportTypes.map((type) => (
-                  <button
-                    key={type}
-                    onClick={() => setSelectedSupportType(type)}
-                    className={`w-full text-left px-3 py-1.5 rounded-lg text-xs transition-colors flex items-center justify-between cursor-pointer active:scale-95 ${
-                      selectedSupportType === type
-                        ? "bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 font-bold"
-                        : "text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/50"
-                    }`}
-                  >
-                    <span>{type}</span>
-                    {selectedSupportType === type && (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-primary dark:text-sky-400" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
+            {renderFilterGroups("sidebar")}
           </aside>
 
           {/* Scholarships Grid & Pagination Container */}

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -48,7 +48,6 @@ import {
 import { usePreferences } from "../lib/PreferencesContext";
 import { FilterChipGroup } from "./ui/FilterChipGroup";
 import { Modal } from "./ui/Modal";
-import { useBodyScrollLock } from "../lib/useBodyScrollLock";
 
 interface BecasExplorerProps {
   searchQuery: string;
@@ -974,63 +973,25 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
           <Modal
             open={mobileFiltersOpen}
             onOpenChange={setMobileFiltersOpen}
-            title="Filtros"
+            title="Filtros de Búsqueda"
             size="md"
             id="mobile-filters-sheet"
-          >
-            {/* Header */}
-            <div className="flex items-center justify-between pb-3 border-b border-outline-variant/30 dark:border-slate-800">
-              <div className="flex items-center gap-2 font-bold text-base text-primary dark:text-sky-300">
-                <Filter className="w-5 h-5 text-secondary dark:text-teal-400" />
-                <span>Filtros de Búsqueda</span>
-              </div>
-<div className="flex items-center gap-2">
-  <Filter className="w-5 h-5 text-secondary dark:text-teal-400" />
-  <span>Filtros de Búsqueda</span>
-</div>
-
-{/* Mobile Filter Controls */}
-<div className="space-y-4">
-  {/* Favoritas Toggle */}
-  <div className="p-3 bg-surface dark:bg-slate-800/80 rounded-xl border border-outline-variant/40 dark:border-slate-700 flex items-center justify-between">
-    <div className="flex items-center gap-2">
-      <Heart
-        className={`w-4 h-4 ${viewModeTab === "favorites" ? "fill-red-500 text-red-500" : "text-on-surface-variant"}`}
-      />
-      <span className="text-xs font-bold text-on-surface dark:text-slate-200">
-        Ver solo mis favoritas
-      </span>
-    </div>
-    <button
-      type="button"
-      onClick={() =>
-        setViewModeTab(viewModeTab === "favorites" ? "all" : "favorites")
-      }
-      className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all active:scale-95 ${
-        viewModeTab === "favorites"
-          ? "bg-red-500 text-white shadow-xs"
-          : "bg-surface-container dark:bg-slate-700 text-on-surface-variant dark:text-slate-300"
-      }`}
-    >
-      {viewModeTab === "favorites" ? "Activado" : "Desactivado"} ({favorites.length})
-    </button>
-  </div>
-
-  {renderFilterGroups("sheet")}
-</div>
-
-{/* Bottom Apply Action */}
-<div className="pt-3 border-t border-outline-variant/30 dark:border-slate-800 sticky bottom-0 bg-surface-container-lowest dark:bg-slate-900">
+            header={
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <div className="flex items-center gap-2 font-bold text-base text-primary dark:text-sky-300">
+                  <Filter className="w-5 h-5 shrink-0 text-secondary dark:text-teal-400" />
+                  <span className="truncate">Filtros de Búsqueda</span>
+                </div>
                 <button
                   type="button"
                   onClick={clearFilters}
-                  className="text-xs font-semibold text-secondary dark:text-teal-400 hover:underline px-2 py-1 active:scale-95"
+                  className="shrink-0 text-xs font-semibold text-secondary dark:text-teal-400 hover:underline px-2 py-1 active:scale-95"
                 >
                   Limpiar todo
                 </button>
               </div>
-            </div>
-
+            }
+          >
             {/* Mobile Filter Controls */}
             <div className="space-y-4">
               {/* Favoritas Toggle */}
@@ -1056,95 +1017,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                 </button>
               </div>
 
-              {/* País Destino Dropdown */}
-              <div>
-                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                  País Destino
-                </label>
-                <select
-                  value={selectedCountry}
-                  onChange={(e) => setSelectedCountry(e.target.value)}
-                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                >
-                  {countries.map((c) => (
-                    <option key={c} value={c}>
-                      {c === "Todos" ? "🌍 Todos los países" : c}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Área de Estudio */}
-              <div>
-                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                  Área de Estudio
-                </label>
-                <select
-                  value={selectedArea}
-                  onChange={(e) => setSelectedArea(e.target.value)}
-                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                >
-                  {areas.map((a) => (
-                    <option key={a} value={a}>
-                      {a === "Todas" ? "🎓 Todas las áreas" : a}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Tipo de Apoyo */}
-              <div>
-                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                  Tipo de Apoyo
-                </label>
-                <select
-                  value={selectedSupportType}
-                  onChange={(e) => setSelectedSupportType(e.target.value)}
-                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                >
-                  {supportTypes.map((t) => (
-                    <option key={t} value={t}>
-                      {t === "Todos" ? "🏆 Todos los apoyos" : t}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Tipo de Entidad */}
-              <div>
-                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                  Tipo de Entidad
-                </label>
-                <select
-                  value={selectedInstitutionType}
-                  onChange={(e) => setSelectedInstitutionType(e.target.value)}
-                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                >
-                  {institutionTypes.map((it) => (
-                    <option key={it} value={it}>
-                      {it === "Todas" ? "🏛️ Todas las entidades" : it}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Fecha Límite */}
-              <div>
-                <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block mb-1.5">
-                  Fecha de Cierre
-                </label>
-                <select
-                  value={selectedDateRange}
-                  onChange={(e) => setSelectedDateRange(e.target.value)}
-                  className="w-full bg-surface dark:bg-slate-800 border border-outline-variant/60 dark:border-slate-700 text-on-surface dark:text-slate-200 text-xs font-semibold rounded-xl p-3 outline-none focus:ring-2 focus:ring-secondary"
-                >
-                  {dateRanges.map((dr) => (
-                    <option key={dr.id} value={dr.id}>
-                      {dr.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              {renderFilterGroups("sheet")}
             </div>
 
             {/* Bottom Apply Action */}

--- a/src/components/ui/FilterChipGroup.tsx
+++ b/src/components/ui/FilterChipGroup.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+
+export interface FilterChipOption {
+  /** Value stored in state when the chip is picked. */
+  id: string;
+  /** Spanish label shown on the chip. */
+  label: string;
+  /** How many results this option would give with the other filters as they are. */
+  count: number;
+}
+
+interface FilterChipGroupProps {
+  /** Spanish label for the whole group. */
+  label: string;
+  icon?: React.ReactNode;
+  options: FilterChipOption[];
+  value: string;
+  onChange: (id: string) => void;
+  /**
+   * Prefix for each chip's `id`, so E2E tests can target a chip by value
+   * rather than by its visible Spanish copy.
+   */
+  idPrefix: string;
+  /**
+   * `scroll` keeps the chips on one swipeable row — right for a short list on
+   * a phone. `wrap` flows them onto several lines, which suits a long list
+   * such as the countries.
+   */
+  layout?: "scroll" | "wrap";
+  /** Resets the group. Omitted when the group is already on its default. */
+  onClear?: () => void;
+}
+
+/**
+ * A single-choice filter rendered as chips with a live result count.
+ *
+ * This replaces the native `<select>` elements the filters used on mobile.
+ * A `<select>` on a phone opens the operating system's own picker, which
+ * cannot show how many results each option leads to — and with 30 of the 48
+ * country x level combinations empty, that count is the whole point.
+ *
+ * An option with no results stays visible and is disabled rather than hidden:
+ * removing it would make the list of options shift underneath the reader every
+ * time another filter changed.
+ */
+export const FilterChipGroup: React.FC<FilterChipGroupProps> = ({
+  label,
+  icon,
+  options,
+  value,
+  onChange,
+  idPrefix,
+  layout = "scroll",
+  onClear,
+}) => {
+  const labelId = `${idPrefix}-label`;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          {icon}
+          <span
+            id={labelId}
+            className="text-xs font-bold uppercase tracking-wider text-on-surface-variant dark:text-slate-400"
+          >
+            {label}
+          </span>
+        </div>
+        {onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs font-semibold text-secondary dark:text-teal-400 hover:underline cursor-pointer active:scale-95 transition-transform"
+          >
+            Ver todos
+          </button>
+        )}
+      </div>
+
+      <div
+        role="group"
+        aria-labelledby={labelId}
+        className={
+          layout === "scroll"
+            ? "flex gap-2 overflow-x-auto no-scrollbar pb-1 -mx-0.5 px-0.5"
+            : "flex flex-wrap gap-2"
+        }
+      >
+        {options.map((option) => {
+          const isSelected = value === option.id;
+          const isEmpty = option.count === 0 && !isSelected;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              id={`${idPrefix}-${option.id}`}
+              onClick={() => onChange(option.id)}
+              disabled={isEmpty}
+              aria-pressed={isSelected}
+              title={isEmpty ? "No hay convocatorias con los filtros actuales" : undefined}
+              className={`shrink-0 inline-flex items-center gap-2 min-h-[44px] px-3 py-2 rounded-xl text-xs font-bold transition-all select-none ${
+                isEmpty
+                  ? "bg-surface dark:bg-slate-900 text-on-surface-variant/40 dark:text-slate-600 cursor-not-allowed border border-transparent"
+                  : isSelected
+                    ? "bg-primary text-white dark:bg-sky-600 shadow-sm ring-2 ring-primary/30 cursor-pointer active:scale-95"
+                    : "bg-surface dark:bg-slate-900 text-on-surface-variant dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700/60 border border-outline-variant/30 dark:border-slate-700 cursor-pointer active:scale-95"
+              }`}
+            >
+              <span className="whitespace-nowrap">{option.label}</span>
+              <span
+                className={`text-[11px] px-2 py-0.5 rounded-full font-mono tabular-nums ${
+                  isSelected
+                    ? "bg-white/20 text-white"
+                    : "bg-surface-container dark:bg-slate-800 text-on-surface-variant dark:text-slate-400"
+                }`}
+              >
+                {option.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## The problem

The filters worked. The interface lied about what they would give.

Counts beside each option were computed against the whole catalogue while the list itself was filtered, so **"Alemania" showed 1 result and "Doctorado" still advertised 4** — and picking both returned nothing. With 22 scholarships across 12 countries, **30 of the 48 country × level combinations are empty**, and nothing warned before selecting one.

Two of the three deadline options did nothing at all: the filter read `daysLeft`, which no scholarship in the dataset carries, so "this semester" and "later" matched everything.

## The change

**Counts that cascade.** One shared `matchesFilters` predicate, used by both the list and the counts, so the two cannot drift apart again. `countWith(overrides)` asks "how many would there be if this one option changed" — narrowing the country immediately re-counts the levels, the areas and the rest.

**Dead ends say so.** An option with no results is disabled and dimmed rather than hidden. Hiding it would make the list of options shift underneath the reader every time another filter changed.

**Country before education level.** The destination is the decision people arrive with, and fixing it first is what makes the level counts mean anything.

**The deadline filter works.** It reads `deadlineDate`, and no longer consults `isUrgent` — a flag written once at record creation and never recomputed, which calls a closed application "closing in 30 days". An already-closed call now belongs to no range.

**No native `<select>` on mobile.** A phone's own picker cannot show how many results an option leads to, and with most combinations empty that count is the point. The new `FilterChipGroup` renders the desktop sidebar and the mobile sheet from the same component, so the two stay in step.

Chip labels were shortened (`🏛️ Post Doctorado / Estancias` → `🏛️ Postdoctorado`) because they are read on a phone. The two area options that both read "Todas las áreas" — one clears the filter, the other is a value scholarships actually carry — are now distinguishable.

## Tests

Seven new cases in `src/components/BecasExplorer.test.tsx`:

- country renders before education level in the document
- picking Alemania lowers the postgrado count
- an option with a zero count is present **and** disabled
- counts are measured against the catalogue (22 total, 7 for España)
- the deadline filter narrows rather than matching everything
- exact split at a fixed clock (2026-10-01): 3 urgent / 9 semester / 12 later / 1 already closed
- the mobile sheet contains no `<select>`

```
126 passed            # vitest, coverage thresholds met
lint: 0 errors, 35 warnings (at the ratchet)
```

Verified in a real browser at 375px: chips scroll on one row, counts update as filters change, the sheet contains no native picker.

## Note

This branch does **not** include #49. Until that merges, the filter sheet on this branch still opens below the fold — that is the separate containing-block bug, not this change. Merging #49 first will show this work in its intended position.

## Out of scope

The rest of the mobile list from this round — card buttons stacking as blocks, the two paginations, the broken-image placeholder, the detail panel, Home and Guías — is not in this branch. Each is its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_