### PR TITLE
fix(test): make the image-fallback E2E actually exercise the fallback

### DIFF
--- a/tests/e2e/becas.mobile.spec.ts
+++ b/tests/e2e/becas.mobile.spec.ts
@@ -61,11 +61,29 @@ test.describe("Scholarship list on a phone", () => {
   });
 
   test("shows a placeholder rather than a broken image when a cover fails", async ({ page }) => {
-    // Point every cover at a URL that cannot resolve, which is what a dead
-    // remote host looks like to the browser.
-    await page.route("**/*.{png,jpg,jpeg,webp,avif}", (route) => route.abort());
+    // Fail every image request, which is what a dead remote host looks like
+    // to the browser.
+    //
+    // Matched by resource type rather than by file extension: the covers are
+    // Unsplash URLs like `photo-1543783207-ec64e4d95325?auto=format&w=800`,
+    // which carry no extension at all. A `**/*.{png,jpg,…}` pattern matches
+    // none of them, so the route never fired and this test passed without
+    // ever exercising the fallback.
+    let imagesBlocked = 0;
+    await page.route("**/*", (route) => {
+      if (route.request().resourceType() !== "image") return route.continue();
+      imagesBlocked += 1;
+      return route.abort();
+    });
     await page.reload();
     await page.locator("#bottom-nav-becas").click();
+
+    // The test has to prove its own premise. The previous pattern matched no
+    // request at all, so this assertion is what stops it passing for the
+    // wrong reason again.
+    await expect
+      .poll(() => imagesBlocked, { message: "no image request was intercepted" })
+      .toBeGreaterThan(0);
 
     const placeholder = page.getByRole("img", { name: /Imagen no disponible/ }).first();
     await expect(placeholder).toBeVisible();


### PR DESCRIPTION
Fixes the failure on `main`:

```
[Mobile Chrome] › tests/e2e/becas.mobile.spec.ts:63
  Scholarship list on a phone › shows a placeholder rather than a broken image when a cover fails
```

## What was wrong

The test intercepted `**/*.{png,jpg,jpeg,webp,avif}`. The scholarship covers are Unsplash URLs:

```
https://images.unsplash.com/photo-1543783207-ec64e4d95325?auto=format&fit=crop&w=800&q=80
```

**No file extension at all.** The pattern matched nothing, the route never fired, and the test asserted a behaviour it had never triggered.

It passed locally for the wrong reason: the agent container blocks outbound requests, so every cover failed on its own and the placeholder appeared regardless. In CI, where the images load, there was nothing to fall back from.

This is my error, and it is exactly the failure mode I wrote a `CLAUDE.md` section about in #65 — a test that passes without exercising its subject.

## The fix

**Match on resource type, not on the URL's extension:**

```ts
await page.route("**/*", (route) => {
  if (route.request().resourceType() !== "image") return route.continue();
  imagesBlocked += 1;
  return route.abort();
});
```

**And make the test prove its own premise:**

```ts
await expect
  .poll(() => imagesBlocked, { message: "no image request was intercepted" })
  .toBeGreaterThan(0);
```

Without that second assertion the same class of mistake passes silently again.

## Verification

Restoring the old extension pattern with the new assertion in place now fails with:

```
Error: no image request was intercepted
```

So the guard catches precisely the bug it was written for.

```
170 unit tests passed
57 Playwright tests passed
lint and format clean
```

Test-only change; no source is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_