### PR TITLE
fix(becas): make the scholarship detail panel readable on a phone

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -148,6 +148,22 @@ Recently addressed and verified by tests:
   failure: the browser would otherwise resolve it against the page URL and
   fetch the document itself.
 
+## Scholarship detail
+
+- Requisitos and beneficios collapse below `lg` through the same `Disclosure`
+  the guides use. Together they are the bulk of the panel and arrived as one
+  wall of text.
+- The calendar action says what it does. "Agendar en Google Calendar" read as
+  booking an appointment with somebody; nothing is booked with anyone, so it
+  is "Recordarme la fecha límite", and the event that lands in the reader's
+  calendar is titled "Recordatorio: cierra la beca …".
+- One link to the official call, not two. The header and the action row both
+  pointed at the same page.
+- The "Consultar IA" button is hidden behind
+  `SHOW_ASK_AI_ABOUT_SCHOLARSHIP`, not deleted: the assistant cannot yet
+  answer usefully about one specific call, and the handler, the prop and the
+  path through `App` stay wired so restoring it is one word.
+
 ## Migration guides
 
 - The guide collapses its heavy blocks below `lg` and leaves them open above

--- a/src/components/BecasExplorer.test.tsx
+++ b/src/components/BecasExplorer.test.tsx
@@ -33,28 +33,103 @@ describe("BecasExplorer Component", () => {
   it("opens scholarship modal details when clicking on a card", () => {
     render(<BecasExplorer {...defaultProps} />);
 
-    // Find and click on the first scholarship "Ver Detalles" button
     const detailButtons = screen.getAllByRole("button", { name: /Ver Detalles/i });
     expect(detailButtons.length).toBeGreaterThan(0);
     fireEvent.click(detailButtons[0]);
 
-    // Check that modal details appear
-    expect(screen.getByText(/Requisitos Principales/i)).toBeInTheDocument();
-    expect(screen.getByText(/Beneficios Incluidos/i)).toBeInTheDocument();
+    // Requisitos and beneficios collapse on a phone, so the panel is
+    // addressed by its controls rather than by the headings inside them.
+    expect(document.getElementById("beca-requisitos")).toBeInTheDocument();
+    expect(document.getElementById("beca-beneficios")).toBeInTheDocument();
+    // The disclosure control reads "Ver requisitos principales", so match the
+    // heading by role rather than by a case-insensitive substring.
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByRole("heading", { name: "Requisitos Principales" })
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("heading", { name: "Beneficios Incluidos" })
+    ).toBeInTheDocument();
   });
 
-  it("calls onAskAIAboutScholarship when clicking Consultar IA in modal", () => {
-    render(<BecasExplorer {...defaultProps} />);
+  /**
+   * The panel arrived as one wall of text with three equally loud buttons,
+   * one of which offered an assistant that cannot yet answer about a specific
+   * call, and another of which said "Agendar" — which reads as booking an
+   * appointment with somebody.
+   */
+  describe("the scholarship detail panel", () => {
+    const openFirstDetail = () => {
+      const result = render(<BecasExplorer {...defaultProps} />);
+      fireEvent.click(screen.getAllByRole("button", { name: /Ver Detalles/i })[0]);
+      return result;
+    };
 
-    // Open modal
-    const detailButtons = screen.getAllByRole("button", { name: /Ver Detalles/i });
-    fireEvent.click(detailButtons[0]);
+    it("collapses requisitos and beneficios, closed to begin with", () => {
+      openFirstDetail();
 
-    // Click on "Consultar IA" button
-    const askAiBtn = screen.getByRole("button", { name: /Consultar IA/i });
-    fireEvent.click(askAiBtn);
+      for (const id of ["beca-requisitos", "beca-beneficios"]) {
+        expect(document.getElementById(id), id).toHaveAttribute("aria-expanded", "false");
+      }
+    });
 
-    expect(defaultProps.onAskAIAboutScholarship).toHaveBeenCalled();
+    it("opens a section when its control is used", () => {
+      openFirstDetail();
+
+      const control = document.getElementById("beca-requisitos") as HTMLElement;
+      fireEvent.click(control);
+
+      expect(control).toHaveAttribute("aria-expanded", "true");
+      expect(document.getElementById("beca-requisitos-panel")).not.toHaveClass("hidden");
+    });
+
+    it("says the calendar action creates a reminder, not an appointment", () => {
+      openFirstDetail();
+
+      const link = document.getElementById("beca-calendar-reminder");
+      expect(link).toHaveTextContent(/Recordarme la fecha límite/i);
+      expect(link).not.toHaveTextContent(/Agendar/i);
+
+      // The event that lands in the reader's calendar says so too.
+      // Query strings encode spaces as `+`, which decodeURIComponent leaves
+      // alone.
+      const href = decodeURIComponent(link?.getAttribute("href") ?? "").replace(/\+/g, " ");
+      expect(href).toMatch(/Recordatorio: cierra la beca/);
+      expect(href).not.toMatch(/Cierre de Convocatoria/);
+    });
+
+    it("links to the official call exactly once", () => {
+      const { container } = openFirstDetail();
+
+      // The header and the action row both linked to the same page.
+      const officialLinks = [...container.ownerDocument.querySelectorAll("a")].filter((a) =>
+        /convocatoria oficial/i.test(a.textContent || "")
+      );
+      expect(officialLinks).toHaveLength(1);
+      expect(document.getElementById("beca-official-link")).toHaveAttribute("target", "_blank");
+      expect(document.getElementById("beca-official-link")).toHaveAttribute(
+        "rel",
+        expect.stringContaining("noopener")
+      );
+    });
+
+    it("hides the assistant button without unwiring it", () => {
+      const onAskAIAboutScholarship = vi.fn();
+      render(<BecasExplorer {...defaultProps} onAskAIAboutScholarship={onAskAIAboutScholarship} />);
+      fireEvent.click(screen.getAllByRole("button", { name: /Ver Detalles/i })[0]);
+
+      expect(document.getElementById("beca-ask-ai")).toBeNull();
+      expect(screen.queryByRole("button", { name: /Consultar IA/i })).toBeNull();
+      expect(onAskAIAboutScholarship).not.toHaveBeenCalled();
+    });
+
+    it("keeps every action reachable by a thumb", () => {
+      openFirstDetail();
+
+      for (const id of ["beca-official-link", "beca-calendar-reminder"]) {
+        expect(document.getElementById(id), id).toHaveClass("min-h-[44px]");
+      }
+    });
   });
 
   it("opens suggest scholarship modal when clicking Sugerir Beca Oficial", () => {
@@ -387,6 +462,67 @@ describe("BecasExplorer Component", () => {
       // The sheet is portalled to `document.body`, so it is outside the
       // render container that the other assertions use.
       expect(sheet.querySelector("#sheet-country-España")).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The suggestion form. It is the only way a reader can add to a catalogue
+   * whose whole claim is that every entry is an official source, so its
+   * behaviour is worth pinning.
+   */
+  describe("suggesting an official scholarship", () => {
+    const openForm = () => {
+      const result = render(<BecasExplorer {...defaultProps} />);
+      fireEvent.click(document.getElementById("suggest-scholarship-btn") as HTMLElement);
+      return result;
+    };
+
+    it("asks for the institution, the country and the link", () => {
+      openForm();
+      const dialog = screen.getByRole("dialog");
+
+      expect(within(dialog).getByText(/Universidad o Institución/i)).toBeInTheDocument();
+      expect(within(dialog).getByText(/País Destino/i)).toBeInTheDocument();
+    });
+
+    it("will not submit without the institution", () => {
+      openForm();
+
+      const input = screen
+        .getByRole("dialog")
+        .querySelector('input[type="text"]') as HTMLInputElement;
+      // Required, so an empty form cannot reach the catalogue at all.
+      expect(input).toBeRequired();
+      expect(input.value).toBe("");
+    });
+
+    it("keeps what was typed while the form is open", () => {
+      openForm();
+
+      const input = screen
+        .getByRole("dialog")
+        .querySelector('input[type="text"]') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "Universidad Autónoma de Madrid" } });
+
+      expect(input.value).toBe("Universidad Autónoma de Madrid");
+    });
+
+    it("confirms the suggestion was sent for verification", () => {
+      openForm();
+
+      const form = screen.getByRole("dialog").querySelector("form") as HTMLFormElement;
+      const input = form.querySelector('input[type="text"]') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "Universidad de Salamanca" } });
+      fireEvent.submit(form);
+
+      // Verification is the point: nothing enters the catalogue unchecked.
+      expect(screen.getByText(/enviada para verificación/i)).toBeInTheDocument();
+    });
+
+    it("does not close the panel the moment it is opened", () => {
+      openForm();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Sugerir Beca Universitaria/i)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -44,6 +44,7 @@ import { usePreferences } from "../lib/PreferencesContext";
 import { FilterChipGroup } from "./ui/FilterChipGroup";
 import { Modal } from "./ui/Modal";
 import { ImageWithFallback } from "./ui/ImageWithFallback";
+import { Disclosure } from "./ui/Disclosure";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card";
@@ -73,6 +74,13 @@ function daysUntil(deadline: string): number | null {
   today.setHours(0, 0, 0, 0);
   return Math.round((target.getTime() - today.getTime()) / 86_400_000);
 }
+
+/**
+ * The assistant cannot yet answer usefully about one specific call, so the
+ * button is hidden rather than removed: the handler, the prop and the path
+ * through `App` stay wired, and restoring it is this one word.
+ */
+const SHOW_ASK_AI_ABOUT_SCHOLARSHIP = false;
 
 /** How many convocatorias each "Cargar más" adds. */
 const LOAD_BATCH_SIZE = 6;
@@ -1607,15 +1615,6 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                   <ShieldCheck className="w-3.5 h-3.5 text-emerald-500" />
                   <span>Portal Oficial Verificado: {selectedScholarship.officialPortalName}</span>
                 </p>
-                <a
-                  href={selectedScholarship.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-xs font-bold text-primary dark:text-sky-400 hover:underline bg-primary/10 dark:bg-sky-950/60 px-2.5 py-1 rounded-lg border border-primary/20"
-                >
-                  <ExternalLink className="w-3 h-3" />
-                  <span>Ir a la convocatoria oficial</span>
-                </a>
               </div>
             )}
           </div>
@@ -1624,81 +1623,101 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
             {selectedScholarship.description}
           </p>
 
-          {/* Requisitos */}
-          <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
-            <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
-              Requisitos Principales
-            </h4>
-            <ul className="space-y-2">
-              {selectedScholarship.requirements.map((req, idx) => (
-                <li
-                  key={idx}
-                  className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
-                >
-                  <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
-                  <span>{req}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {/* Requisitos and beneficios collapse on a phone: together they are
+              the bulk of the panel, and they arrived as one wall of text. */}
+          <Disclosure
+            id="beca-requisitos"
+            label="Ver requisitos principales"
+            labelWhenOpen="Ocultar requisitos"
+          >
+            <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
+              <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
+                Requisitos Principales
+              </h4>
+              <ul className="space-y-2">
+                {selectedScholarship.requirements.map((req, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
+                  >
+                    <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" />
+                    <span>{req}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Disclosure>
 
-          {/* Beneficios */}
-          <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
-            <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
-              Beneficios Incluidos
-            </h4>
-            <ul className="space-y-2">
-              {selectedScholarship.benefits.map((ben, idx) => (
-                <li
-                  key={idx}
-                  className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
-                >
-                  <Sparkles className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
-                  <span>{ben}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <Disclosure
+            id="beca-beneficios"
+            label="Ver beneficios incluidos"
+            labelWhenOpen="Ocultar beneficios"
+          >
+            <div className="space-y-3 bg-surface dark:bg-slate-900 p-4 rounded-2xl border border-outline-variant/30 dark:border-slate-800">
+              <h4 className="font-bold text-sm text-primary dark:text-sky-300 uppercase tracking-wider">
+                Beneficios Incluidos
+              </h4>
+              <ul className="space-y-2">
+                {selectedScholarship.benefits.map((ben, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-start gap-2 text-sm text-on-surface-variant dark:text-slate-300"
+                  >
+                    <Sparkles className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                    <span>{ben}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Disclosure>
 
           {/* Modal Actions */}
-          <div className="flex flex-col sm:flex-row items-center gap-3 pt-4 border-t border-outline-variant/30 dark:border-slate-700">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2.5 pt-4 border-t border-outline-variant/30 dark:border-slate-700">
             <a
+              id="beca-official-link"
               href={selectedScholarship.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="btn-tactile w-full sm:w-auto flex-1 inline-flex items-center justify-center gap-2 bg-primary dark:bg-sky-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-primary-container transition-all text-xs shadow-sm hover:shadow-md"
+              className="btn-tactile inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-primary dark:bg-sky-600 px-4 text-xs font-bold text-white transition-all hover:bg-primary-container"
             >
-              <ExternalLink className="w-4 h-4" />
-              <span>Link a la Convocatoria Oficial</span>
+              <ExternalLink className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <span>Convocatoria oficial</span>
             </a>
 
             <a
+              id="beca-calendar-reminder"
               href={generateGoogleCalendarUrl({
-                title: `Cierre de Convocatoria: ${selectedScholarship.title}`,
-                details: `Fecha límite para enviar expediente a ${selectedScholarship.title}. Requisitos: ${selectedScholarship.requirements.join(", ")}. Enlace oficial convocatoria: ${selectedScholarship.link}`,
+                // Says what it is. "Agendar" read as booking an appointment
+                // with somebody; nothing is booked with anyone — this puts a
+                // reminder in the reader's own calendar.
+                title: `Recordatorio: cierra la beca ${selectedScholarship.title}`,
+                details: `Último día para enviar tu expediente a ${selectedScholarship.title}.\n\nRequisitos: ${selectedScholarship.requirements.join(", ")}\n\nConvocatoria oficial: ${selectedScholarship.link}`,
                 startDate: selectedScholarship.deadlineDate,
                 location: selectedScholarship.country,
               })}
               target="_blank"
-              rel="noreferrer"
-              className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-4 rounded-xl transition-all text-xs shadow-sm hover:shadow-md"
+              rel="noopener noreferrer"
+              className="btn-tactile inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 text-xs font-bold text-white transition-all hover:bg-emerald-700"
             >
-              <CalendarIcon className="w-4 h-4" />
-              <span>Agendar en Google Calendar</span>
+              <CalendarIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <span>Recordarme la fecha límite</span>
             </a>
 
-            <button
-              type="button"
-              onClick={() => {
-                const scholarshipToAsk = selectedScholarship;
-                setSelectedScholarship(null);
-                onAskAIAboutScholarship(scholarshipToAsk);
-              }}
-              className="btn-tactile w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-secondary dark:bg-teal-600 text-white font-bold py-3 px-4 rounded-xl hover:bg-secondary-container hover:text-secondary-900 transition-all text-xs shadow-sm hover:shadow-md"
-            >
-              <Bot className="w-4 h-4" />
-              <span>Consultar IA</span>
-            </button>
+            {SHOW_ASK_AI_ABOUT_SCHOLARSHIP && (
+              <button
+                type="button"
+                id="beca-ask-ai"
+                onClick={() => {
+                  const scholarshipToAsk = selectedScholarship;
+                  setSelectedScholarship(null);
+                  onAskAIAboutScholarship(scholarshipToAsk);
+                }}
+                className="btn-tactile inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-secondary dark:bg-teal-600 px-4 text-xs font-bold text-white transition-all hover:bg-secondary-container"
+              >
+                <Bot className="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span>Consultar IA</span>
+              </button>
+            )}
           </div>
         </Modal>
       )}

--- a/tests/e2e/becas.mobile.spec.ts
+++ b/tests/e2e/becas.mobile.spec.ts
@@ -104,3 +104,94 @@ test.describe("Scholarship list on a phone", () => {
     expect(after).toBeGreaterThan(before);
   });
 });
+
+/**
+ * The scholarship detail panel.
+ *
+ * It arrived as one wall of text with three equally loud buttons — one
+ * offering an assistant that cannot yet answer about a specific call, and one
+ * saying "Agendar", which reads as booking an appointment with somebody.
+ */
+test.describe("Scholarship detail on a phone", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#bottom-nav-becas").click();
+    await page
+      .getByRole("button", { name: /Ver Detalles/ })
+      .first()
+      .click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("collapses requisitos and beneficios, and opens them on tap", async ({ page }) => {
+    for (const id of ["beca-requisitos", "beca-beneficios"]) {
+      const control = page.locator(`#${id}`);
+      await expect(control, id).toBeVisible();
+      await expect(control).toHaveAttribute("aria-expanded", "false");
+      await expect(page.locator(`#${id}-panel`)).toBeHidden();
+    }
+
+    await page.locator("#beca-requisitos").click();
+    await expect(page.locator("#beca-requisitos-panel")).toBeVisible();
+    // Opening one leaves the other alone: they are separate disclosures, not
+    // an accordion where reading one hides the other.
+    await expect(page.locator("#beca-beneficios-panel")).toBeHidden();
+  });
+
+  test("keeps the bulk of the panel out of the way until it is asked for", async ({ page }) => {
+    // Measure the collapsible content itself rather than the dialog: the
+    // dialog is height-capped, so its own box and scrollHeight are the same
+    // whether the sections are open or shut.
+    const collapsibleHeight = () =>
+      page.evaluate(() =>
+        ["beca-requisitos-panel", "beca-beneficios-panel"].reduce(
+          (total, id) =>
+            total + Math.round(document.getElementById(id)?.getBoundingClientRect().height ?? 0),
+          0
+        )
+      );
+
+    // Collapsed means `display: none`, so it occupies nothing at all.
+    expect(await collapsibleHeight()).toBe(0);
+
+    for (const id of ["beca-requisitos", "beca-beneficios"]) {
+      await page.locator(`#${id}`).click();
+      await expect(page.locator(`#${id}`)).toHaveAttribute("aria-expanded", "true");
+    }
+
+    expect(await collapsibleHeight()).toBeGreaterThan(0);
+  });
+
+  test("offers the official call once, safely", async ({ page }) => {
+    const link = page.locator("#beca-official-link");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", /^https?:\/\//);
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", /noopener/);
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/convocatoria oficial/i)).toHaveCount(1);
+  });
+
+  test("says the calendar action sets a reminder", async ({ page }) => {
+    const link = page.locator("#beca-calendar-reminder");
+    await expect(link).toContainText(/Recordarme la fecha límite/i);
+    await expect(link).not.toContainText(/Agendar/i);
+  });
+
+  test("does not offer the assistant", async ({ page }) => {
+    await expect(page.locator("#beca-ask-ai")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Consultar IA/i })).toHaveCount(0);
+  });
+
+  test("keeps every action inside the viewport and thumb-sized", async ({ page }) => {
+    const width = page.viewportSize()!.width;
+
+    for (const id of ["beca-official-link", "beca-calendar-reminder"]) {
+      const box = await page.locator(`#${id}`).boundingBox();
+      expect(box, id).not.toBeNull();
+      expect(box!.height, id).toBeGreaterThanOrEqual(44);
+      expect(box!.x + box!.width, id).toBeLessThanOrEqual(width);
+    }
+  });
+});

--- a/tests/e2e/latinomigra.spec.ts
+++ b/tests/e2e/latinomigra.spec.ts
@@ -53,8 +53,12 @@ test.describe("LatinoMigra - End to End Suite", () => {
       .first()
       .click();
 
-    // Check modal detail is displayed
-    await expect(page.locator("text=Requisitos Principales").first()).toBeVisible();
+    // Check modal detail is displayed. Matched by role: the panel also has a
+    // disclosure control reading "Ver requisitos principales", which a text
+    // substring match picks up first and which is hidden on this viewport.
+    await expect(
+      page.getByRole("heading", { name: "Requisitos Principales", exact: true })
+    ).toBeVisible();
 
     // Close the modal
     const closeButton = page

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       thresholds: {
         statements: 54,
         branches: 49,
-        functions: 48,
+        functions: 49,
         lines: 54,
         "src/lib/PreferencesContext.tsx": {
           statements: 95,


### PR DESCRIPTION
Closes #53.

The panel arrived as one wall of text with three equally loud buttons.

## Requisitos and beneficios collapse below `lg`

Through the same `Disclosure` the guides use. Together they are the bulk of the panel, and on a phone they pushed everything else off the screen. Two **separate** disclosures rather than an accordion — reading the requirements should not hide the benefits.

## The calendar action says what it does

*"Agendar en Google Calendar"* read as booking an appointment with somebody. Nothing is booked with anyone.

| | before | after |
|---|---|---|
| button | Agendar en Google Calendar | **Recordarme la fecha límite** |
| event title | Cierre de Convocatoria: … | **Recordatorio: cierra la beca …** |

## One link to the official call, not two

The header and the action row both pointed at the same page. The remaining one is sized as an action rather than a banner — the previous button was `flex-1` and full-width.

## "Consultar IA" is hidden, not deleted

The assistant cannot yet answer usefully about one specific call. `SHOW_ASK_AI_ABOUT_SCHOLARSHIP` is a module constant, so the handler, the prop and the path through `App` stay wired and restoring it is one word.

## Two existing tests updated — and why

Flagging these rather than burying them:

- One clicked the button that is now hidden. That behaviour is deliberately removed.
- One matched `"Requisitos Principales"` as a case-insensitive substring, which now also matches the disclosure control reading *"Ver requisitos principales"*. It asserts the heading by role instead.

The same substring problem broke the desktop suite in `latinomigra.spec.ts` and is fixed the same way.

## Tests

**Unit — `BecasExplorer.test.tsx` (11 new)**

Six for the panel: both sections start collapsed, a control opens its own section, the calendar copy *and the generated event URL* both say reminder and no longer say "Agendar", the official call is linked exactly once with `noopener`, the assistant button is absent without its handler firing, both actions keep a 44px target.

Five for the suggestion form, which had **none**: the fields it asks for, the institution being required, typed input surviving, the verification confirmation, the panel staying open.

**E2E — `becas.mobile.spec.ts` (6 new)**: sections collapse and open on tap without disturbing each other, the collapsed content occupies *nothing at all* (`display: none`, measured), the official link present once and safe, the calendar copy, no assistant button, both actions inside the viewport at 44px.

```
214 unit tests passed
63 Playwright tests passed
lint and format clean
```

## Coverage

Functions 48 → **49**.

Worth noting how that number was reached: the ratchet caught this change dipping statements below 54, and the answer was five more tests on the previously untested suggestion form — not a lower threshold.

## Documentation

`docs/ux.md` gains a **Scholarship detail** section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_