### PR TITLE
fix(becas): one way through the catalogue, and covers that fail visibly

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -131,6 +131,23 @@ Recently addressed and verified by tests:
 - Dismissing the drawer restores the reading position instead of jumping to the
   top.
 
+## Scholarship list
+
+- One way through the catalogue. The screen carried a numbered pager and a
+  "load more" button behind a mode switch, plus a page-size selector — three
+  controls doing one job, and on a phone the numbered pager was a row of tap
+  targets nobody asked for. Lazy loading is what remains: `LOAD_BATCH_SIZE`
+  convocatorias at a time, a progress bar that announces itself, and an
+  explicit end state.
+- Changing a filter resets to the first batch. What was loaded before the
+  change says nothing about what matches after it.
+- A cover image that fails to load renders a labelled placeholder rather than
+  the browser's broken-image glyph, which reads as the application being
+  broken instead of one picture being gone.
+  `src/components/ui/ImageWithFallback.tsx`. An empty `src` counts as a
+  failure: the browser would otherwise resolve it against the page URL and
+  fetch the document itself.
+
 ## Migration guides
 
 - The guide collapses its heavy blocks below `lg` and leaves them open above

--- a/src/components/BecasExplorer.test.tsx
+++ b/src/components/BecasExplorer.test.tsx
@@ -64,51 +64,86 @@ describe("BecasExplorer Component", () => {
     expect(screen.getByText(/Sugerir Beca Universitaria/i)).toBeInTheDocument();
   });
 
-  it("renders pagination controls and navigates between pages", () => {
-    render(<BecasExplorer {...defaultProps} />);
+  /**
+   * The screen used to carry a numbered pager and a "load more" button behind
+   * a mode switch, plus a page-size selector — three controls doing one job.
+   * On a phone the numbered pager was a row of tap targets nobody asked for.
+   */
+  describe("paging through the catalogue", () => {
+    it("offers exactly one way to see more", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
 
-    // Page 1 should be active initially with 6 cards displayed
-    const page1Btn = screen.getByRole("button", { name: "1" });
-    expect(page1Btn).toHaveAttribute("aria-current", "page");
+      expect(container.querySelector("#btn-load-more-scholarships")).toBeInTheDocument();
+      expect(container.querySelector("#pagination-first-page")).toBeNull();
+      expect(container.querySelector("#pagination-prev-page")).toBeNull();
+      expect(container.querySelector("#mode-paginated-btn")).toBeNull();
+      expect(container.querySelector("#mode-lazy-btn")).toBeNull();
+      expect(container.querySelector('[id^="items-per-page-"]')).toBeNull();
+    });
 
-    // Check next page button
-    const nextBtn = screen.getByRole("button", { name: /Siguiente/i });
-    expect(nextBtn).toBeInTheDocument();
-    expect(nextBtn).not.toBeDisabled();
+    it("starts with one batch and says how much of the catalogue that is", () => {
+      render(<BecasExplorer {...defaultProps} />);
 
-    // Click next page
-    fireEvent.click(nextBtn);
-    const page2Btn = screen.getByRole("button", { name: "2" });
-    expect(page2Btn).toHaveAttribute("aria-current", "page");
-  });
+      expect(screen.getByText(/Mostrando/)).toHaveTextContent(/6.*de.*22 convocatorias/);
+      expect(screen.getAllByRole("button", { name: /Ver Detalles/i })).toHaveLength(6);
+    });
 
-  it("supports lazy loading / carga diferida mode and loading more items", () => {
-    render(<BecasExplorer {...defaultProps} />);
+    it("adds a batch on each request and says how many that will be", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
 
-    // Switch to Carga Diferida mode
-    const lazyModeBtn = screen.getByRole("button", { name: /Carga Diferida/i });
-    fireEvent.click(lazyModeBtn);
+      const loadMore = container.querySelector("#btn-load-more-scholarships") as HTMLElement;
+      expect(loadMore).toHaveTextContent(/\+6/);
 
-    // Look for the "Cargar Más Convocatorias" button
-    const loadMoreBtn = screen.getByRole("button", { name: /Cargar Más Convocatorias/i });
-    expect(loadMoreBtn).toBeInTheDocument();
+      fireEvent.click(loadMore);
+      expect(screen.getAllByRole("button", { name: /Ver Detalles/i })).toHaveLength(12);
+    });
 
-    // Click load more
-    fireEvent.click(loadMoreBtn);
-    expect(screen.getByText(/Progreso de carga/i)).toBeInTheDocument();
-  });
+    it("never promises more than is left", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
 
-  it("changes items per page when selecting size option", () => {
-    const { container } = render(<BecasExplorer {...defaultProps} />);
+      // 22 scholarships: the first batch is 6, two more take it to 18, and
+      // the button then has to offer the remaining 4 rather than a full batch.
+      for (let i = 0; i < 2; i += 1) {
+        fireEvent.click(container.querySelector("#btn-load-more-scholarships") as HTMLElement);
+      }
+      expect(container.querySelector("#btn-load-more-scholarships")).toHaveTextContent(/\+4/);
+    });
 
-    // Click on "Todas" items per page button by ID
-    const allBtn = container.querySelector("#items-per-page-all");
-    expect(allBtn).toBeInTheDocument();
-    if (allBtn) {
-      fireEvent.click(allBtn);
-    }
+    it("reports the end instead of a button that would add nothing", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
 
-    expect(screen.getByText(/Mostrando todas las/i)).toBeInTheDocument();
+      for (let i = 0; i < 4; i += 1) {
+        const more = container.querySelector("#btn-load-more-scholarships");
+        if (more) fireEvent.click(more as HTMLElement);
+      }
+
+      expect(container.querySelector("#btn-load-more-scholarships")).toBeNull();
+      expect(screen.getByText(/Has llegado al final de las 22 convocatorias/i)).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "22");
+    });
+
+    it("goes back to the first batch when the filters change", () => {
+      const { container } = render(<BecasExplorer {...defaultProps} />);
+
+      fireEvent.click(container.querySelector("#btn-load-more-scholarships") as HTMLElement);
+      expect(screen.getAllByRole("button", { name: /Ver Detalles/i })).toHaveLength(12);
+
+      // What was loaded before a filter changed says nothing about what
+      // matches after it.
+      fireEvent.click(container.querySelector("#country-chip-España") as HTMLElement);
+      expect(screen.getAllByRole("button", { name: /Ver Detalles/i }).length).toBeLessThanOrEqual(
+        6
+      );
+    });
+
+    it("announces loading progress rather than only drawing a bar", () => {
+      render(<BecasExplorer {...defaultProps} />);
+
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAccessibleName(/Progreso de carga/i);
+      expect(bar).toHaveAttribute("aria-valuenow", "6");
+      expect(bar).toHaveAttribute("aria-valuemax", "22");
+    });
   });
 
   it("toggles favorites in memory and filters by My Favorites section", async () => {

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -19,12 +19,7 @@ import {
   Award,
   PlusCircle,
   Send,
-  ChevronLeft,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
   ArrowDownCircle,
-  Layers,
   SlidersHorizontal,
   RefreshCw,
   BookOpen,
@@ -48,6 +43,7 @@ import {
 import { usePreferences } from "../lib/PreferencesContext";
 import { FilterChipGroup } from "./ui/FilterChipGroup";
 import { Modal } from "./ui/Modal";
+import { ImageWithFallback } from "./ui/ImageWithFallback";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card";
@@ -77,6 +73,9 @@ function daysUntil(deadline: string): number | null {
   today.setHours(0, 0, 0, 0);
   return Math.round((target.getTime() - today.getTime()) / 86_400_000);
 }
+
+/** How many convocatorias each "Cargar más" adds. */
+const LOAD_BATCH_SIZE = 6;
 
 /** Long enough for a slow connection, short enough to not look frozen. */
 const CATALOGUE_FETCH_TIMEOUT_MS = 8000;
@@ -270,11 +269,11 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
   });
   const [suggestSuccess, setSuggestSuccess] = useState<boolean>(false);
 
-  // Pagination & Lazy Loading State
-  const [itemsPerPage, setItemsPerPage] = useState<number>(6);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [visibleCount, setVisibleCount] = useState<number>(6);
-  const [displayMode, setDisplayMode] = useState<"paginated" | "continuous">("paginated");
+  /**
+   * How many convocatorias are on screen. The list loads more on request and
+   * never paginates: one way through the catalogue, not two behind a switch.
+   */
+  const [visibleCount, setVisibleCount] = useState<number>(LOAD_BATCH_SIZE);
   const mainListRef = useRef<HTMLDivElement>(null);
 
   const countries = [
@@ -375,8 +374,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     setSelectedDateRange("Todas");
     setSortBy("deadline-asc");
     setSearchQuery("");
-    setCurrentPage(1);
-    setVisibleCount(itemsPerPage > 0 ? itemsPerPage : 6);
+    setVisibleCount(LOAD_BATCH_SIZE);
   };
 
   /**
@@ -644,10 +642,10 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     // as well only risks the two lists drifting apart.
   }, [scholarshipsList, viewModeTab, favorites, matchesFilters, sortBy]);
 
-  // Reset pagination when viewModeTab, filters, sort or pageSize change
+  // Start from the top of the catalogue whenever the filters change: what was
+  // loaded before the change says nothing about what matches after it.
   useEffect(() => {
-    setCurrentPage(1);
-    setVisibleCount(itemsPerPage > 0 ? itemsPerPage : filteredScholarships.length);
+    setVisibleCount(LOAD_BATCH_SIZE);
   }, [
     viewModeTab,
     searchQuery,
@@ -658,35 +656,28 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     selectedInstitutionType,
     selectedDateRange,
     sortBy,
-    itemsPerPage,
   ]);
 
-  const totalPages =
-    itemsPerPage > 0 ? Math.max(1, Math.ceil(filteredScholarships.length / itemsPerPage)) : 1;
-  const validCurrentPage = Math.min(Math.max(1, currentPage), totalPages);
+  const displayedScholarships = useMemo(
+    () => filteredScholarships.slice(0, visibleCount),
+    [filteredScholarships, visibleCount]
+  );
 
-  const displayedScholarships = useMemo(() => {
-    if (displayMode === "continuous") {
-      return filteredScholarships.slice(0, visibleCount);
-    }
-    if (itemsPerPage === 0) {
-      return filteredScholarships;
-    }
-    const startIdx = (validCurrentPage - 1) * itemsPerPage;
-    return filteredScholarships.slice(startIdx, startIdx + itemsPerPage);
-  }, [filteredScholarships, displayMode, visibleCount, itemsPerPage, validCurrentPage]);
+  /** How many the next tap would add — the button says so rather than guessing. */
+  const nextBatchSize = Math.min(
+    LOAD_BATCH_SIZE,
+    filteredScholarships.length - displayedScholarships.length
+  );
 
-  const handlePageChange = (page: number) => {
-    const targetPage = Math.min(Math.max(1, page), totalPages);
-    setCurrentPage(targetPage);
-    if (mainListRef.current) {
-      mainListRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  };
+  // An empty catalogue is fully loaded, not 0% loaded: dividing by zero here
+  // put NaN in the progress readout and in the bar's width.
+  const loadedPercentage =
+    filteredScholarships.length === 0
+      ? 100
+      : Math.round((displayedScholarships.length / filteredScholarships.length) * 100);
 
   const handleLoadMore = () => {
-    const step = itemsPerPage > 0 ? itemsPerPage : 6;
-    setVisibleCount((prev) => Math.min(prev + step, filteredScholarships.length));
+    setVisibleCount((prev) => Math.min(prev + LOAD_BATCH_SIZE, filteredScholarships.length));
   };
 
   const handleSuggestSubmit = (e: React.FormEvent) => {
@@ -1157,101 +1148,23 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                 )}
               </div>
 
-              {/* List Toolbar: Counters, Items Per Page & Display Mode */}
-              <div className="bg-surface-container-lowest dark:bg-slate-800 p-4 rounded-2xl border border-outline-variant/40 dark:border-slate-700 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                <div className="flex items-center gap-3 text-xs md:text-sm text-on-surface-variant dark:text-slate-300">
-                  <span>
-                    {filteredScholarships.length === 0 ? (
-                      "0 convocatorias encontradas"
-                    ) : displayMode === "continuous" ? (
-                      <>
-                        Mostrando <strong>{displayedScholarships.length}</strong> de{" "}
-                        <strong>{filteredScholarships.length}</strong> convocatorias
-                      </>
-                    ) : itemsPerPage === 0 ? (
-                      <>
-                        Mostrando todas las <strong>{filteredScholarships.length}</strong>{" "}
-                        convocatorias
-                      </>
-                    ) : (
-                      <>
-                        Mostrando{" "}
-                        <strong>
-                          {Math.min(
-                            (validCurrentPage - 1) * itemsPerPage + 1,
-                            filteredScholarships.length
-                          )}
-                          –{Math.min(validCurrentPage * itemsPerPage, filteredScholarships.length)}
-                        </strong>{" "}
-                        de <strong>{filteredScholarships.length}</strong> convocatorias
-                      </>
-                    )}
+              {/* List Toolbar: how much of the catalogue is on screen. */}
+              <div className="bg-surface-container-lowest dark:bg-slate-800 p-4 rounded-2xl border border-outline-variant/40 dark:border-slate-700 flex flex-wrap items-center gap-3">
+                <span className="text-xs md:text-sm text-on-surface-variant dark:text-slate-300">
+                  {filteredScholarships.length === 0 ? (
+                    "0 convocatorias encontradas"
+                  ) : (
+                    <>
+                      Mostrando <strong>{displayedScholarships.length}</strong> de{" "}
+                      <strong>{filteredScholarships.length}</strong> convocatorias
+                    </>
+                  )}
+                </span>
+                {favorites.length > 0 && (
+                  <span className="text-secondary dark:text-teal-300 font-semibold bg-secondary/10 dark:bg-teal-900/30 px-2 py-0.5 rounded-full text-xs">
+                    ♥ {favorites.length} guardadas
                   </span>
-                  {favorites.length > 0 && (
-                    <span className="text-secondary dark:text-teal-300 font-semibold bg-secondary/10 dark:bg-teal-900/30 px-2 py-0.5 rounded-full text-xs">
-                      ♥ {favorites.length} guardadas
-                    </span>
-                  )}
-                </div>
-
-                {/* Layout Controls: Mode & Items per Page */}
-                <div className="flex flex-wrap items-center gap-2.5">
-                  {/* Display Mode Toggle */}
-                  <div className="flex items-center bg-surface dark:bg-slate-900 p-1 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-xs">
-                    <button
-                      type="button"
-                      onClick={() => setDisplayMode("paginated")}
-                      id="mode-paginated-btn"
-                      className={`inline-flex items-center justify-center gap-1.5 min-h-[40px] px-3 py-1 rounded-lg font-semibold transition-all ${
-                        displayMode === "paginated"
-                          ? "bg-primary text-white dark:bg-sky-600 shadow-xs"
-                          : "text-on-surface-variant dark:text-slate-400 hover:text-primary dark:hover:text-sky-300"
-                      }`}
-                      title="Modo Paginación: navegar página por página"
-                    >
-                      <Layers className="w-3.5 h-3.5" />
-                      <span className="hidden xs:inline">Páginas</span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setDisplayMode("continuous")}
-                      id="mode-lazy-btn"
-                      className={`inline-flex items-center justify-center gap-1.5 min-h-[40px] px-3 py-1 rounded-lg font-semibold transition-all ${
-                        displayMode === "continuous"
-                          ? "bg-secondary text-white dark:bg-teal-600 shadow-xs"
-                          : "text-on-surface-variant dark:text-slate-400 hover:text-secondary dark:hover:text-teal-300"
-                      }`}
-                      title="Modo Carga Progresiva: botón Cargar Más para móviles"
-                    >
-                      <ArrowDownCircle className="w-3.5 h-3.5" />
-                      <span className="hidden xs:inline">Carga Diferida</span>
-                    </button>
-                  </div>
-
-                  {/* Items per Page Selector */}
-                  {displayMode === "paginated" && (
-                    <div className="flex items-center gap-1 bg-surface dark:bg-slate-900 p-1 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-xs font-semibold">
-                      <span className="text-[11px] text-on-surface-variant dark:text-slate-400 px-1 hidden md:inline">
-                        Ver:
-                      </span>
-                      {[6, 12, 18, 0].map((size) => (
-                        <button
-                          key={size}
-                          type="button"
-                          onClick={() => setItemsPerPage(size)}
-                          id={`items-per-page-${size === 0 ? "all" : size}`}
-                          className={`min-w-[40px] min-h-[40px] sm:min-w-0 sm:min-h-0 px-2 py-1 inline-flex items-center justify-center rounded-lg transition-colors ${
-                            itemsPerPage === size
-                              ? "bg-primary/15 dark:bg-sky-900/60 text-primary dark:text-sky-300 font-bold"
-                              : "text-on-surface-variant dark:text-slate-400 hover:bg-surface-container dark:hover:bg-slate-800"
-                          }`}
-                        >
-                          {size === 0 ? "Todas" : size}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                )}
               </div>
 
               {filteredScholarships.length === 0 ? (
@@ -1306,7 +1219,8 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                         <Card key={beca.id} className="hover:shadow-xl transition-all group">
                           <div>
                             <CardHeader className="h-44 overflow-hidden">
-                              <img
+                              <ImageWithFallback
+                                id={`beca-image-${beca.id}`}
                                 src={beca.imageUrl}
                                 alt={beca.title}
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
@@ -1416,186 +1330,84 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                     })}
                   </div>
 
-                  {/* Bottom Pagination & Lazy Loading Section */}
+                  {/*
+                    One way to page through the list, not two.
+
+                    The screen used to carry a numbered pager and a "load more"
+                    button behind a mode switch, plus a page-size selector — three
+                    controls doing one job, and on a phone the numbered pager was
+                    a row of tap targets nobody asked for. Lazy loading is what a
+                    catalogue on a phone wants: keep reading, or stop.
+                  */}
                   <div className="pt-2">
-                    {displayMode === "continuous" ? (
-                      /* Lazy Loading / Infinite Scroll Mode */
-                      <div className="bg-surface-container-lowest dark:bg-slate-800 p-6 rounded-2xl border border-outline-variant/40 dark:border-slate-700 text-center space-y-4">
-                        {/* Progress Bar */}
-                        <div className="max-w-md mx-auto space-y-1.5">
-                          <div className="flex items-center justify-between text-xs text-on-surface-variant dark:text-slate-400 font-medium">
-                            <span>Progreso de carga</span>
-                            <span>
-                              {displayedScholarships.length} de {filteredScholarships.length} (
-                              {Math.round(
-                                (displayedScholarships.length / filteredScholarships.length) * 100
-                              )}
-                              %)
-                            </span>
-                          </div>
-                          <div className="w-full bg-surface-container dark:bg-slate-700 h-2 rounded-full overflow-hidden">
-                            <div
-                              className="bg-secondary dark:bg-teal-400 h-full rounded-full transition-all duration-300"
-                              style={{
-                                width: `${(displayedScholarships.length / filteredScholarships.length) * 100}%`,
-                              }}
-                            />
-                          </div>
+                    <div className="bg-surface-container-lowest dark:bg-slate-800 p-6 rounded-2xl border border-outline-variant/40 dark:border-slate-700 text-center space-y-4">
+                      {/* Progress Bar */}
+                      <div className="max-w-md mx-auto space-y-1.5">
+                        <div className="flex items-center justify-between text-xs text-on-surface-variant dark:text-slate-400 font-medium">
+                          <span id="load-progress-label">Progreso de carga</span>
+                          <span>
+                            {displayedScholarships.length} de {filteredScholarships.length} (
+                            {loadedPercentage}%)
+                          </span>
                         </div>
-
-                        {displayedScholarships.length < filteredScholarships.length ? (
-                          <div className="space-y-2">
-                            <button
-                              type="button"
-                              onClick={handleLoadMore}
-                              id="btn-load-more-scholarships"
-                              className="btn-tactile inline-flex items-center gap-2 bg-secondary dark:bg-teal-600 hover:bg-secondary/90 text-white font-bold text-sm px-6 py-3 rounded-xl shadow-md hover:shadow-lg transition-all"
-                            >
-                              <ArrowDownCircle className="w-4 h-4 animate-bounce" />
-                              <span>
-                                Cargar Más Convocatorias (+
-                                {Math.min(
-                                  itemsPerPage > 0 ? itemsPerPage : 6,
-                                  filteredScholarships.length - displayedScholarships.length
-                                )}
-                                )
-                              </span>
-                            </button>
-                            <p className="text-xs text-on-surface-variant dark:text-slate-400">
-                              Quedan {filteredScholarships.length - displayedScholarships.length}{" "}
-                              becas por mostrar
-                            </p>
-                          </div>
-                        ) : (
-                          <div className="space-y-2 py-2">
-                            <p className="text-sm font-bold text-emerald-600 dark:text-emerald-400 flex items-center justify-center gap-1.5">
-                              <CheckCircle2 className="w-4 h-4" />
-                              <span>
-                                Has llegado al final de las {filteredScholarships.length}{" "}
-                                convocatorias
-                              </span>
-                            </p>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                if (mainListRef.current) {
-                                  mainListRef.current.scrollIntoView({
-                                    behavior: "smooth",
-                                    block: "start",
-                                  });
-                                }
-                              }}
-                              className="btn-tactile text-xs font-semibold text-secondary dark:text-teal-300 hover:underline inline-block py-1 px-2"
-                            >
-                              Volver arriba del listado ↑
-                            </button>
-                          </div>
-                        )}
+                        <div
+                          role="progressbar"
+                          aria-labelledby="load-progress-label"
+                          aria-valuemin={0}
+                          aria-valuemax={filteredScholarships.length}
+                          aria-valuenow={displayedScholarships.length}
+                          className="w-full bg-surface-container dark:bg-slate-700 h-2 rounded-full overflow-hidden"
+                        >
+                          <div
+                            className="bg-secondary dark:bg-teal-400 h-full rounded-full transition-all duration-300"
+                            style={{ width: `${loadedPercentage}%` }}
+                          />
+                        </div>
                       </div>
-                    ) : (
-                      /* Standard Numbered Pagination Mode */
-                      itemsPerPage > 0 &&
-                      totalPages > 1 && (
-                        <div className="bg-surface-container-lowest dark:bg-slate-800 p-4 md:p-6 rounded-2xl border border-outline-variant/40 dark:border-slate-700 flex flex-col sm:flex-row items-center justify-between gap-4">
-                          <div className="text-xs md:text-sm text-on-surface-variant dark:text-slate-400 font-medium">
-                            Página <strong>{validCurrentPage}</strong> de{" "}
-                            <strong>{totalPages}</strong> ({filteredScholarships.length}{" "}
-                            convocatorias)
-                          </div>
 
-                          {/* Navigation Controls */}
-                          <div className="flex items-center gap-1.5">
-                            {/* First Page */}
-                            <button
-                              type="button"
-                              onClick={() => handlePageChange(1)}
-                              disabled={validCurrentPage === 1}
-                              aria-label="Primera página"
-                              id="pagination-first-page"
-                              className="btn-tactile p-2 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-on-surface dark:text-slate-200 hover:bg-surface-container dark:hover:bg-slate-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
-                            >
-                              <ChevronsLeft className="w-4 h-4" />
-                            </button>
-
-                            {/* Previous Page */}
-                            <button
-                              type="button"
-                              onClick={() => handlePageChange(validCurrentPage - 1)}
-                              disabled={validCurrentPage === 1}
-                              aria-label="Página anterior"
-                              id="pagination-prev-page"
-                              className="btn-tactile px-3 py-2 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-xs font-bold text-on-surface dark:text-slate-200 hover:bg-surface-container dark:hover:bg-slate-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all flex items-center gap-1"
-                            >
-                              <ChevronLeft className="w-4 h-4" />
-                              <span className="hidden md:inline">Anterior</span>
-                            </button>
-
-                            {/* Numbered Page Buttons */}
-                            <div className="flex items-center gap-1">
-                              {Array.from({ length: totalPages }, (_, i) => i + 1)
-                                .filter((page) => {
-                                  if (page === 1 || page === totalPages) return true;
-                                  return Math.abs(page - validCurrentPage) <= 1;
-                                })
-                                .map((page, idx, arr) => {
-                                  const prevPage = arr[idx - 1];
-                                  const showEllipsisBefore = prevPage && page - prevPage > 1;
-
-                                  return (
-                                    <React.Fragment key={page}>
-                                      {showEllipsisBefore && (
-                                        <span className="px-1 text-xs text-on-surface-variant dark:text-slate-500 font-bold">
-                                          …
-                                        </span>
-                                      )}
-                                      <button
-                                        type="button"
-                                        onClick={() => handlePageChange(page)}
-                                        id={`pagination-page-${page}`}
-                                        aria-current={
-                                          page === validCurrentPage ? "page" : undefined
-                                        }
-                                        className={`btn-tactile w-9 h-9 rounded-xl text-xs font-bold transition-all flex items-center justify-center ${
-                                          page === validCurrentPage
-                                            ? "bg-primary text-white dark:bg-sky-600 shadow-sm ring-2 ring-primary/20"
-                                            : "border border-outline-variant/40 dark:border-slate-700 text-on-surface dark:text-slate-300 hover:bg-surface-container dark:hover:bg-slate-700"
-                                        }`}
-                                      >
-                                        {page}
-                                      </button>
-                                    </React.Fragment>
-                                  );
-                                })}
-                            </div>
-
-                            {/* Next Page */}
-                            <button
-                              type="button"
-                              onClick={() => handlePageChange(validCurrentPage + 1)}
-                              disabled={validCurrentPage === totalPages}
-                              aria-label="Página siguiente"
-                              id="pagination-next-page"
-                              className="btn-tactile px-3 py-2 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-xs font-bold text-on-surface dark:text-slate-200 hover:bg-surface-container dark:hover:bg-slate-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all flex items-center gap-1"
-                            >
-                              <span className="hidden md:inline">Siguiente</span>
-                              <ChevronRight className="w-4 h-4" />
-                            </button>
-
-                            {/* Last Page */}
-                            <button
-                              type="button"
-                              onClick={() => handlePageChange(totalPages)}
-                              disabled={validCurrentPage === totalPages}
-                              aria-label="Última página"
-                              id="pagination-last-page"
-                              className="btn-tactile p-2 rounded-xl border border-outline-variant/40 dark:border-slate-700 text-on-surface dark:text-slate-200 hover:bg-surface-container dark:hover:bg-slate-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
-                            >
-                              <ChevronsRight className="w-4 h-4" />
-                            </button>
-                          </div>
+                      {displayedScholarships.length < filteredScholarships.length ? (
+                        <div className="space-y-2">
+                          <button
+                            type="button"
+                            onClick={handleLoadMore}
+                            id="btn-load-more-scholarships"
+                            className="btn-tactile inline-flex items-center gap-2 bg-secondary dark:bg-teal-600 hover:bg-secondary/90 text-white font-bold text-sm px-6 py-3 rounded-xl shadow-md hover:shadow-lg transition-all"
+                          >
+                            <ArrowDownCircle className="w-4 h-4" aria-hidden="true" />
+                            <span>Cargar Más Convocatorias (+{nextBatchSize})</span>
+                          </button>
+                          <p className="text-xs text-on-surface-variant dark:text-slate-400">
+                            Quedan {filteredScholarships.length - displayedScholarships.length}{" "}
+                            becas por mostrar
+                          </p>
                         </div>
-                      )
-                    )}
+                      ) : (
+                        <div className="space-y-2 py-2">
+                          <p className="text-sm font-bold text-emerald-600 dark:text-emerald-400 flex items-center justify-center gap-1.5">
+                            <CheckCircle2 className="w-4 h-4" aria-hidden="true" />
+                            <span>
+                              Has llegado al final de las {filteredScholarships.length}{" "}
+                              convocatorias
+                            </span>
+                          </p>
+                          <button
+                            type="button"
+                            id="btn-back-to-list-top"
+                            onClick={() => {
+                              if (mainListRef.current) {
+                                mainListRef.current.scrollIntoView({
+                                  behavior: "smooth",
+                                  block: "start",
+                                });
+                              }
+                            }}
+                            className="btn-tactile text-xs font-semibold text-secondary dark:text-teal-300 hover:underline inline-block py-1 px-2"
+                          >
+                            Volver arriba del listado ↑
+                          </button>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
               )}

--- a/src/components/ui/ImageWithFallback.test.tsx
+++ b/src/components/ui/ImageWithFallback.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders as render } from "../../test/renderWithProviders";
+import { ImageWithFallback } from "./ImageWithFallback";
+
+describe("ImageWithFallback", () => {
+  it("renders the image while it loads fine", () => {
+    render(<ImageWithFallback id="cover" src="https://example.test/a.jpg" alt="Beca DAAD" />);
+
+    const img = screen.getByAltText("Beca DAAD");
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "https://example.test/a.jpg");
+  });
+
+  it("defers loading until the image is near the viewport", () => {
+    render(<ImageWithFallback src="https://example.test/a.jpg" alt="Beca DAAD" />);
+    expect(screen.getByAltText("Beca DAAD")).toHaveAttribute("loading", "lazy");
+  });
+
+  it("replaces a failed image with a placeholder, not the browser's broken icon", () => {
+    render(<ImageWithFallback id="cover" src="https://example.test/gone.jpg" alt="Beca DAAD" />);
+
+    fireEvent.error(screen.getByAltText("Beca DAAD"));
+
+    expect(screen.queryByAltText("Beca DAAD")).not.toBeInTheDocument();
+    expect(screen.getByText(/Imagen no disponible/i)).toBeInTheDocument();
+  });
+
+  it("names what is missing, so the placeholder is not an anonymous grey box", () => {
+    render(<ImageWithFallback src="https://example.test/gone.jpg" alt="Beca DAAD" />);
+    fireEvent.error(screen.getByAltText("Beca DAAD"));
+
+    expect(
+      screen.getByRole("img", { name: /Imagen no disponible: Beca DAAD/i })
+    ).toBeInTheDocument();
+  });
+
+  it("treats a missing src as a failure rather than fetching the page itself", () => {
+    // An empty `src` resolves against the document URL, so the browser
+    // downloads the HTML and then fails to decode it as an image.
+    render(<ImageWithFallback src="" alt="Beca sin portada" />);
+
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByText(/Imagen no disponible/i)).toBeInTheDocument();
+  });
+
+  it("treats an absent src the same way", () => {
+    render(<ImageWithFallback alt="Beca sin portada" />);
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByText(/Imagen no disponible/i)).toBeInTheDocument();
+  });
+
+  it("keeps the caller's layout classes on the placeholder", () => {
+    // The placeholder stands in for the image inside a fixed-height card, so
+    // it has to fill the same box or the card collapses around it.
+    render(<ImageWithFallback id="cover" src="" alt="Beca" className="w-full h-full" />);
+
+    const placeholder = document.getElementById("cover");
+    expect(placeholder).toHaveClass("w-full");
+    expect(placeholder).toHaveClass("h-full");
+  });
+});

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { ImageOff } from "lucide-react";
+
+interface ImageWithFallbackProps {
+  src?: string;
+  /** Describes the picture, not the file. Empty when purely decorative. */
+  alt: string;
+  className?: string;
+  /** Prefix for the element's `id`, so E2E can target the fallback. */
+  id?: string;
+}
+
+/**
+ * An image that shows a placeholder instead of a broken-image icon.
+ *
+ * The scholarship covers are remote URLs on hosts this project does not
+ * control. When one stops resolving the browser draws its own broken-image
+ * glyph inside a card that otherwise looks fine, which reads as the
+ * application being broken rather than one picture being gone.
+ *
+ * The placeholder is deliberately visible rather than a blank box: a missing
+ * cover is worth noticing, and a silent fallback is how a broken feature goes
+ * unnoticed here.
+ */
+export const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({
+  src,
+  alt,
+  className = "",
+  id,
+}) => {
+  const [failed, setFailed] = useState(false);
+
+  // An empty or absent `src` is a failure too — the browser resolves it
+  // against the page URL and fetches the document itself.
+  if (failed || !src) {
+    return (
+      <div
+        id={id}
+        role="img"
+        aria-label={`Imagen no disponible: ${alt}`}
+        className={`flex flex-col items-center justify-center gap-1.5 bg-surface-container dark:bg-slate-900 text-on-surface-variant/70 dark:text-slate-500 ${className}`}
+      >
+        <ImageOff className="w-7 h-7" aria-hidden="true" />
+        <span className="text-[11px] font-semibold">Imagen no disponible</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      id={id}
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className={className}
+    />
+  );
+};

--- a/tests/e2e/becas.mobile.spec.ts
+++ b/tests/e2e/becas.mobile.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The scholarship list on a phone.
+ *
+ * The screen used to carry two ways of paging — a numbered pager and a "load
+ * more" button behind a mode switch — plus a page-size selector. Three
+ * controls doing one job, and on a phone the numbered pager was a row of tap
+ * targets nobody asked for. There is one way through the catalogue now.
+ */
+test.describe("Scholarship list on a phone", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#bottom-nav-becas").click();
+    await expect(page.locator("#btn-open-mobile-filters")).toBeVisible();
+  });
+
+  test("has one way to see more, and no numbered pager", async ({ page }) => {
+    await expect(page.locator("#btn-load-more-scholarships")).toBeVisible();
+
+    for (const id of [
+      "#pagination-first-page",
+      "#pagination-prev-page",
+      "#pagination-next-page",
+      "#mode-paginated-btn",
+      "#mode-lazy-btn",
+    ]) {
+      await expect(page.locator(id), id).toHaveCount(0);
+    }
+    await expect(page.locator('[id^="items-per-page-"]')).toHaveCount(0);
+  });
+
+  test("grows the list on request and stops at the end", async ({ page }) => {
+    const cards = page.getByRole("button", { name: /Ver Detalles/ });
+    const first = await cards.count();
+    expect(first).toBeGreaterThan(0);
+
+    await page.locator("#btn-load-more-scholarships").click();
+    expect(await cards.count()).toBeGreaterThan(first);
+
+    // Keep going until the button retires itself.
+    for (let i = 0; i < 10; i += 1) {
+      const more = page.locator("#btn-load-more-scholarships");
+      if ((await more.count()) === 0) break;
+      await more.click();
+    }
+
+    await expect(page.locator("#btn-load-more-scholarships")).toHaveCount(0);
+    await expect(page.getByText(/Has llegado al final/i)).toBeVisible();
+    await expect(page.locator("#btn-back-to-list-top")).toBeVisible();
+  });
+
+  test("keeps the load control reachable and sized for a thumb", async ({ page }) => {
+    const box = await page.locator("#btn-load-more-scholarships").boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeGreaterThanOrEqual(44);
+
+    const viewport = page.viewportSize();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+  });
+
+  test("shows a placeholder rather than a broken image when a cover fails", async ({ page }) => {
+    // Point every cover at a URL that cannot resolve, which is what a dead
+    // remote host looks like to the browser.
+    await page.route("**/*.{png,jpg,jpeg,webp,avif}", (route) => route.abort());
+    await page.reload();
+    await page.locator("#bottom-nav-becas").click();
+
+    const placeholder = page.getByRole("img", { name: /Imagen no disponible/ }).first();
+    await expect(placeholder).toBeVisible();
+
+    // The card keeps its shape: a placeholder that collapses is as bad as a
+    // broken icon.
+    const box = await placeholder.boundingBox();
+    expect(box!.height).toBeGreaterThan(40);
+  });
+
+  test("puts the card actions on one row instead of stacking them as blocks", async ({ page }) => {
+    const positions = await page.evaluate(() => {
+      const details = [...document.querySelectorAll("button")].find((b) =>
+        /Ver Detalles/.test(b.textContent || "")
+      );
+      const footer = details?.parentElement;
+      if (!footer) return null;
+      return [...footer.children].map((el) => Math.round(el.getBoundingClientRect().top));
+    });
+
+    expect(positions).not.toBeNull();
+    expect(positions!.length).toBeGreaterThan(1);
+    // Same top edge means one row. Stacked blocks was the complaint.
+    expect(new Set(positions).size).toBe(1);
+  });
+
+  test("announces how much of the catalogue is loaded", async ({ page }) => {
+    const bar = page.getByRole("progressbar");
+    await expect(bar).toBeVisible();
+    await expect(bar).toHaveAttribute("aria-valuemax", /\d+/);
+
+    const before = Number(await bar.getAttribute("aria-valuenow"));
+    await page.locator("#btn-load-more-scholarships").click();
+    const after = Number(await bar.getAttribute("aria-valuenow"));
+
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,11 +36,14 @@ export default defineConfig({
        * country mapping — where high coverage is both achievable and valuable,
        * so it carries its own stricter budget.
        */
+      // A ratchet, not a target: raised with each pull request that adds
+      // tests, so coverage can only go up. Never lower these to make a build
+      // pass — write the test instead.
       thresholds: {
-        statements: 43,
-        branches: 43,
-        functions: 36,
-        lines: 43,
+        statements: 52,
+        branches: 47,
+        functions: 46,
+        lines: 52,
         "src/lib/PreferencesContext.tsx": {
           statements: 95,
           branches: 85,


### PR DESCRIPTION
Closes #52.

## Two paginations became one

The list carried a numbered pager **and** a "load more" button behind a mode switch, **plus** a page-size selector — three controls doing one job. On a phone the numbered pager was a row of tap targets nobody asked for.

Lazy loading is what remains: six convocatorias at a time, a progress bar that announces itself to assistive technology, and an explicit end state instead of a button that would add nothing.

Removing the paginated mode takes `displayMode`, `currentPage`, `totalPages`, `validCurrentPage`, `handlePageChange` and `itemsPerPage` with it, along with five now-unused icons.

**Two defects surfaced while removing it:**

- An empty catalogue divided by zero, so the progress readout and the bar's width were `NaN`. Empty is *fully* loaded, not 0% loaded.
- Changing a filter left the previously loaded count in place. What was loaded before a filter changed says nothing about what matches after it.

## A failed cover renders a placeholder

The covers are remote URLs on hosts this project does not control. When one stops resolving, the browser draws its broken-image glyph inside an otherwise fine card — which reads as the application being broken rather than one picture being gone.

An empty `src` counts as a failure too: the browser resolves it against the page URL and fetches the document itself.

## Two items were already fixed

The issue also listed card actions stacking as blocks and unreadable badges. Both were fixed by the shadcn adoption in #58. Confirmed by measurement rather than assumed — at 375px both card actions share a top edge (`y: 388`), so they are on one row.

## A note on three replaced tests

Three unit cases covered the numbered pager, the mode switch and the page-size selector. That is behaviour this change deliberately removes, so the cases are replaced rather than deleted — the list still has to page, it now does it one way. Flagging it explicitly because "tests changed to pass" is the shape of a real problem, and this is not that.

## Tests

**Unit — `ImageWithFallback.test.tsx` (7)**: renders the image, defers loading, swaps to the placeholder on error, names what is missing, treats empty and absent `src` as failures, keeps the caller's layout classes so the card does not collapse.

**Unit — `BecasExplorer.test.tsx` (7 new)**: exactly one paging control exists, the first batch and its count, each request adds a batch, the button never promises more than is left, the end state replaces it, a filter change resets to the first batch, the progress bar carries a name and values.

**E2E — `becas.mobile.spec.ts` (6)**: no numbered pager, the list grows and stops, the control stays thumb-sized and inside the viewport, a blocked image yields a placeholder that keeps the card's shape, the card actions share one row, progress advances.

```
170 unit tests passed
57 Playwright tests passed
lint: 0 errors, 33 warnings (down from 35)
```

## Coverage

| | before | after |
|---|---|---|
| statements | 43 | **52** |
| branches | 43 | **47** |
| functions | 36 | **46** |
| lines | 43 | **52** |

Raised to what the suite now reaches, with a comment saying these are a ratchet and are never to be lowered to make a build pass.

## Documentation

`docs/ux.md` gains a **Scholarship list** section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_