### PR TITLE
fix(guias): make the migration guide readable on a phone

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -131,6 +131,31 @@ Recently addressed and verified by tests:
 - Dismissing the drawer restores the reading position instead of jumping to the
   top.
 
+## Migration guides
+
+- The guide collapses its heavy blocks below `lg` and leaves them open above
+  it. Measured at 375px, the screen ran to 9857px — twelve screens of
+  scrolling to reach the anti-scam section at the bottom; it is 6519px now.
+  Three blocks collapse: each visa card's requirements and actions, the
+  document checklist, and the anti-scam guide.
+- The split is done in CSS, not by measuring the viewport in JavaScript. The
+  panel is always in the DOM and always shown at `lg`; the control that
+  toggles it is hidden there, so `aria-expanded` never claims something is
+  collapsed on a screen where it is not. `src/components/ui/Disclosure.tsx`.
+  The breakpoint sits on a wrapper rather than on the control itself:
+  `lg:hidden` and a display utility on one element let the emitted order pick
+  the winner, and it picked `inline-flex`.
+- The migration route no longer marks a phase as the one you are on.
+  `activeRoadmapStep` started at 2, so phase two was flagged as current for
+  every visitor on every load, and tapping a card moved a marker that meant
+  nothing — the application does not know where anyone is in their process.
+  It renders as an ordered list, with the phase number in the heading for a
+  screen reader and the digit badge left decorative.
+- Each visa carries a visible link to its official source. It used to be a
+  grey text link between a vote counter and an AI button, on a screen whose
+  whole claim is that it points at official sources. A visa with no source
+  says so rather than showing nothing.
+
 ## Visual hierarchy
 
 - Type scale and spacing are consistent within screens.

--- a/src/components/GuiaMigracion.test.tsx
+++ b/src/components/GuiaMigracion.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, within } from "@testing-library/react";
 import { renderWithProviders as render } from "../test/renderWithProviders";
 import { GuiaMigracion } from "./GuiaMigracion";
+import { MIGRATION_GUIDES_DATA } from "../data/migrationGuides";
 
 describe("GuiaMigracion Component", () => {
   const defaultProps = {
@@ -39,5 +40,136 @@ describe("GuiaMigracion Component", () => {
     const askAiBtn = screen.getByRole("button", { name: /Preguntar a IA cuál me conviene/i });
     fireEvent.click(askAiBtn);
     expect(defaultProps.onAskAIAboutGuide).toHaveBeenCalledWith("España");
+  });
+  /**
+   * The route is a sequence of four phases to follow. It used to render as
+   * four buttons with `activeRoadmapStep` starting at 2, so phase two was
+   * marked as the current one on every load, for everyone — and tapping a
+   * card moved the marker, which meant nothing, because the application does
+   * not know where anyone is in their process.
+   */
+  describe("migration route", () => {
+    it("renders the phases as an ordered list", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      const step = document.getElementById("roadmap-step-1");
+      expect(step).toBeInTheDocument();
+      expect(step?.tagName).toBe("LI");
+      expect(step?.closest("ol")).not.toBeNull();
+    });
+
+    it("marks no phase as the one you are on", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      // Regression: nothing may single out a phase, since no phase can be
+      // known to be current.
+      for (const num of [1, 2, 3, 4]) {
+        const step = document.getElementById(`roadmap-step-${num}`);
+        expect(step).toBeInTheDocument();
+        expect(step?.getAttribute("aria-current")).toBeNull();
+        expect(step?.className).toBe(document.getElementById("roadmap-step-1")?.className);
+      }
+    });
+
+    it("offers nothing to click in the route", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      const list = document.getElementById("roadmap-step-1")?.closest("ol");
+      expect(list).not.toBeNull();
+      expect(within(list as HTMLElement).queryAllByRole("button")).toHaveLength(0);
+    });
+
+    it("numbers the phases for a screen reader as well as visually", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      // The digit badge is decorative; the phase number belongs to the
+      // heading, where it is announced.
+      expect(screen.getByText(/^Fase 1:/)).toBeInTheDocument();
+      expect(screen.getByText(/^Fase 4:/)).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The guides' claim is that they point at official sources. That link was a
+   * grey text link wedged between a vote counter and an AI button.
+   */
+  describe("official visa sources", () => {
+    const spanishVisas = MIGRATION_GUIDES_DATA.ES?.visas ?? [];
+
+    it("has a visa catalogue to assert against", () => {
+      expect(spanishVisas.length).toBeGreaterThan(0);
+    });
+
+    it("links every visa to its official source", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      for (const visa of spanishVisas) {
+        const link = document.getElementById(`visa-official-source-${visa.id}`);
+        const missing = document.getElementById(`visa-missing-source-${visa.id}`);
+
+        if (visa.officialSourceUrl) {
+          expect(link).toBeInTheDocument();
+          expect(link).toHaveAttribute("href", visa.officialSourceUrl);
+        } else {
+          // Never silent: a guide that promises official sources has to say
+          // when one is absent.
+          expect(missing).toBeInTheDocument();
+        }
+      }
+    });
+
+    it("opens the official source safely in a new tab", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      const withSource = spanishVisas.filter((v) => v.officialSourceUrl);
+      expect(withSource.length).toBeGreaterThan(0);
+
+      for (const visa of withSource) {
+        const link = document.getElementById(`visa-official-source-${visa.id}`);
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+        expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+      }
+    });
+
+    it("names the visa in the link, so the destination is not just 'Portal oficial'", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      const visa = spanishVisas.find((v) => v.officialSourceUrl);
+      const link = document.getElementById(`visa-official-source-${visa!.id}`);
+      expect(link).toHaveTextContent(visa!.name);
+    });
+  });
+
+  /**
+   * The guide ran to 9857px on a 375px viewport — twelve screens to reach the
+   * anti-scam section. The heavy blocks collapse on a phone now.
+   */
+  describe("density on a phone", () => {
+    it("collapses the visa details, the checklist and the anti-scam guide", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      for (const id of ["checklist-details", "antiscam-details"]) {
+        const control = document.getElementById(id);
+        expect(control, id).toBeInTheDocument();
+        expect(control).toHaveAttribute("aria-expanded", "false");
+      }
+
+      const visa = MIGRATION_GUIDES_DATA.ES?.visas?.[0];
+      expect(document.getElementById(`visa-details-${visa!.id}`)).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      );
+    });
+
+    it("expands a section when its control is used", () => {
+      render(<GuiaMigracion {...defaultProps} />);
+
+      const control = document.getElementById("checklist-details") as HTMLElement;
+      fireEvent.click(control);
+
+      expect(control).toHaveAttribute("aria-expanded", "true");
+      expect(document.getElementById("checklist-details-panel")).not.toHaveClass("hidden");
+    });
   });
 });

--- a/src/components/GuiaMigracion.tsx
+++ b/src/components/GuiaMigracion.tsx
@@ -8,6 +8,7 @@ import {
   Download,
   Bot,
   Sparkles,
+  AlertTriangle,
   ChevronRight,
   ShieldCheck,
   Building,
@@ -20,6 +21,7 @@ import { NavigationTab } from "../types";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { MIGRATION_GUIDES_DATA } from "../data/migrationGuides";
 import { COUNTRY_ANTI_SCAM_DATA } from "../data/antiScamData";
+import { Disclosure } from "./ui/Disclosure";
 import { CalendarAgendaButton } from "./CalendarAgendaButton";
 import { fetchVisaGuideVotes, voteVisaHelpful, VisaVotesData } from "../lib/firebase";
 import { usePreferences } from "../lib/PreferencesContext";
@@ -39,7 +41,6 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
   const selectedCountryCode = destinationCountryCode || "ES";
   const setSelectedCountryCode = setDestinationCountryByCode;
   const [selectedCategory, setSelectedCategory] = useState<string>("todos");
-  const [activeRoadmapStep, setActiveRoadmapStep] = useState<number>(2);
   const [visaVotes, setVisaVotes] = useState<Record<string, VisaVotesData>>({});
   const [userVotedVisas, setUserVotedVisas] = useState<Record<string, boolean>>({});
 
@@ -210,8 +211,8 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
               Ruta Migratoria y Cronograma Realista
             </h2>
             <p className="text-xs text-on-surface-variant dark:text-slate-400">
-              Fases indispensables desde la preparación en tu país hasta tus primeros días en
-              destino.
+              Las cuatro fases, en orden, desde la preparación en tu país hasta tus primeros días en
+              destino. Es la ruta que vas a recorrer, no un registro de tu avance.
             </p>
           </div>
           <div className="inline-flex items-center gap-2 bg-amber-500/10 text-amber-800 dark:text-amber-300 px-3.5 py-1.5 rounded-full text-xs font-bold self-start sm:self-auto">
@@ -221,39 +222,38 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
         </div>
 
         {/* Roadmap Steps */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {roadmapSteps.map((step) => {
-            const isActive = activeRoadmapStep === step.num;
-            return (
-              <button
-                key={step.num}
-                onClick={() => setActiveRoadmapStep(step.num)}
-                className={`p-4 rounded-2xl text-left border transition-all cursor-pointer ${
-                  isActive
-                    ? "bg-primary/10 dark:bg-sky-900/40 border-primary dark:border-sky-400 shadow-sm"
-                    : "bg-surface dark:bg-slate-900 border-outline-variant/30 dark:border-slate-800 hover:border-outline-variant"
-                }`}
+        {/*
+          An ordered list, not a set of buttons. These are four phases in a
+          fixed order, and the order is the information — but the interface
+          used to mark phase two as the current one on every load, for
+          everyone, because `activeRoadmapStep` started at 2. Tapping a card
+          moved the highlight, which meant nothing: the application does not
+          know where anyone is in their process. A marker that cannot be true
+          is worse than no marker.
+        */}
+        <ol className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {roadmapSteps.map((step) => (
+            <li
+              key={step.num}
+              id={`roadmap-step-${step.num}`}
+              className="p-4 rounded-2xl border bg-surface dark:bg-slate-900 border-outline-variant/30 dark:border-slate-800"
+            >
+              <span
+                className="w-8 h-8 mb-2 rounded-full flex items-center justify-center font-bold text-xs bg-surface-container dark:bg-slate-800 text-on-surface-variant dark:text-slate-300 tabular-nums"
+                aria-hidden="true"
               >
-                <div className="flex items-center justify-between mb-2">
-                  <span
-                    className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-xs ${
-                      isActive
-                        ? "bg-primary dark:bg-sky-500 text-white"
-                        : "bg-surface-container dark:bg-slate-800 text-on-surface-variant"
-                    }`}
-                  >
-                    0{step.num}
-                  </span>
-                  {isActive && <Sparkles className="w-4 h-4 text-primary dark:text-sky-400" />}
-                </div>
-                <h4 className="font-bold text-sm text-primary dark:text-sky-300">{step.title}</h4>
-                <p className="text-xs text-on-surface-variant dark:text-slate-400 mt-1 leading-relaxed">
-                  {step.desc}
-                </p>
-              </button>
-            );
-          })}
-        </div>
+                0{step.num}
+              </span>
+              <h4 className="font-bold text-sm text-primary dark:text-sky-300">
+                <span className="sr-only">Fase {step.num}: </span>
+                {step.title}
+              </h4>
+              <p className="text-xs text-on-surface-variant dark:text-slate-400 mt-1 leading-relaxed">
+                {step.desc}
+              </p>
+            </li>
+          ))}
+        </ol>
       </div>
 
       {/* Visas Section & Cost of Living */}
@@ -349,101 +349,125 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
                   {visa.description}
                 </p>
 
-                {/* Key Facts: Cost & Funds */}
-                {(visa.estimatedCostOfVisa || visa.proofOfFundsRequired) && (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 bg-surface/80 dark:bg-slate-900/60 p-3.5 rounded-2xl text-xs border border-outline-variant/20 dark:border-slate-800">
-                    {visa.proofOfFundsRequired && (
-                      <div className="space-y-0.5">
-                        <span className="text-on-surface-variant dark:text-slate-400 font-medium">
-                          💰 Fondos Mínimos Exigidos:
-                        </span>
-                        <p className="font-bold text-primary dark:text-sky-300">
-                          {visa.proofOfFundsRequired}
-                        </p>
-                      </div>
-                    )}
-                    {visa.estimatedCostOfVisa && (
-                      <div className="space-y-0.5">
-                        <span className="text-on-surface-variant dark:text-slate-400 font-medium">
-                          🏷️ Tasa Oficial del Trámite:
-                        </span>
-                        <p className="font-bold text-on-surface dark:text-slate-200">
-                          {visa.estimatedCostOfVisa}
-                        </p>
-                      </div>
-                    )}
-                  </div>
+                {visa.officialSourceUrl ? (
+                  <a
+                    id={`visa-official-source-${visa.id}`}
+                    href={visa.officialSourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-h-[44px] w-full sm:w-auto items-center justify-center gap-2 rounded-xl bg-primary/10 dark:bg-sky-900/40 px-4 py-2 text-xs font-bold text-primary dark:text-sky-300 hover:bg-primary hover:text-white transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4 shrink-0" aria-hidden="true" />
+                    <span>
+                      {visa.officialSourceLabel || "Portal oficial"}
+                      <span className="sr-only">
+                        {" "}
+                        de la visa {visa.name} (se abre en otra pestaña)
+                      </span>
+                    </span>
+                  </a>
+                ) : (
+                  // Visible rather than silent: a guide that claims official
+                  // sources has to say when one is missing.
+                  <p
+                    id={`visa-missing-source-${visa.id}`}
+                    className="inline-flex items-center gap-2 text-xs font-semibold text-amber-700 dark:text-amber-400"
+                  >
+                    <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
+                    Todavía no tenemos el enlace oficial de esta visa.
+                  </p>
                 )}
 
-                {/* Key Requirements List */}
-                <div className="space-y-2 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/20 dark:border-slate-800">
-                  <span className="text-xs font-bold text-primary dark:text-sky-300 uppercase tracking-wider block">
-                    Requisitos Indispensables
-                  </span>
-                  <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-on-surface-variant dark:text-slate-300">
-                    {visa.keyRequirements.map((req, idx) => (
-                      <li key={idx} className="flex items-start gap-2">
-                        <Check className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
-                        <span className="leading-snug">{req}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                {/* Funds, requirements and actions: the bulk of the card. */}
+                <Disclosure
+                  id={`visa-details-${visa.id}`}
+                  label="Ver requisitos y trámites"
+                  labelWhenOpen="Ocultar requisitos y trámites"
+                >
+                  {/* Key Facts: Cost & Funds */}
+                  {(visa.estimatedCostOfVisa || visa.proofOfFundsRequired) && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 bg-surface/80 dark:bg-slate-900/60 p-3.5 rounded-2xl text-xs border border-outline-variant/20 dark:border-slate-800">
+                      {visa.proofOfFundsRequired && (
+                        <div className="space-y-0.5">
+                          <span className="text-on-surface-variant dark:text-slate-400 font-medium">
+                            💰 Fondos Mínimos Exigidos:
+                          </span>
+                          <p className="font-bold text-primary dark:text-sky-300">
+                            {visa.proofOfFundsRequired}
+                          </p>
+                        </div>
+                      )}
+                      {visa.estimatedCostOfVisa && (
+                        <div className="space-y-0.5">
+                          <span className="text-on-surface-variant dark:text-slate-400 font-medium">
+                            🏷️ Tasa Oficial del Trámite:
+                          </span>
+                          <p className="font-bold text-on-surface dark:text-slate-200">
+                            {visa.estimatedCostOfVisa}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
 
-                {/* Action Buttons: Official Source, DB Votes, Calendar & AI */}
-                <div className="pt-2 flex flex-wrap items-center justify-between gap-3 border-t border-outline-variant/30 dark:border-slate-700">
-                  <div className="flex flex-wrap items-center gap-3">
-                    {visa.officialSourceUrl && (
-                      <a
-                        href={visa.officialSourceUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-xs font-semibold text-on-surface-variant dark:text-slate-400 hover:text-primary dark:hover:text-sky-300 flex items-center gap-1"
+                  {/* Key Requirements List */}
+                  <div className="space-y-2 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/20 dark:border-slate-800">
+                    <span className="text-xs font-bold text-primary dark:text-sky-300 uppercase tracking-wider block">
+                      Requisitos Indispensables
+                    </span>
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-on-surface-variant dark:text-slate-300">
+                      {visa.keyRequirements.map((req, idx) => (
+                        <li key={idx} className="flex items-start gap-2">
+                          <Check className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
+                          <span className="leading-snug">{req}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* Action Buttons: Official Source, DB Votes, Calendar & AI */}
+                  <div className="pt-2 flex flex-wrap items-center justify-between gap-3 border-t border-outline-variant/30 dark:border-slate-700">
+                    <div className="flex flex-wrap items-center gap-3">
+                      {/* Community Upvotes */}
+                      <button
+                        onClick={() => handleVoteVisa(visa.id)}
+                        disabled={userVotedVisas[visa.id]}
+                        title="Votar información útil"
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-bold transition-all border cursor-pointer ${
+                          userVotedVisas[visa.id]
+                            ? "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/60 dark:text-emerald-300 dark:border-emerald-800"
+                            : "bg-surface hover:bg-surface-container text-on-surface-variant dark:bg-slate-900 dark:text-slate-300 border-outline-variant/40 dark:border-slate-800"
+                        }`}
                       >
-                        <ExternalLink className="w-3.5 h-3.5" />
-                        <span>{visa.officialSourceLabel || "Portal Oficial"}</span>
-                      </a>
-                    )}
+                        <ThumbsUp
+                          className={`w-3.5 h-3.5 ${userVotedVisas[visa.id] ? "fill-current" : ""}`}
+                        />
+                        <span>{visaVotes[visa.id]?.helpfulVotes || 18} útiles</span>
+                      </button>
+                    </div>
 
-                    {/* Community Upvotes */}
-                    <button
-                      onClick={() => handleVoteVisa(visa.id)}
-                      disabled={userVotedVisas[visa.id]}
-                      title="Votar información útil"
-                      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-bold transition-all border cursor-pointer ${
-                        userVotedVisas[visa.id]
-                          ? "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/60 dark:text-emerald-300 dark:border-emerald-800"
-                          : "bg-surface hover:bg-surface-container text-on-surface-variant dark:bg-slate-900 dark:text-slate-300 border-outline-variant/40 dark:border-slate-800"
-                      }`}
-                    >
-                      <ThumbsUp
-                        className={`w-3.5 h-3.5 ${userVotedVisas[visa.id] ? "fill-current" : ""}`}
+                    <div className="flex flex-wrap items-center gap-2">
+                      {/* Calendar Agenda Button */}
+                      <CalendarAgendaButton
+                        variant="compact"
+                        label="Agendar Cita"
+                        event={{
+                          title: `Cita / Trámite Visa: ${visa.name} (${guide.country})`,
+                          details: `Recordatorio de cita y entrega de expediente para la visa ${visa.name} en ${guide.country}.\n\nRequisitos clave: \n- ${visa.keyRequirements.join("\n- ")}\n\nFondos requeridos: ${visa.proofOfFundsRequired || "N/A"}\nPortal oficial: ${visa.officialSourceUrl || "LatinoMigra"}`,
+                          location: `Consulado / Centro de Visas de ${guide.country}`,
+                        }}
                       />
-                      <span>{visaVotes[visa.id]?.helpfulVotes || 18} útiles</span>
-                    </button>
-                  </div>
 
-                  <div className="flex flex-wrap items-center gap-2">
-                    {/* Calendar Agenda Button */}
-                    <CalendarAgendaButton
-                      variant="compact"
-                      label="Agendar Cita"
-                      event={{
-                        title: `Cita / Trámite Visa: ${visa.name} (${guide.country})`,
-                        details: `Recordatorio de cita y entrega de expediente para la visa ${visa.name} en ${guide.country}.\n\nRequisitos clave: \n- ${visa.keyRequirements.join("\n- ")}\n\nFondos requeridos: ${visa.proofOfFundsRequired || "N/A"}\nPortal oficial: ${visa.officialSourceUrl || "LatinoMigra"}`,
-                        location: `Consulado / Centro de Visas de ${guide.country}`,
-                      }}
-                    />
-
-                    <button
-                      onClick={() => onAskAIAboutGuide(guide.country, visa.name)}
-                      className="inline-flex items-center gap-1.5 text-xs font-bold bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 hover:bg-primary hover:text-white px-3.5 py-1.5 rounded-lg transition-colors cursor-pointer"
-                    >
-                      <Bot className="w-3.5 h-3.5" />
-                      <span>Consultar con IA</span>
-                    </button>
+                      <button
+                        onClick={() => onAskAIAboutGuide(guide.country, visa.name)}
+                        className="inline-flex items-center gap-1.5 text-xs font-bold bg-primary/10 dark:bg-sky-900/40 text-primary dark:text-sky-300 hover:bg-primary hover:text-white px-3.5 py-1.5 rounded-lg transition-colors cursor-pointer"
+                      >
+                        <Bot className="w-3.5 h-3.5" />
+                        <span>Consultar con IA</span>
+                      </button>
+                    </div>
                   </div>
-                </div>
+                </Disclosure>
               </div>
             ))}
           </div>
@@ -547,43 +571,49 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
           </button>
         </div>
 
-        {/* Interactive Checklist Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {guide.documents.map((doc) => {
-            const isChecked = docState[doc.id] ?? false;
-            return (
-              <div
-                key={doc.id}
-                onClick={() => toggleDoc(doc.id)}
-                className={`p-4 rounded-2xl border transition-all cursor-pointer flex items-start gap-3.5 ${
-                  isChecked
-                    ? "bg-emerald-500/10 border-emerald-500/40 text-emerald-950 dark:text-emerald-200"
-                    : "bg-surface dark:bg-slate-900 border-outline-variant/30 dark:border-slate-800 hover:border-outline-variant"
-                }`}
-              >
-                <div className="pt-0.5 shrink-0">
-                  {isChecked ? (
-                    <CheckCircle2 className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-                  ) : (
-                    <Circle className="w-5 h-5 text-on-surface-variant dark:text-slate-500" />
-                  )}
+        <Disclosure
+          id="checklist-details"
+          label="Ver la lista de documentos"
+          labelWhenOpen="Ocultar la lista de documentos"
+        >
+          {/* Interactive Checklist Grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {guide.documents.map((doc) => {
+              const isChecked = docState[doc.id] ?? false;
+              return (
+                <div
+                  key={doc.id}
+                  onClick={() => toggleDoc(doc.id)}
+                  className={`p-4 rounded-2xl border transition-all cursor-pointer flex items-start gap-3.5 ${
+                    isChecked
+                      ? "bg-emerald-500/10 border-emerald-500/40 text-emerald-950 dark:text-emerald-200"
+                      : "bg-surface dark:bg-slate-900 border-outline-variant/30 dark:border-slate-800 hover:border-outline-variant"
+                  }`}
+                >
+                  <div className="pt-0.5 shrink-0">
+                    {isChecked ? (
+                      <CheckCircle2 className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                    ) : (
+                      <Circle className="w-5 h-5 text-on-surface-variant dark:text-slate-500" />
+                    )}
+                  </div>
+                  <div className="space-y-0.5">
+                    <h4
+                      className={`font-bold text-sm ${
+                        isChecked ? "line-through opacity-80" : "text-primary dark:text-sky-300"
+                      }`}
+                    >
+                      {doc.title}
+                    </h4>
+                    <p className="text-xs text-on-surface-variant dark:text-slate-400 leading-relaxed">
+                      {doc.subtitle}
+                    </p>
+                  </div>
                 </div>
-                <div className="space-y-0.5">
-                  <h4
-                    className={`font-bold text-sm ${
-                      isChecked ? "line-through opacity-80" : "text-primary dark:text-sky-300"
-                    }`}
-                  >
-                    {doc.title}
-                  </h4>
-                  <p className="text-xs text-on-surface-variant dark:text-slate-400 leading-relaxed">
-                    {doc.subtitle}
-                  </p>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        </Disclosure>
       </div>
 
       {/* Dynamic Country-Specific Anti-Scam Guide Section */}
@@ -624,60 +654,66 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
             </div>
           </div>
 
-          {/* Housing & Rental Safety Advice */}
-          <div className="p-4 bg-white/80 dark:bg-slate-900/80 rounded-2xl border border-rose-200 dark:border-slate-800 text-xs space-y-1.5">
-            <h4 className="font-bold text-primary dark:text-sky-300 flex items-center gap-2">
-              <Building className="w-4 h-4 text-secondary" />
-              <span>
-                Reglas de Oro para Alquiler Seguro en{" "}
-                {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].country}:
-              </span>
-            </h4>
-            <p className="text-on-surface-variant dark:text-slate-300 leading-relaxed">
-              {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].officialRentalPortalInfo}
-            </p>
-          </div>
+          <Disclosure
+            id="antiscam-details"
+            label="Ver estafas frecuentes y cómo denunciar"
+            labelWhenOpen="Ocultar estafas frecuentes"
+          >
+            {/* Housing & Rental Safety Advice */}
+            <div className="p-4 bg-white/80 dark:bg-slate-900/80 rounded-2xl border border-rose-200 dark:border-slate-800 text-xs space-y-1.5">
+              <h4 className="font-bold text-primary dark:text-sky-300 flex items-center gap-2">
+                <Building className="w-4 h-4 text-secondary" />
+                <span>
+                  Reglas de Oro para Alquiler Seguro en{" "}
+                  {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].country}:
+                </span>
+              </h4>
+              <p className="text-on-surface-variant dark:text-slate-300 leading-relaxed">
+                {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].officialRentalPortalInfo}
+              </p>
+            </div>
 
-          {/* Common Scams Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].keyScamAlerts.map((scam, i) => (
-              <div
-                key={i}
-                className="bg-white dark:bg-slate-900 p-5 rounded-2xl border border-rose-200/80 dark:border-rose-900/40 space-y-3 shadow-xs"
-              >
-                <div className="font-bold text-sm text-rose-950 dark:text-rose-200 flex items-start gap-2">
-                  <span className="text-rose-600 font-black">⚠️</span>
-                  <span>{scam.scamType}</span>
-                </div>
-
-                <div className="space-y-1 text-xs">
-                  <div className="font-bold text-on-surface dark:text-slate-200">
-                    Señal de Alerta:
+            {/* Common Scams Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].keyScamAlerts.map((scam, i) => (
+                <div
+                  key={i}
+                  className="bg-white dark:bg-slate-900 p-5 rounded-2xl border border-rose-200/80 dark:border-rose-900/40 space-y-3 shadow-xs"
+                >
+                  <div className="font-bold text-sm text-rose-950 dark:text-rose-200 flex items-start gap-2">
+                    <span className="text-rose-600 font-black">⚠️</span>
+                    <span>{scam.scamType}</span>
                   </div>
-                  <p className="text-on-surface-variant dark:text-slate-400 leading-relaxed italic">
-                    "{scam.warningSign}"
-                  </p>
-                </div>
 
-                <div className="space-y-1 text-xs pt-1 border-t border-rose-100 dark:border-slate-800">
-                  <div className="font-bold text-emerald-700 dark:text-emerald-400 flex items-center gap-1">
-                    <ShieldCheck className="w-3.5 h-3.5" />
-                    <span>Cómo Protegerte:</span>
+                  <div className="space-y-1 text-xs">
+                    <div className="font-bold text-on-surface dark:text-slate-200">
+                      Señal de Alerta:
+                    </div>
+                    <p className="text-on-surface-variant dark:text-slate-400 leading-relaxed italic">
+                      "{scam.warningSign}"
+                    </p>
                   </div>
-                  <p className="text-on-surface dark:text-slate-300 leading-relaxed font-medium">
-                    {scam.howToProtect}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
 
-          <div className="text-xs text-on-surface-variant dark:text-slate-400 flex items-center gap-1.5 pt-1">
-            <span>Organismo oficial de defensa al consumidor: </span>
-            <strong className="text-primary dark:text-sky-300">
-              {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].officialConsumerProtectionAgency}
-            </strong>
-          </div>
+                  <div className="space-y-1 text-xs pt-1 border-t border-rose-100 dark:border-slate-800">
+                    <div className="font-bold text-emerald-700 dark:text-emerald-400 flex items-center gap-1">
+                      <ShieldCheck className="w-3.5 h-3.5" />
+                      <span>Cómo Protegerte:</span>
+                    </div>
+                    <p className="text-on-surface dark:text-slate-300 leading-relaxed font-medium">
+                      {scam.howToProtect}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="text-xs text-on-surface-variant dark:text-slate-400 flex items-center gap-1.5 pt-1">
+              <span>Organismo oficial de defensa al consumidor: </span>
+              <strong className="text-primary dark:text-sky-300">
+                {COUNTRY_ANTI_SCAM_DATA[selectedCountryCode].officialConsumerProtectionAgency}
+              </strong>
+            </div>
+          </Disclosure>
         </div>
       )}
     </div>

--- a/src/components/ui/Disclosure.test.tsx
+++ b/src/components/ui/Disclosure.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders as render } from "../../test/renderWithProviders";
+import { Disclosure } from "./Disclosure";
+
+describe("Disclosure", () => {
+  const content = "Contenido plegable";
+
+  it("starts closed, with the panel hidden and the control saying so", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles">
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    const control = screen.getByRole("button", { name: /Ver detalles/i });
+    expect(control).toHaveAttribute("aria-expanded", "false");
+
+    // The panel stays in the DOM: it is shown by CSS at `lg`, where the
+    // control is not rendered at all. Only its classes change.
+    const panel = document.getElementById("test-disclosure-panel");
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveClass("hidden");
+    expect(panel).toHaveClass("lg:block");
+  });
+
+  it("points the control at the panel it controls", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles">
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    const control = screen.getByRole("button", { name: /Ver detalles/i });
+    expect(control).toHaveAttribute("aria-controls", "test-disclosure-panel");
+    expect(document.getElementById("test-disclosure-panel")).toBeInTheDocument();
+  });
+
+  it("opens and closes on click, and changes its own label", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles" labelWhenOpen="Ocultar detalles">
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    const control = screen.getByRole("button", { name: /Ver detalles/i });
+    fireEvent.click(control);
+
+    expect(control).toHaveAttribute("aria-expanded", "true");
+    expect(control).toHaveTextContent(/Ocultar detalles/i);
+    expect(document.getElementById("test-disclosure-panel")).not.toHaveClass("hidden");
+
+    fireEvent.click(control);
+    expect(control).toHaveAttribute("aria-expanded", "false");
+    expect(control).toHaveTextContent(/Ver detalles/i);
+  });
+
+  it("keeps the label when no open label is given", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles">
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    const control = screen.getByRole("button", { name: /Ver detalles/i });
+    fireEvent.click(control);
+    expect(control).toHaveTextContent(/Ver detalles/i);
+  });
+
+  it("can start open", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles" defaultOpen>
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    expect(screen.getByRole("button", { name: /Ver detalles/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(document.getElementById("test-disclosure-panel")).not.toHaveClass("hidden");
+  });
+
+  it("hides the control from wide screens rather than the panel", () => {
+    render(
+      <Disclosure id="test-disclosure" label="Ver detalles">
+        <p>{content}</p>
+      </Disclosure>
+    );
+
+    // `lg:hidden` and a display utility on the same element let the emitted
+    // order decide the winner, and it picked the wrong one once already. The
+    // breakpoint belongs to a wrapper that sets nothing else.
+    const control = screen.getByRole("button", { name: /Ver detalles/i });
+    expect(control).not.toHaveClass("lg:hidden");
+    expect(control.parentElement).toHaveClass("lg:hidden");
+  });
+
+  it("gives each instance its own panel id when none is supplied", () => {
+    render(
+      <>
+        <Disclosure label="Primero">
+          <p>uno</p>
+        </Disclosure>
+        <Disclosure label="Segundo">
+          <p>dos</p>
+        </Disclosure>
+      </>
+    );
+
+    const [first, second] = screen.getAllByRole("button");
+    expect(first.getAttribute("aria-controls")).not.toBe(second.getAttribute("aria-controls"));
+  });
+});

--- a/src/components/ui/Disclosure.tsx
+++ b/src/components/ui/Disclosure.tsx
@@ -1,0 +1,71 @@
+import React, { useId, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+interface DisclosureProps {
+  /** Spanish label for the control, e.g. "Ver requisitos". */
+  label: string;
+  /** Label once open. Defaults to `label`. */
+  labelWhenOpen?: string;
+  children: React.ReactNode;
+  /** Open on first render. */
+  defaultOpen?: boolean;
+  /** Prefix for the control's `id`, so E2E can target it. */
+  id?: string;
+}
+
+/**
+ * Collapses long content on a phone and leaves it open on a wide screen.
+ *
+ * The guides run to 9857px on a 375px viewport — twelve screens of scrolling
+ * to reach the anti-scam section at the bottom. Collapsing helps there and
+ * only there: on a desktop, where the same content occupies a fraction of the
+ * page, hiding it behind a control would be a step backwards.
+ *
+ * That breakpoint split is done in CSS rather than by measuring the viewport
+ * in JavaScript. The panel is always in the DOM and always rendered at `lg`;
+ * only below `lg` does the open state control it. So the control itself is
+ * hidden at `lg`, and its `aria-expanded` never claims something is collapsed
+ * on a screen where it is not.
+ */
+export const Disclosure: React.FC<DisclosureProps> = ({
+  label,
+  labelWhenOpen,
+  children,
+  defaultOpen = false,
+  id,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const generatedId = useId();
+  const panelId = `${id ?? generatedId}-panel`;
+
+  return (
+    <div className="space-y-3">
+      {/*
+        The breakpoint lives on the wrapper, not on the button. `lg:hidden`
+        and `inline-flex` both set `display`, and putting them on one element
+        makes the result depend on which utility Tailwind emits last — it
+        emitted `inline-flex`, so the control stayed visible on desktop.
+      */}
+      <div className="lg:hidden">
+        <button
+          type="button"
+          id={id}
+          onClick={() => setOpen((prev) => !prev)}
+          aria-expanded={open}
+          aria-controls={panelId}
+          className="flex w-full min-h-[44px] items-center justify-between gap-2 rounded-xl border border-outline-variant/40 dark:border-slate-700 bg-surface dark:bg-slate-900 px-3.5 py-2 text-xs font-bold text-primary dark:text-sky-300 cursor-pointer active:scale-[0.99] transition-transform"
+        >
+          <span>{open ? (labelWhenOpen ?? label) : label}</span>
+          <ChevronDown
+            className={`w-4 h-4 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+
+      <div id={panelId} className={`${open ? "block" : "hidden"} lg:block space-y-4`}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/tests/e2e/guias.mobile.spec.ts
+++ b/tests/e2e/guias.mobile.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The migration guides on a phone.
+ *
+ * Measured before this suite existed: the guide ran to 9857px inside a 375px
+ * viewport — twelve screens of scrolling to reach the anti-scam section at the
+ * bottom. Three blocks now collapse below `lg`, and the collapse is done in
+ * CSS so the same content stays open on a desktop.
+ *
+ * These are end-to-end tests because that is a breakpoint decision: only a
+ * real layout engine resolves which of `lg:hidden` and a display utility wins,
+ * and it picked the wrong one on the first attempt.
+ */
+
+const GUIDE_DISCLOSURES = ["checklist-details", "antiscam-details"];
+
+test.describe("Migration guides on a phone", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#bottom-nav-guia").click();
+    await expect(page.locator("#roadmap-step-1")).toBeVisible();
+  });
+
+  test("collapses the heavy sections", async ({ page }) => {
+    for (const id of GUIDE_DISCLOSURES) {
+      const control = page.locator(`#${id}`);
+      await expect(control, id).toBeVisible();
+      await expect(control).toHaveAttribute("aria-expanded", "false");
+      await expect(page.locator(`#${id}-panel`)).toBeHidden();
+    }
+  });
+
+  test("opens a section on tap and closes it again", async ({ page }) => {
+    const control = page.locator("#checklist-details");
+    const panel = page.locator("#checklist-details-panel");
+
+    await control.click();
+    await expect(control).toHaveAttribute("aria-expanded", "true");
+    await expect(panel).toBeVisible();
+
+    await control.click();
+    await expect(control).toHaveAttribute("aria-expanded", "false");
+    await expect(panel).toBeHidden();
+  });
+
+  test("is materially shorter than the same guide fully expanded", async ({ page }) => {
+    const collapsed = await page.evaluate(() => document.documentElement.scrollHeight);
+
+    for (const id of GUIDE_DISCLOSURES) {
+      await page.locator(`#${id}`).click();
+    }
+    for (const control of await page.locator('button[id^="visa-details-"]').all()) {
+      await control.click();
+    }
+
+    const expanded = await page.evaluate(() => document.documentElement.scrollHeight);
+
+    // A collapse that saves nothing is decoration. The guide was twelve
+    // screens tall; it has to be meaningfully less than the open version.
+    expect(collapsed).toBeLessThan(expanded * 0.8);
+  });
+
+  test("reaches every control by keyboard and reports its state", async ({ page }) => {
+    const control = page.locator("#checklist-details");
+    await control.focus();
+    await expect(control).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await expect(control).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#checklist-details-panel")).toBeVisible();
+  });
+
+  test("gives every visa a visible link to its official source", async ({ page }) => {
+    const links = page.locator('a[id^="visa-official-source-"]');
+    const count = await links.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i += 1) {
+      const link = links.nth(i);
+      await expect(link).toBeVisible();
+      await expect(link).toHaveAttribute("href", /^https?:\/\//);
+      await expect(link).toHaveAttribute("target", "_blank");
+      // `noopener` matters: without it the opened page can reach back
+      // through `window.opener`.
+      await expect(link).toHaveAttribute("rel", /noopener/);
+    }
+  });
+
+  test("marks no phase of the route as the one you are on", async ({ page }) => {
+    // Regression: `activeRoadmapStep` started at 2, so phase two was flagged
+    // as current for every visitor, and tapping moved a marker that meant
+    // nothing.
+    const classNames = await page.evaluate(() =>
+      [1, 2, 3, 4].map((n) => document.getElementById(`roadmap-step-${n}`)?.className ?? null)
+    );
+
+    expect(classNames.every((c) => c !== null)).toBe(true);
+    expect(new Set(classNames).size).toBe(1);
+    await expect(page.locator("#roadmap-step-1").locator("xpath=ancestor::ol")).toHaveCount(1);
+  });
+});
+
+test.describe("Migration guides on a wide screen", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("shows the content with no collapse control at all", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#nav-item-guia").click();
+    await expect(page.locator("#roadmap-step-1")).toBeVisible();
+
+    for (const id of GUIDE_DISCLOSURES) {
+      await expect(page.locator(`#${id}`), id).toBeHidden();
+      await expect(page.locator(`#${id}-panel`), `${id}-panel`).toBeVisible();
+    }
+
+    // The visa cards too: nothing on a desktop should be behind a control.
+    await expect(page.locator('button[id^="visa-details-"]:visible')).toHaveCount(0);
+    await expect(page.locator("#checklist-details-panel")).toContainText(/Pasaporte/i);
+  });
+});


### PR DESCRIPTION
Closes #54.

## Three problems on one screen

### The route claimed to know where you are

`activeRoadmapStep` started at `2`, so phase two was marked as the current one on every load, for every visitor. Tapping a card moved the marker — which meant nothing, because the application has no idea where anyone is in their process.

A marker that cannot be true is worse than no marker. The four phases render as an ordered list now. The order is real information and stays; the phase number moves into the heading where a screen reader announces it, and the digit badge is left decorative.

### The official source was hard to find

All 24 visas already carry `officialSourceUrl` — the data was never the problem. It was rendered as a grey text link wedged between a vote counter and an AI button, on a screen whose entire claim is that it points at official sources.

It is now a full-width action that names the visa it leads to, opening with `noopener noreferrer`. A visa with no source says so, rather than silently rendering nothing.

### It was twelve screens tall

| | before | after |
|---|---|---|
| page height at 375px | **9857px** (12.1 screens) | **6519px** (8.0 screens) |
| collapse controls on mobile | — | 6 |
| collapse controls at 1280px | — | 0 |

Three blocks collapse below `lg`: each visa's requirements and actions, the document checklist, and the anti-scam guide.

The collapse is CSS, not a viewport measured in JavaScript. The panel is always in the DOM and always open at `lg`, and the control is hidden there — so `aria-expanded` never claims something is collapsed on a screen where it is not.

One thing worth knowing for the next component: the breakpoint sits on a wrapper, not on the control. `lg:hidden` and a display utility on the same element let the emitted order decide the winner, and Tailwind emitted `inline-flex`. The control stayed visible on desktop until it was measured in a browser.

## Tests

**Unit — `Disclosure.test.tsx` (7)**: default closed, `aria-controls` wiring, toggling, the open label, `defaultOpen`, unique ids per instance, and that the breakpoint is on the wrapper rather than the control.

**Unit — `GuiaMigracion.test.tsx` (10 new)**: the route is an ordered list, no phase is singled out, nothing in it is clickable, phases are numbered for a screen reader; every visa links to its own official source, safely, and names the visa; the three blocks start collapsed and open on click.

**E2E — `guias.mobile.spec.ts` (7)**, because a breakpoint is resolved by a layout engine and jsdom has none: sections collapsed on a phone, tap to open and close, keyboard reachable, the collapsed page under 80% of the expanded one, every official link visible with `noopener`, no phase marked, and at 1280px no control at all with the content visible.

Both the desktop-visibility case and the route case were confirmed to **fail** against the previous code before being kept.

```
150 unit tests passed
51 Playwright tests passed
lint: 0 errors, 35 warnings (at the ratchet)
```

## Documentation

`docs/ux.md` gains a **Migration guides** section with the measurements and the wrapper-breakpoint note.

## Out of scope

The visa card's own density beyond the collapse, and the AI button — the guides equivalent of #53 — are not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_