### PR TITLE
fix(home): say what the platform is, and lead only where it can go

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -131,6 +131,19 @@ Recently addressed and verified by tests:
 - Dismissing the drawer restores the reading position instead of jumping to the
   top.
 
+## The first screen
+
+- Two destinations, side by side at every width. Three wide buttons wrapped
+  onto three full-width lines at 375px and read as stacked blocks rather than
+  a choice — and the third led to the planner, which the navigation no longer
+  offers.
+- No catalogue figures. The badge claimed "+5,000 Becas Activas" against a
+  catalogue of 22, on the one screen whose job is to say what the product is.
+  Numbers about the catalogue belong on the catalogue, where they are counted
+  rather than asserted.
+- Nothing here links to a hidden screen. The planner card is gone with the
+  planner.
+
 ## Scholarship list
 
 - One way through the catalogue. The screen carried a numbered pager and a

--- a/src/components/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders as render } from "../test/renderWithProviders";
+import { Breadcrumbs } from "./Breadcrumbs";
+
+describe("Breadcrumbs", () => {
+  const defaultProps = { activeTab: "becas" as const, setActiveTab: vi.fn() };
+
+  it("renders nothing on the first screen", () => {
+    // A trail from home to home says nothing.
+    const { container } = render(<Breadcrumbs {...defaultProps} activeTab="home" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("names the trail for assistive technology", () => {
+    render(<Breadcrumbs {...defaultProps} />);
+    expect(screen.getByRole("navigation")).toHaveAccessibleName(/breadcrumb/i);
+  });
+
+  it("offers a way back to the first screen", () => {
+    const setActiveTab = vi.fn();
+    render(<Breadcrumbs {...defaultProps} setActiveTab={setActiveTab} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Inicio/i }));
+    expect(setActiveTab).toHaveBeenCalledWith("home");
+  });
+
+  it("names the screen you are on", () => {
+    render(<Breadcrumbs {...defaultProps} />);
+    expect(screen.getByText(/Catálogo de Becas/i)).toBeInTheDocument();
+  });
+
+  it("adds the sub-page when one is given", () => {
+    render(<Breadcrumbs {...defaultProps} subPageTitle="Beca DAAD" />);
+
+    expect(screen.getByText(/Catálogo de Becas/i)).toBeInTheDocument();
+    expect(screen.getByText("Beca DAAD")).toBeInTheDocument();
+  });
+
+  it("falls back to the tab's own name rather than rendering a blank step", () => {
+    render(<Breadcrumbs {...defaultProps} activeTab={"guia"} />);
+    expect(screen.getByText(/Guía de Migración/i)).toBeInTheDocument();
+  });
+
+  it("accepts extra classes without losing its own layout", () => {
+    render(<Breadcrumbs {...defaultProps} className="mb-4" />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("mb-4");
+    // The trail scrolls rather than wrapping: it sits above the page title
+    // on a phone.
+    expect(nav).toHaveClass("overflow-x-auto");
+  });
+});

--- a/src/components/HeroLanding.test.tsx
+++ b/src/components/HeroLanding.test.tsx
@@ -33,8 +33,6 @@ describe("HeroLanding Component", () => {
     const destinations: [string, string][] = [
       ["hero-btn-becas", "becas"],
       ["hero-btn-guias", "guia"],
-      ["hero-btn-planificador", "planificador"],
-      ["feature-btn-plan", "planificador"],
       ["feature-btn-chat", "chat"],
       ["feature-btn-guia-step", "guia"],
       ["feature-btn-becas-verified", "becas"],
@@ -57,7 +55,7 @@ describe("HeroLanding Component", () => {
 
       // A landing page whose buttons point at a removed screen is the failure
       // this guards: every destination has to be one the app can render.
-      const known = new Set(["becas", "guia", "planificador", "chat", "home"]);
+      const known = new Set(["becas", "guia", "chat", "home"]);
       container.querySelectorAll("button").forEach((button) => {
         setActiveTab.mockClear();
         fireEvent.click(button);
@@ -130,7 +128,7 @@ describe("HeroLanding Component", () => {
     it("still offers every destination", () => {
       const { container } = render(<HeroLanding setActiveTab={vi.fn()} />);
 
-      for (const id of ["hero-btn-becas", "hero-btn-guias", "hero-btn-planificador"]) {
+      for (const id of ["hero-btn-becas", "hero-btn-guias"]) {
         expect(container.querySelector(`#${id}`), id).toBeInTheDocument();
       }
     });
@@ -149,6 +147,55 @@ describe("HeroLanding Component", () => {
         const name = button.textContent?.trim() || button.getAttribute("aria-label");
         expect(name, `button#${button.id}`).toBeTruthy();
       });
+    });
+  });
+  /**
+   * The first screen says what the platform is and where to go. It used to
+   * also carry catalogue figures, and its actions read as stacked blocks on a
+   * phone.
+   */
+  describe("what the first screen offers", () => {
+    it("leads only to screens the navigation offers", () => {
+      const setActiveTab = vi.fn();
+      const { container } = render(<HeroLanding setActiveTab={setActiveTab} />);
+
+      // The planner is hidden, so a link to it from here is a dead end.
+      expect(container.querySelector("#hero-btn-planificador")).toBeNull();
+      expect(container.querySelector("#feature-btn-plan")).toBeNull();
+
+      container.querySelectorAll("button").forEach((button) => {
+        setActiveTab.mockClear();
+        fireEvent.click(button);
+        for (const call of setActiveTab.mock.calls) {
+          expect(call[0], button.id || button.textContent?.trim()).not.toBe("planificador");
+        }
+      });
+    });
+
+    it("makes no claim about the size of the catalogue", () => {
+      render(<HeroLanding setActiveTab={vi.fn()} />);
+
+      // The badge said "+5,000 Becas Activas" against a catalogue of 22.
+      expect(screen.queryByText(/\+5,000/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Becas Activas/i)).not.toBeInTheDocument();
+    });
+
+    it("puts its two destinations side by side rather than stacked", () => {
+      const { container } = render(<HeroLanding setActiveTab={vi.fn()} />);
+
+      const becas = container.querySelector("#hero-btn-becas");
+      const guias = container.querySelector("#hero-btn-guias");
+      expect(becas?.parentElement).toBe(guias?.parentElement);
+      // Two columns at every width, so neither becomes a full-bleed block.
+      expect(becas?.parentElement).toHaveClass("grid-cols-2");
+    });
+
+    it("keeps both actions at a thumb-sized target", () => {
+      const { container } = render(<HeroLanding setActiveTab={vi.fn()} />);
+
+      for (const id of ["hero-btn-becas", "hero-btn-guias"]) {
+        expect(container.querySelector(`#${id}`), id).toHaveClass("min-h-[48px]");
+      }
     });
   });
 });

--- a/src/components/HeroLanding.tsx
+++ b/src/components/HeroLanding.tsx
@@ -86,15 +86,20 @@ export const HeroLanding: React.FC<HeroLandingProps> = ({ setActiveTab, currentU
               prevención de estafas y soporte consular.
             </p>
 
-            {/* Action Buttons */}
-            <div className="flex flex-wrap items-center gap-3.5 pt-2">
+            {/*
+              Two destinations, side by side even on a phone. Three wide
+              buttons wrapped onto three full-width lines at 375px and read as
+              stacked blocks rather than a choice — and the third led to the
+              planner, which the navigation no longer offers.
+            */}
+            <div className="grid grid-cols-2 gap-3 pt-2 sm:flex sm:flex-wrap sm:items-center">
               <button
                 onClick={() => setActiveTab("becas")}
                 id="hero-btn-becas"
                 aria-label="Buscar Becas"
-                className="inline-flex items-center gap-2 bg-primary dark:bg-sky-600 hover:bg-primary-container text-on-primary dark:text-white px-5 py-3 rounded-xl font-bold text-sm shadow-md hover:shadow-lg transition-all active:scale-95 cursor-pointer"
+                className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-xl bg-primary dark:bg-sky-600 px-4 text-sm font-bold text-on-primary dark:text-white shadow-md transition-all hover:bg-primary-container hover:shadow-lg active:scale-95 cursor-pointer"
               >
-                <Search className="w-4 h-4" />
+                <Search className="w-4 h-4 shrink-0" aria-hidden="true" />
                 <span>Buscar Becas</span>
               </button>
 
@@ -102,20 +107,10 @@ export const HeroLanding: React.FC<HeroLandingProps> = ({ setActiveTab, currentU
                 onClick={() => setActiveTab("guia")}
                 id="hero-btn-guias"
                 aria-label="Ver Guías Migratorias"
-                className="inline-flex items-center gap-2 bg-secondary dark:bg-teal-600 hover:bg-secondary/90 text-white px-5 py-3 rounded-xl font-bold text-sm shadow-md hover:shadow-lg transition-all active:scale-95 cursor-pointer"
+                className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-xl bg-secondary dark:bg-teal-600 px-4 text-sm font-bold text-white shadow-md transition-all hover:bg-secondary/90 hover:shadow-lg active:scale-95 cursor-pointer"
               >
-                <Compass className="w-4 h-4" />
-                <span>Ver Guías Migratorias</span>
-              </button>
-
-              <button
-                onClick={() => setActiveTab("planificador")}
-                id="hero-btn-planificador"
-                aria-label="Armar Mi Plan de Migración"
-                className="inline-flex items-center gap-2 bg-surface-container dark:bg-slate-800 hover:bg-surface-container-high text-primary dark:text-sky-300 px-4 py-3 rounded-xl font-semibold text-sm border border-outline-variant/60 dark:border-slate-700 transition-all active:scale-95 cursor-pointer"
-              >
-                <Calculator className="w-4 h-4 text-emerald-500" />
-                <span>Planificador 360°</span>
+                <Compass className="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span>Ver Guías</span>
               </button>
             </div>
 
@@ -143,20 +138,12 @@ export const HeroLanding: React.FC<HeroLandingProps> = ({ setActiveTab, currentU
               <div className="absolute inset-0 bg-gradient-to-t from-primary/40 via-transparent to-transparent" />
             </div>
 
-            {/* Floating Stats Badge */}
-            <div className="absolute -bottom-6 -left-4 sm:left-4 bg-surface-container-lowest dark:bg-slate-800/95 backdrop-blur-md p-4 rounded-2xl shadow-xl border border-outline-variant/50 dark:border-slate-700 flex items-center gap-4">
-              <div className="w-12 h-12 rounded-xl bg-secondary-container/40 dark:bg-teal-500/20 text-secondary dark:text-teal-300 flex items-center justify-center font-bold">
-                <Award className="w-6 h-6" />
-              </div>
-              <div>
-                <span className="block text-xs font-bold text-on-surface-variant dark:text-slate-400 uppercase tracking-wider">
-                  Oportunidades
-                </span>
-                <span className="text-xl font-extrabold text-primary dark:text-sky-300">
-                  +5,000 Becas Activas
-                </span>
-              </div>
-            </div>
+            {/*
+              No catalogue figures here. This badge claimed "+5,000 Becas
+              Activas" against a catalogue of 22, on the screen whose job is
+              to say what the product is. Numbers about the catalogue belong
+              on the catalogue, where they are counted rather than asserted.
+            */}
           </div>
         </div>
       </section>
@@ -172,31 +159,7 @@ export const HeroLanding: React.FC<HeroLandingProps> = ({ setActiveTab, currentU
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          {/* Card 1: Planificador */}
-          <div className="bg-surface-container-lowest dark:bg-slate-800 p-6 rounded-2xl border border-secondary/30 dark:border-teal-500/30 hover:shadow-lg transition-all space-y-4 flex flex-col justify-between">
-            <div className="space-y-3">
-              <div className="w-12 h-12 rounded-xl bg-teal-100 dark:bg-teal-900/50 text-teal-600 dark:text-teal-300 flex items-center justify-center">
-                <Calculator className="w-6 h-6" />
-              </div>
-              <h3 className="font-headline-sm text-lg font-bold text-primary dark:text-sky-300">
-                Planificador de Migración
-              </h3>
-              <p className="text-xs text-on-surface-variant dark:text-slate-300 leading-relaxed">
-                Calcula presupuesto real, recomendaciones de ciudad por clima/coste, guía
-                antiestafas y checklist con o sin hijos.
-              </p>
-            </div>
-            <button
-              onClick={() => setActiveTab("planificador")}
-              id="feature-btn-plan"
-              className="inline-flex items-center gap-2 min-h-[44px] text-secondary dark:text-teal-300 font-semibold text-xs hover:underline pt-2"
-            >
-              <span>Configurar Plan</span>
-              <ArrowRight className="w-3.5 h-3.5" />
-            </button>
-          </div>
-
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Card 2: AI Assistant */}
           <div className="bg-surface-container-lowest dark:bg-slate-800 p-6 rounded-2xl border border-outline-variant/40 dark:border-slate-700 hover:shadow-lg transition-all space-y-4 flex flex-col justify-between">
             <div className="space-y-3">

--- a/tests/e2e/latinomigra.spec.ts
+++ b/tests/e2e/latinomigra.spec.ts
@@ -26,8 +26,9 @@ test.describe("LatinoMigra - End to End Suite", () => {
     await expect(page.locator("#nav-item-comunidad")).toBeVisible();
     await page.keyboard.press("Escape");
 
-    // Check metrics / trust badges exist
-    await expect(page.locator("text=+5,000 Becas Activas").first()).toBeVisible();
+    // No catalogue figures on the first screen: the badge claimed "+5,000
+    // Becas Activas" against a catalogue of 22.
+    await expect(page.getByText(/\+5,000/)).toHaveCount(0);
   });
 
   test("2. Pantalla Explorador de Becas: Filtros, búsqueda y modal de detalle", async ({

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -450,3 +450,44 @@ test.describe("Mobile dialog focus", () => {
     await expect(trigger).toBeFocused();
   });
 });
+
+/**
+ * The first screen on a phone.
+ *
+ * Its three hero actions wrapped onto three full-width lines at 375px and
+ * read as stacked blocks rather than a choice, and one of them led to the
+ * planner, which the navigation no longer offers.
+ */
+test.describe("Home on a phone", () => {
+  test("puts its two destinations on one row", async ({ page }) => {
+    await page.goto("/");
+
+    const becas = await page.locator("#hero-btn-becas").boundingBox();
+    const guias = await page.locator("#hero-btn-guias").boundingBox();
+
+    expect(becas).not.toBeNull();
+    expect(guias).not.toBeNull();
+    // Same top edge means one row. Stacked blocks was the complaint.
+    expect(Math.abs(becas!.y - guias!.y)).toBeLessThanOrEqual(2);
+
+    const width = page.viewportSize()!.width;
+    expect(becas!.x + becas!.width).toBeLessThanOrEqual(width);
+    expect(guias!.x + guias!.width).toBeLessThanOrEqual(width);
+  });
+
+  test("keeps both actions thumb-sized", async ({ page }) => {
+    await page.goto("/");
+
+    for (const id of ["#hero-btn-becas", "#hero-btn-guias"]) {
+      const box = await page.locator(id).boundingBox();
+      expect(box!.height, id).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test("offers no route to a screen the navigation has hidden", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("#hero-btn-planificador")).toHaveCount(0);
+    await expect(page.locator("#feature-btn-plan")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #55.

## Three hero buttons became two

At 375px they wrapped onto three full-width lines and read as stacked blocks rather than a choice. Two destinations now share a row at every width, each at a 48px target.

The third led to the planner, which the navigation no longer offers.

## The catalogue figure is gone

The badge claimed **"+5,000 Becas Activas"** against a bundled catalogue of **22** — on the one screen whose job is to say what the product *is*.

Numbers about the catalogue belong on the catalogue, where they are counted rather than asserted. This is also the "scholarship content on Home" the issue asks to remove.

## This closes a gap in #57 — one I left

#57 hid the planner from the navigation but left Home linking to it **twice**, from `hero-btn-planificador` and `feature-btn-plan`. Its own acceptance criterion said "no dead ends", and I missed it there. Both are gone, along with the planner feature card.

## Two existing tests updated

- The parameterised destination table listed the planner twice — that behaviour is deliberately removed.
- The E2E home test asserted the "+5,000" badge was visible.

## Tests added

**`HeroLanding.test.tsx` (4)** — no control anywhere on the screen navigates to the planner (every button is clicked and checked, not just the two known ids), no claim about catalogue size, the two actions share a parent and a two-column grid rather than stacking, both keep a 48px target.

**`mobile.spec.ts` (3)** — in a real browser: the two actions share a top edge and stay inside the viewport, both at least 44px tall, neither hidden-screen control exists.

**`Breadcrumbs.test.tsx` (7)**, the component's first — nothing renders on the first screen, the trail is named for assistive technology, home is reachable, the current screen is named, a sub-page is appended, an unknown tab falls back to its own name, the trail scrolls rather than wrapping.

```
213 unit tests passed
60 Playwright tests passed
lint and format clean
```

## Coverage

Held at 54/49/48/54. Worth being precise: this change **removed more covered lines than it added**, and dipped statements to 53.97%. The ratchet caught it, and the Breadcrumbs tests are what brought it back over — not a lowered threshold.

## Note on ordering

Cut from `main`, so it does not depend on #72 (#57). If #72 merges first the two are independent; if this merges first, the planner is unreachable from Home before it is unreachable from the navigation. Either order is safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_