### PR TITLE
feat(nav): narrow the product to Becas and Guías

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -131,6 +131,22 @@ Recently addressed and verified by tests:
 - Dismissing the drawer restores the reading position instead of jumping to the
   top.
 
+## What the navigation offers
+
+- The product is narrowed to Becas and Guías. The planner, the calculator,
+  volunteering, the community and the feedback hub are no longer linked from
+  the top bar, the drawer, the bottom bar or the footer.
+- They are **hidden, not deleted**: the components, their data and their tests
+  are untouched and still compile. `src/lib/navigation.ts` holds the single
+  list, so restoring a screen is deleting one line rather than editing four
+  components.
+- The desktop "Herramientas" menu held only hidden screens for a
+  non-administrator, so it no longer renders at all rather than opening onto
+  an empty panel.
+- Navigation is `useState` in `App.tsx` with no router, so a hidden screen has
+  no URL to arrive by and is genuinely unreachable — which is also why the
+  end-to-end tests that drove those screens were removed rather than adapted.
+
 ## Scholarship list
 
 - One way through the catalogue. The screen carried a numbered pager and a

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -17,4 +17,48 @@ describe("Footer Component", () => {
     fireEvent.click(screen.getByText(/Becas & Estudios/i));
     expect(setActiveTab).toHaveBeenCalledWith("becas");
   });
+  /**
+   * The footer is the other place a hidden screen could still be reachable
+   * from. It reads the same list as the rest of the navigation.
+   */
+  describe("hidden screens", () => {
+    it("offers no link to a screen the product has hidden", () => {
+      render(<Footer setActiveTab={vi.fn()} />);
+
+      // Assert on controls, not on any text: the footer's prose mentions the
+      // community without linking to it.
+      for (const label of [/Planificador/i, /Calculadora/i, /Voluntariados/i, /Comunidad/i]) {
+        expect(screen.queryByRole("button", { name: label }), String(label)).toBeNull();
+      }
+    });
+
+    it("still offers the screens the product is built on", () => {
+      const setActiveTab = vi.fn();
+      render(<Footer setActiveTab={setActiveTab} />);
+
+      fireEvent.click(screen.getByText(/Guía de Migración/i));
+      expect(setActiveTab).toHaveBeenCalledWith("guia");
+    });
+
+    it("keeps the consular map and the assistant", () => {
+      const setActiveTab = vi.fn();
+      render(<Footer setActiveTab={setActiveTab} />);
+
+      fireEvent.click(screen.getByText(/Mapa Consular/i));
+      expect(setActiveTab).toHaveBeenCalledWith("mapa");
+    });
+
+    it("leaves no empty section behind", () => {
+      const { container } = render(<Footer setActiveTab={vi.fn()} />);
+
+      // A column whose every link was hidden would render as a heading over
+      // nothing.
+      container.querySelectorAll("ul").forEach((list) => {
+        expect(
+          list.children.length,
+          list.previousElementSibling?.textContent ?? ""
+        ).toBeGreaterThan(0);
+      });
+    });
+  });
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,6 +18,7 @@ import {
   HeartHandshake,
   Bot,
 } from "lucide-react";
+import { isTabVisible } from "../lib/navigation";
 import { NavigationTab } from "../types";
 import { useLanguage } from "../lib/i18n";
 import { Modal } from "./ui/Modal";
@@ -78,24 +79,28 @@ export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
               <span>{t("footer.tools", "Herramientas")}</span>
             </h4>
             <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
-              <li>
-                <button
-                  onClick={() => handleNavigate("planificador")}
-                  className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
-                >
-                  <Compass className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
-                  <span>{t("nav.planificador", "Planificador 360° (Presupuesto & Clima)")}</span>
-                </button>
-              </li>
-              <li>
-                <button
-                  onClick={() => handleNavigate("calculadora")}
-                  className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
-                >
-                  <Calculator className="w-3.5 h-3.5 text-teal-500 shrink-0" />
-                  <span>{t("nav.calculadora", "Calculadora de Costo de Vida y Divisas")}</span>
-                </button>
-              </li>
+              {isTabVisible("planificador") && (
+                <li>
+                  <button
+                    onClick={() => handleNavigate("planificador")}
+                    className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
+                  >
+                    <Compass className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
+                    <span>{t("nav.planificador", "Planificador 360° (Presupuesto & Clima)")}</span>
+                  </button>
+                </li>
+              )}
+              {isTabVisible("calculadora") && (
+                <li>
+                  <button
+                    onClick={() => handleNavigate("calculadora")}
+                    className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
+                  >
+                    <Calculator className="w-3.5 h-3.5 text-teal-500 shrink-0" />
+                    <span>{t("nav.calculadora", "Calculadora de Costo de Vida y Divisas")}</span>
+                  </button>
+                </li>
+              )}
               <li>
                 <button
                   onClick={() => handleNavigate("becas")}
@@ -105,19 +110,21 @@ export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
                   <span>{t("nav.becas", "Catálogo de Becas 2026-2027")}</span>
                 </button>
               </li>
-              <li>
-                <button
-                  onClick={() => handleNavigate("voluntariados")}
-                  className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
-                >
-                  <HeartHandshake className="w-3.5 h-3.5 text-rose-500 shrink-0" />
-                  <span>
-                    {language === "en"
-                      ? "Volunteering & Exchanges"
-                      : "Voluntariados e Intercambios"}
-                  </span>
-                </button>
-              </li>
+              {isTabVisible("voluntariados") && (
+                <li>
+                  <button
+                    onClick={() => handleNavigate("voluntariados")}
+                    className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
+                  >
+                    <HeartHandshake className="w-3.5 h-3.5 text-rose-500 shrink-0" />
+                    <span>
+                      {language === "en"
+                        ? "Volunteering & Exchanges"
+                        : "Voluntariados e Intercambios"}
+                    </span>
+                  </button>
+                </li>
+              )}
               <li>
                 <button
                   onClick={() => handleNavigate("mapa")}
@@ -145,32 +152,36 @@ export const Footer: React.FC<FooterProps> = ({ setActiveTab }) => {
               {t("footer.community", "Comunidad & Asistencia")}
             </h4>
             <ul className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
-              <li>
-                <button
-                  onClick={() => handleNavigate("comunidad")}
-                  className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
-                >
-                  <MessageSquare className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-                  <span>
-                    {language === "en"
-                      ? "Community Forum & Experiences"
-                      : "Foro de Migrantes & Consejos"}
-                  </span>
-                </button>
-              </li>
-              <li>
-                <button
-                  onClick={() => handleNavigate("feedback")}
-                  className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
-                >
-                  <MessageSquarePlus className="w-3.5 h-3.5 text-rose-500 shrink-0" />
-                  <span>
-                    {language === "en"
-                      ? "Suggest New Feature or Scholarship"
-                      : "Sugerir Nueva Beca o Función"}
-                  </span>
-                </button>
-              </li>
+              {isTabVisible("comunidad") && (
+                <li>
+                  <button
+                    onClick={() => handleNavigate("comunidad")}
+                    className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
+                  >
+                    <MessageSquare className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                    <span>
+                      {language === "en"
+                        ? "Community Forum & Experiences"
+                        : "Foro de Migrantes & Consejos"}
+                    </span>
+                  </button>
+                </li>
+              )}
+              {isTabVisible("feedback") && (
+                <li>
+                  <button
+                    onClick={() => handleNavigate("feedback")}
+                    className="footer-link w-full min-h-[44px] sm:min-h-0 flex items-center gap-2 py-2.5 sm:py-1 px-2 -mx-2 rounded-lg hover:bg-surface-container dark:hover:bg-slate-800 hover:text-primary dark:hover:text-sky-300 transition-all text-left"
+                  >
+                    <MessageSquarePlus className="w-3.5 h-3.5 text-rose-500 shrink-0" />
+                    <span>
+                      {language === "en"
+                        ? "Suggest New Feature or Scholarship"
+                        : "Sugerir Nueva Beca o Función"}
+                    </span>
+                  </button>
+                </li>
+              )}
               <li>
                 <button
                   onClick={() => handleNavigate("chat")}

--- a/src/components/MobileBottomNav.test.tsx
+++ b/src/components/MobileBottomNav.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders as render } from "../test/renderWithProviders";
+import { MobileBottomNav } from "./MobileBottomNav";
+
+describe("MobileBottomNav", () => {
+  const defaultProps = {
+    activeTab: "home" as const,
+    setActiveTab: vi.fn(),
+    onOpenMenu: vi.fn(),
+  };
+
+  it("offers the four destinations the product is built on", () => {
+    const { container } = render(<MobileBottomNav {...defaultProps} />);
+
+    for (const id of ["home", "becas", "guia", "chat"]) {
+      expect(container.querySelector(`#bottom-nav-${id}`), id).toBeInTheDocument();
+    }
+  });
+
+  it("offers nothing the product has hidden", () => {
+    const { container } = render(<MobileBottomNav {...defaultProps} />);
+
+    for (const id of ["planificador", "calculadora", "voluntariados", "comunidad", "feedback"]) {
+      expect(container.querySelector(`#bottom-nav-${id}`), id).toBeNull();
+    }
+  });
+
+  it("navigates on tap", () => {
+    const setActiveTab = vi.fn();
+    const { container } = render(<MobileBottomNav {...defaultProps} setActiveTab={setActiveTab} />);
+
+    fireEvent.click(container.querySelector("#bottom-nav-becas") as HTMLElement);
+    expect(setActiveTab).toHaveBeenCalledWith("becas");
+  });
+
+  it("marks the screen you are on, and only that one", () => {
+    const { container } = render(<MobileBottomNav {...defaultProps} activeTab="becas" />);
+
+    const current = container.querySelectorAll('[aria-current="page"]');
+    expect(current).toHaveLength(1);
+    expect(current[0].id).toBe("bottom-nav-becas");
+  });
+
+  it("marks nothing when the screen is not in the bar", () => {
+    // The consular map is reachable but has no slot here; the bar must not
+    // then highlight an unrelated destination.
+    const { container } = render(<MobileBottomNav {...defaultProps} activeTab="mapa" />);
+    expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
+  });
+
+  it("opens the drawer for everything else", () => {
+    const onOpenMenu = vi.fn();
+    const { container } = render(<MobileBottomNav {...defaultProps} onOpenMenu={onOpenMenu} />);
+
+    fireEvent.click(container.querySelector("#bottom-nav-menu") as HTMLElement);
+    expect(onOpenMenu).toHaveBeenCalled();
+  });
+
+  it("gives every control a name and a thumb-sized target", () => {
+    const { container } = render(<MobileBottomNav {...defaultProps} />);
+
+    container.querySelectorAll("button").forEach((button) => {
+      const name = button.textContent?.trim() || button.getAttribute("aria-label");
+      expect(name, button.id).toBeTruthy();
+    });
+  });
+});

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Home, GraduationCap, BookOpen, Sparkles, Menu } from "lucide-react";
+import { isTabVisible } from "../lib/navigation";
 import { NavigationTab } from "../types";
 import { useLanguage } from "../lib/i18n";
 
@@ -24,12 +25,16 @@ export const MobileBottomNav: React.FC<MobileBottomNavProps> = ({
   const { language } = useLanguage();
   const es = language !== "en";
 
-  const items: { id: NavigationTab; label: string; icon: React.ReactNode }[] = [
+  const allItems: { id: NavigationTab; label: string; icon: React.ReactNode }[] = [
     { id: "home", label: es ? "Inicio" : "Home", icon: <Home className="w-5 h-5" /> },
     { id: "becas", label: es ? "Becas" : "Grants", icon: <GraduationCap className="w-5 h-5" /> },
     { id: "guia", label: es ? "Guías" : "Guides", icon: <BookOpen className="w-5 h-5" /> },
     { id: "chat", label: es ? "Chat IA" : "AI Chat", icon: <Sparkles className="w-5 h-5" /> },
   ];
+
+  // None of these four are hidden today, but the bar reads the same list
+  // as the rest of the navigation so it cannot drift from it.
+  const items = allItems.filter((item) => isTabVisible(item.id));
 
   const handleNavigate = (tab: NavigationTab) => {
     setActiveTab(tab);

--- a/src/components/TopNavBar.test.tsx
+++ b/src/components/TopNavBar.test.tsx
@@ -25,16 +25,25 @@ describe("TopNavBar Component", () => {
     expect(screen.getByText("Chat IA")).toBeInTheDocument();
   });
 
-  it("groups secondary destinations behind the tools menu", () => {
+  /**
+   * The product is narrowed to Becas and Guías. The tools menu held only
+   * hidden screens for a signed-out visitor, so it no longer renders at all
+   * rather than opening onto nothing.
+   */
+  it("offers no destination that the product has hidden", () => {
     render(<TopNavBar {...defaultProps} />);
 
-    // Not inline in the bar...
-    expect(screen.queryByText("Comunidad")).not.toBeInTheDocument();
+    for (const label of [/Comunidad/i, /Planificador/i, /Calculadora/i, /Voluntariados/i]) {
+      expect(screen.queryByText(label), String(label)).not.toBeInTheDocument();
+    }
+    expect(screen.queryByRole("button", { name: /Herramientas/i })).not.toBeInTheDocument();
+  });
 
-    // ...but one click away.
-    fireEvent.click(screen.getByRole("button", { name: /Herramientas/i }));
-    expect(screen.getByText("Comunidad")).toBeInTheDocument();
-    expect(screen.getByText(/Planificador/i)).toBeInTheDocument();
+  it("still offers the two screens the product is built on", () => {
+    render(<TopNavBar {...defaultProps} />);
+
+    expect(screen.getAllByText(/Becas/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Guía de Migración")).toBeInTheDocument();
   });
 
   /**
@@ -53,8 +62,16 @@ describe("TopNavBar Component", () => {
       ...overrides,
     });
 
-    const openToolsMenu = () =>
-      fireEvent.click(screen.getByRole("button", { name: /Herramientas/i }));
+    /**
+     * The tools menu only renders when it has something in it. For a
+     * non-administrator every entry behind it is now hidden, so the menu is
+     * absent — and "Panel de Control" is absent with it, which is what these
+     * cases are really about.
+     */
+    const openToolsMenu = () => {
+      const trigger = screen.queryByRole("button", { name: /Herramientas/i });
+      if (trigger) fireEvent.click(trigger);
+    };
 
     it("is hidden from a signed-in user with no admin entry", () => {
       render(<TopNavBar {...defaultProps} currentUser={signedIn()} />);

--- a/src/components/TopNavBar.tsx
+++ b/src/components/TopNavBar.tsx
@@ -23,6 +23,7 @@ import {
   Settings,
   Trash2,
 } from "lucide-react";
+import { isTabVisible } from "../lib/navigation";
 import { NavigationTab, ThemeMode, GoogleUser } from "../types";
 import { useLanguage } from "../lib/i18n";
 import { useCurrency } from "../lib/CurrencyContext";
@@ -199,7 +200,11 @@ export const TopNavBar: React.FC<TopNavBarProps> = ({
   };
 
   const userIsAdmin = isAdmin(currentUser);
-  const navItems = allNavItems.filter((item) => !item.adminOnly || userIsAdmin);
+  // Hidden screens leave the navigation together, from one list — see
+  // `src/lib/navigation.ts`.
+  const navItems = allNavItems.filter(
+    (item) => (!item.adminOnly || userIsAdmin) && isTabVisible(item.id)
+  );
   const primaryNavItems = navItems.filter((item) => item.primary);
   const secondaryNavItems = navItems.filter((item) => !item.primary);
   const secondaryIsActive = secondaryNavItems.some((item) => item.id === activeTab);

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { HIDDEN_TABS, isTabVisible } from "./navigation";
+import { NavigationTab } from "../types";
+
+/**
+ * The product is narrowed to Becas and Guías. These screens still exist and
+ * still compile; nothing links to them.
+ */
+describe("navigation visibility", () => {
+  it("keeps the screens the product is built on", () => {
+    for (const tab of ["home", "becas", "guia"] as NavigationTab[]) {
+      expect(isTabVisible(tab), tab).toBe(true);
+    }
+  });
+
+  it("hides the unfinished screens", () => {
+    for (const tab of [
+      "planificador",
+      "calculadora",
+      "voluntariados",
+      "comunidad",
+      "feedback",
+    ] as NavigationTab[]) {
+      expect(isTabVisible(tab), tab).toBe(false);
+    }
+  });
+
+  it("hides nothing the product depends on", () => {
+    // A hidden Becas or Guías would leave the application with no way in.
+    expect(HIDDEN_TABS).not.toContain("becas");
+    expect(HIDDEN_TABS).not.toContain("guia");
+    expect(HIDDEN_TABS).not.toContain("home");
+  });
+
+  it("lists each hidden screen once", () => {
+    expect(new Set(HIDDEN_TABS).size).toBe(HIDDEN_TABS.length);
+  });
+
+  it("treats an unknown tab as visible rather than swallowing it", () => {
+    // Failing open is right here: a screen that exists but is missing from
+    // the list should still be reachable, not silently unreachable.
+    expect(isTabVisible("something-new" as NavigationTab)).toBe(true);
+  });
+});

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,26 @@
+import { NavigationTab } from "../types";
+
+/**
+ * Screens the navigation does not offer.
+ *
+ * The product is being narrowed to Becas and Guías. These screens exist and
+ * still compile — their components, data and tests are untouched — but
+ * nothing links to them, so the navigation reflects what is actually
+ * finished.
+ *
+ * Restoring one is deleting a line here. That is the whole point of the list
+ * being in one place rather than repeated across the top bar, the drawer, the
+ * bottom bar and the footer.
+ */
+export const HIDDEN_TABS: readonly NavigationTab[] = [
+  "planificador",
+  "calculadora",
+  "voluntariados",
+  "comunidad",
+  "feedback",
+] as const;
+
+/** Whether the navigation should offer this screen. */
+export function isTabVisible(tab: NavigationTab): boolean {
+  return !HIDDEN_TABS.includes(tab);
+}

--- a/tests/e2e/consistency.spec.ts
+++ b/tests/e2e/consistency.spec.ts
@@ -6,23 +6,6 @@ import { test, expect } from "@playwright/test";
  */
 
 test.describe("Country selection consistency", () => {
-  test("a destination picked in the guides carries over to the planner", async ({ page }) => {
-    await page.goto("/");
-
-    await page.locator("#nav-item-guia").click();
-    await page
-      .getByRole("button", { name: /Alemania/i })
-      .first()
-      .click();
-    await expect(page.locator("text=Tipos de Visado en Alemania").first()).toBeVisible();
-
-    // Open the planner from the grouped tools menu.
-    await page.locator("#nav-tools-menu-btn").click();
-    await page.locator("#nav-item-planificador").click();
-
-    await expect(page.locator("#planner-destination-country")).toHaveValue("Alemania");
-  });
-
   // Uses Alemania rather than Portugal on purpose: LOCATIONS_DATA only covers
   // Alemania, Canadá, EE.UU., España, Reino Unido and Suiza, so a destination
   // outside that set has no consular entries for the map to select.
@@ -79,7 +62,8 @@ test.describe("Desktop navigation", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
 
-    const lastNavItem = await page.locator("#nav-tools-menu-btn").boundingBox();
+    // The tools menu is gone, so the last inline destination is the bar's end.
+    const lastNavItem = await page.locator("#nav-item-chat").boundingBox();
     const firstAction = await page.locator("#alerts-center-btn").boundingBox();
 
     expect(lastNavItem).not.toBeNull();
@@ -90,26 +74,15 @@ test.describe("Desktop navigation", () => {
     ).toBeLessThanOrEqual(firstAction!.x + 1);
   });
 
-  test("reaches secondary screens through the tools menu", async ({ page }) => {
-    await page.goto("/");
-
-    await expect(page.locator("#nav-item-calculadora")).toBeHidden();
-    await page.locator("#nav-tools-menu-btn").click();
-    await expect(page.locator("#nav-tools-menu")).toBeVisible();
-
-    await page.locator("#nav-item-calculadora").click();
-    await expect(page.locator("#nav-tools-menu")).toBeHidden();
-    await expect(page.locator("text=Calculadora").first()).toBeVisible();
-  });
-
-  test("closes the tools menu when clicking outside", async ({ page }) => {
-    await page.goto("/");
-
-    await page.locator("#nav-tools-menu-btn").click();
-    await expect(page.locator("#nav-tools-menu")).toBeVisible();
-
-    await page.locator("h1").first().click();
-    await expect(page.locator("#nav-tools-menu")).toBeHidden();
+  test("does not offer the screens the product has hidden", async ({ page }) => {
+    // Narrowed to Becas and Guías — see `src/lib/navigation.ts`. The tools
+    // menu held only hidden screens, so it is gone rather than opening onto
+    // nothing.
+    await expect(page.locator("#nav-item-planificador")).toHaveCount(0);
+    await expect(page.locator("#nav-item-calculadora")).toHaveCount(0);
+    await expect(page.locator("#nav-item-comunidad")).toHaveCount(0);
+    await expect(page.locator("#nav-item-voluntariados")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Herramientas/i })).toHaveCount(0);
   });
 
   test("groups currency, language and theme under one preferences menu", async ({ page }) => {
@@ -146,23 +119,6 @@ test.describe("Preference persistence", () => {
     await page.waitForTimeout(600);
     await page.reload();
     await expect.poll(isDark).toBe(!before);
-  });
-
-  test("keeps the destination country across a reload", async ({ page }) => {
-    await page.goto("/");
-    await page.locator("#nav-item-guia").click();
-    await page
-      .getByRole("button", { name: /Alemania/i })
-      .first()
-      .click();
-
-    await page.waitForTimeout(600); // past the write debounce
-    await page.reload();
-
-    // The planner reads the same context, so the choice must survive there too.
-    await page.locator("#nav-tools-menu-btn").click();
-    await page.locator("#nav-item-planificador").click();
-    await expect(page.locator("#planner-destination-country")).toHaveValue("Alemania");
   });
 
   test("stores preferences in a cookie and never in browser storage", async ({ page }) => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,18 +1,14 @@
 import { Page, expect } from "@playwright/test";
 
-/** Every screen reachable from the navigation. */
-export const ALL_TABS = [
-  "home",
-  "planificador",
-  "calculadora",
-  "becas",
-  "voluntariados",
-  "guia",
-  "mapa",
-  "comunidad",
-  "feedback",
-  "chat",
-] as const;
+/**
+ * Every screen reachable from the navigation.
+ *
+ * The product is narrowed to Becas and Guías, so the planner, the calculator,
+ * volunteering, the community and the feedback hub are no longer offered —
+ * see `src/lib/navigation.ts`. Their components still exist; nothing links to
+ * them. Restoring one means adding it back here as well.
+ */
+export const ALL_TABS = ["home", "becas", "guia", "mapa", "chat"] as const;
 
 export type Tab = (typeof ALL_TABS)[number];
 

--- a/tests/e2e/latinomigra.spec.ts
+++ b/tests/e2e/latinomigra.spec.ts
@@ -20,11 +20,9 @@ test.describe("LatinoMigra - End to End Suite", () => {
     await expect(page.locator("#nav-item-guia")).toBeVisible();
     await expect(page.locator("#nav-item-chat")).toBeVisible();
     await expect(page.locator("#nav-item-mapa")).toBeVisible();
-    // Secondary destinations live behind the grouped tools menu.
-    await expect(page.locator("#nav-tools-menu-btn")).toBeVisible();
-    await page.locator("#nav-tools-menu-btn").click();
-    await expect(page.locator("#nav-item-comunidad")).toBeVisible();
-    await page.keyboard.press("Escape");
+    // The tools menu held only screens the product has hidden, so it no
+    // longer renders — see `src/lib/navigation.ts`.
+    await expect(page.locator("#nav-tools-menu-btn")).toHaveCount(0);
 
     // Check metrics / trust badges exist
     await expect(page.locator("text=+5,000 Becas Activas").first()).toBeVisible();
@@ -111,18 +109,6 @@ test.describe("LatinoMigra - End to End Suite", () => {
     // Verify country filters exist
     await expect(page.locator("text=Tu País de Origen:")).toBeVisible();
     await expect(page.locator("#select-user-country")).toBeVisible();
-  });
-
-  test("6. Pantalla Comunidad: Historias de éxito y red de apoyo", async ({ page }) => {
-    // Click on "Comunidad" tab
-    await page.locator("#nav-tools-menu-btn").click();
-    await page.locator("#nav-item-comunidad").click();
-
-    // Verify Comunidad heading
-    await expect(page.locator("h1").first()).toContainText("Foros y Experiencias");
-
-    // Verify forum search or button
-    await expect(page.locator("#new-post-forum-btn")).toBeVisible();
   });
 
   test("7. Cambio de Tema: alterna entre Modo Claro y Modo Oscuro", async ({ page }) => {

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -78,9 +78,10 @@ test.describe("Mobile navigation", () => {
     await page.locator("#bottom-nav-menu").click();
     await expect(page.locator("#mobile-nav-drawer")).toBeVisible();
 
-    await page.locator("#drawer-nav-item-calculadora").click();
+    // The calculator is no longer offered — see `src/lib/navigation.ts`.
+    await page.locator("#drawer-nav-item-mapa").click();
     await expect(page.locator("#mobile-nav-drawer")).toBeHidden();
-    await expect(page.locator("h1").first()).toContainText("Calculadora de Costo de Vida");
+    await expect(page.locator("h1").first()).toContainText(/Consular|Consulados/i);
   });
 
   test("closes the drawer with Escape", async ({ page }) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       thresholds: {
         statements: 54,
         branches: 49,
-        functions: 48,
+        functions: 50,
         lines: 54,
         "src/lib/PreferencesContext.tsx": {
           statements: 95,


### PR DESCRIPTION
Closes #57.

Ten screens were reachable from the navigation. Two are the product; the rest are unfinished and dilute both the navigation and the effort.

Leaving the top bar, drawer, bottom bar and footer: **Planificador, Calculadora, Voluntariados, Comunidad, Sugerencias**.

## Hidden, not deleted

Components, data and tests are untouched and still compile. `src/lib/navigation.ts` holds the single list:

```ts
export const HIDDEN_TABS: readonly NavigationTab[] = [
  "planificador", "calculadora", "voluntariados", "comunidad", "feedback",
];
```

Restoring a screen is deleting one line — not editing four components. That is what stops the four navigations drifting apart.

## Two consequences worth naming

- The desktop **"Herramientas" menu no longer renders at all** for anyone who is not an administrator: every entry behind it is hidden, and a menu that opens onto nothing is worse than no menu.
- Navigation is `useState` in `App.tsx` with **no router**, so a hidden screen has no URL to arrive by. It is genuinely unreachable — that answers the open question in the issue.

## Coverage removed, said plainly

These E2E tests drove screens that no longer exist in the navigation, so they are removed rather than adapted:

| file | test |
|---|---|
| `consistency.spec.ts` | destination carries over to the planner |
| `consistency.spec.ts` | keeps the destination country across a reload |
| `consistency.spec.ts` | reaches secondary screens through the tools menu |
| `consistency.spec.ts` | closes the tools menu when clicking outside |
| `latinomigra.spec.ts` | the Comunidad screen |
| `mobile.spec.ts` | drawer navigation (now uses the consular map) |

**What is genuinely lost**: end-to-end coverage of country sharing between the guides and the planner. It cannot be replaced end to end while the planner is unreachable. It belongs in a unit test on `PreferencesContext`, which is already at 100% statements for the sharing logic itself — flagging it rather than pretending nothing went.

One `TopNavBar` unit test is rewritten: it asserted Comunidad and Planificador were one click away, which is exactly the behaviour being removed.

## Tests added

- **`navigation.test.ts` (5)** — kept screens, hidden screens, nothing the product depends on is hidden, no duplicates, and an unknown tab is treated as *visible* rather than silently unreachable.
- **`MobileBottomNav.test.tsx` (7)**, the component's first — the four destinations, none of the hidden ones, navigation on tap, exactly one `aria-current`, none when the screen has no slot, the drawer button, every control named.
- **`Footer.test.tsx` (4)** — no control leads to a hidden screen, the kept ones work, and no column is left as a heading over nothing.

```
221 unit tests passed
53 Playwright tests passed
lint and format clean
```

Coverage: functions 48 → **50**.

## Documentation

`docs/ux.md` gains a **What the navigation offers** section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_