### PR TITLE
docs: record commit authorship and how commits get verified

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,26 @@ These are project-specific. A reasonable default would break them.
 
 ---
 
+## Commit identity
+
+Commits are authored by the repository owner, not by the agent. Set this
+before the first commit of a session — the container is recreated each time,
+so it does not persist:
+
+```bash
+git config user.name  "ana-izaguirre"
+git config user.email "gaortizb777@gmail.com"
+```
+
+This keeps a squash merge from adding a `Co-authored-by` trailer, and makes
+the branch history match the merge commit.
+
+Commits made inside the agent container are **not** signed: there is no
+signing key there, and there should not be one. Verification comes from
+GitHub instead — merging through the pull request button makes GitHub the
+committer and signs the result, so every commit that reaches `main` is
+Verified. Merge from the pull request; do not push to `main` directly.
+
 ## Workflow
 
 ### One change per pull request


### PR DESCRIPTION
## Why

Commits made from the agent container were authored as `Claude <noreply@anthropic.com>`. Two consequences:

- every squash merge picked up a `Co-authored-by: Claude` trailer
- the branch history disagreed with the merge commit, which is authored by the repository owner

## What changes

A short **Commit identity** section in `CLAUDE.md`, above Workflow. It records the two `git config` lines to set at the start of a session — the container is recreated each time, so nothing persists on disk.

It also writes down where verification actually comes from, since this was not obvious:

| | committer | Verified |
|---|---|---|
| commit on a feature branch | the author | no |
| commit on `main` after merging the PR | `GitHub <noreply@github.com>` | **yes** |

There is no signing key in the agent container, and there should not be one — signing as the owner would mean holding their private key in an ephemeral environment. GitHub signs the merge commit instead, so everything that reaches `main` through the pull request button is Verified. The note says to merge from the PR and not push to `main` directly.

## Verification

This PR's own commit is authored as `ana-izaguirre <gaortizb777@gmail.com>`, so it is the first one where the trailer will not appear.

## Not covered

Signing the intermediate branch commits. That needs a key registered on the account as a signing key, which is a decision and a secret to handle — worth its own issue if the intermediate commits ever need to be Verified too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_