### PR TITLE
fix(guias): stop inventing 18 votes, and give the vote somewhere to live (#79)

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -52,7 +52,7 @@ the table below is the only record of the intended shape.
 | `forumPosts` | public | **`create` unauthenticated** | Browser |
 | `forumPosts/{id}/replies` | public | **`create` unauthenticated** | Browser |
 | `feedbackSuggestions` | public | **`create` unauthenticated** | Browser |
-| `visa_guide_votes/{code}/visas` | **no rule declared** | **no rule declared** | Browser (always denied) |
+| `visa_guide_votes/{voteId}` | Public | Signed-in, own id only, create only | Browser |
 
 ### Rule structure
 
@@ -79,15 +79,26 @@ accepts — `uid`, `displayName`, `email`, `photoURL`, `countryOfOrigin`,
 `updatedAt`. `allow write` previously accepted any field, including `role`,
 which `App.tsx` read back as an authorization decision.
 
-### `visa_guide_votes` — undeclared path
+### `visa_guide_votes` — one document per (user, country, visa)
 
-`fetchVisaGuideVotes` and `voteVisaHelpful` in `src/lib/firebase.ts` read and
-write `visa_guide_votes/{countryCode}/visas`. That path appears in no `match`
-block, so the deny-all catch-all applies. Both functions catch the permission
-error and fall back to a module-level `Map`, so the failure is invisible. Guide
-helpfulness votes have never persisted.
+The path used to be `visa_guide_votes/{countryCode}/visas`, which appeared in no
+`match` block, so the deny-all catch-all applied. Both functions caught the
+permission error and fell back to a module-level `Map`, so the failure was
+invisible — and the guide printed `helpfulVotes || 18`, an invented count, for
+every visa in the product (#24, #79).
 
-It is the only collection referenced in code but absent from the rules.
+It is a flat collection now. The document id is
+`{uid}__{countryCode}__{visaId}`, and the rule requires the id to match the
+fields in the document, so the id itself enforces one vote per person: a second
+vote writes the same document and `create` fails once it exists. There is no
+`update` and no `delete`, and no stored counter — a counter any signed-in
+client may increment is a counter anyone can inflate, and there is no server
+here to hold it.
+
+The count is an aggregation over those documents (`getCountFromServer`), which
+is why `read` is public: a guest sees the counts and cannot vote.
+
+A failed read leaves the counts unknown, and unknown renders as no number.
 
 ## Write paths
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -240,6 +240,11 @@ Recently addressed and verified by tests:
   The breakpoint sits on a wrapper rather than on the control itself:
   `lg:hidden` and a display utility on one element let the emitted order pick
   the winner, and it picked `inline-flex`.
+- The usefulness counter shows a number only when one was read. It printed
+  `helpfulVotes || 18` for every visa, so a country with no votes claimed
+  eighteen people had found each visa useful; a failed read now says so and a
+  visa with no votes invites the first one. Voting requires signing in, because
+  the vote document is keyed by the person casting it.
 - The migration route no longer marks a phase as the one you are on.
   `activeRoadmapStep` started at 2, so phase two was flagged as current for
   every visitor on every load, and tapping a card moved a marker that meant

--- a/firestore.rules
+++ b/firestore.rules
@@ -100,6 +100,33 @@ service cloud.firestore {
       allow delete: if isSignedIn() && resource.data.userId == request.auth.uid;
     }
 
+    // Visa guide votes: one document per (user, country, visa).
+    //
+    // The collection had no rule at all, so every write was denied by the
+    // catch-all and the client swallowed the failure and printed an invented
+    // count instead (#24, #79).
+    //
+    // The document id carries all three parts, so the id itself enforces one
+    // vote per person: a second vote writes the same document, and `create`
+    // fails once it exists. That is why there is no update rule and no stored
+    // counter -- a counter any signed-in client may increment is a counter
+    // anyone can inflate, and there is no server here to hold it. The count is
+    // an aggregation over these documents, which is why read is public.
+    match /visa_guide_votes/{voteId} {
+      allow read: if true;
+      allow create: if isSignedIn()
+                    && voteId == request.auth.uid + '__'
+                                 + request.resource.data.countryCode + '__'
+                                 + request.resource.data.visaId
+                    && request.resource.data.userId == request.auth.uid
+                    && isValidId(request.resource.data.countryCode)
+                    && isValidId(request.resource.data.visaId)
+                    && request.resource.data.keys().hasOnly(
+                         ['userId', 'countryCode', 'visaId', 'createdAt']);
+      // No update and no delete: a vote is a fact about a moment, and an
+      // editable one is a counter in disguise.
+    }
+
     // Community Forum Posts: Anyone can read, authenticated or guest users can post/like with size limits
     match /forumPosts/{postId} {
       allow read: if true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -266,7 +266,12 @@ export default function App() {
 
         {activeTab === "guia" && (
           <main className="animate-fade-in">
-            <GuiaMigracion setActiveTab={setActiveTab} onAskAIAboutGuide={handleAskAIAboutGuide} />
+            <GuiaMigracion
+              setActiveTab={setActiveTab}
+              onAskAIAboutGuide={handleAskAIAboutGuide}
+              currentUser={currentUser}
+              onOpenAuthModal={() => setAuthModalOpen(true)}
+            />
           </main>
         )}
 

--- a/src/components/GuiaMigracion.tsx
+++ b/src/components/GuiaMigracion.tsx
@@ -25,6 +25,7 @@ import { COUNTRY_ANTI_SCAM_DATA } from "../data/antiScamData";
 import { Disclosure } from "./ui/Disclosure";
 import { CalendarAgendaButton } from "./CalendarAgendaButton";
 import { fetchVisaGuideVotes, voteVisaHelpful, VisaVotesData } from "../lib/firebase";
+import { GoogleUser } from "../types";
 import { usePreferences } from "../lib/PreferencesContext";
 import { useCurrency } from "../lib/CurrencyContext";
 import { convertCostRange, formatCostRange } from "../lib/currency";
@@ -32,11 +33,16 @@ import { convertCostRange, formatCostRange } from "../lib/currency";
 interface GuiaMigracionProps {
   setActiveTab: (tab: NavigationTab) => void;
   onAskAIAboutGuide: (countryName: string, visaName?: string) => void;
+  /** Voting needs an identity: the vote document is keyed by it. */
+  currentUser?: GoogleUser | null;
+  onOpenAuthModal?: () => void;
 }
 
 export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
   setActiveTab,
   onAskAIAboutGuide,
+  currentUser,
+  onOpenAuthModal,
 }) => {
   const { t } = useLanguage();
   // Country selection is shared app-wide, so opening a guide for Alemania also
@@ -49,41 +55,64 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
   const [visaVotes, setVisaVotes] = useState<Record<string, VisaVotesData>>({});
   const [userVotedVisas, setUserVotedVisas] = useState<Record<string, boolean>>({});
 
+  /**
+   * How the vote counts are going.
+   *
+   * The counter used to print `helpfulVotes || 18` — so a country with no votes
+   * at all, which is every country while the collection is empty, claimed
+   * eighteen people had found each visa useful. A count that could not be read
+   * now renders as no count (#79).
+   */
+  const [votesStatus, setVotesStatus] = useState<"loading" | "loaded" | "failed">("loading");
+  const [voteError, setVoteError] = useState<string | null>(null);
+
   const guide = MIGRATION_GUIDES_DATA[selectedCountryCode] || MIGRATION_GUIDES_DATA["ES"];
 
-  // Fetch real-time votes & stats for the active country from Firestore DB
+  // Community vote counts for the active country.
   useEffect(() => {
     let isMounted = true;
-    async function loadVotes() {
-      try {
-        const data = await fetchVisaGuideVotes(selectedCountryCode);
-        if (isMounted) {
-          setVisaVotes(data);
-        }
-      } catch (e) {
+    setVotesStatus("loading");
+    fetchVisaGuideVotes(selectedCountryCode)
+      .then((data) => {
+        if (!isMounted) return;
+        setVisaVotes(data);
+        setVotesStatus("loaded");
+      })
+      .catch((e) => {
         console.warn("Could not load visa votes:", e);
-      }
-    }
-    loadVotes();
+        if (isMounted) setVotesStatus("failed");
+      });
     return () => {
       isMounted = false;
     };
   }, [selectedCountryCode]);
 
+  // A vote belongs to a person, so the tab change carries no votes with it.
+  useEffect(() => {
+    setUserVotedVisas({});
+  }, [selectedCountryCode, currentUser?.id]);
+
   const handleVoteVisa = async (visaId: string) => {
+    if (!currentUser?.id) {
+      onOpenAuthModal?.();
+      return;
+    }
     if (userVotedVisas[visaId]) return;
-    setUserVotedVisas((prev) => ({ ...prev, [visaId]: true }));
+
+    setVoteError(null);
     try {
-      const newCount = await voteVisaHelpful(selectedCountryCode, visaId);
-      setVisaVotes((prev) => ({
-        ...prev,
-        [visaId]: {
-          ...(prev[visaId] || { difficultyRating: 3, totalReviews: 1 }),
-          helpfulVotes: newCount,
-        },
-      }));
+      const newCount = await voteVisaHelpful(currentUser.id, selectedCountryCode, visaId);
+      setUserVotedVisas((prev) => ({ ...prev, [visaId]: true }));
+      setVisaVotes((prev) => ({ ...prev, [visaId]: { helpfulVotes: newCount } }));
+      setVotesStatus("loaded");
     } catch (e) {
+      // The write used to be answered with an invented number from an
+      // in-memory cache, so a denied write looked exactly like a successful
+      // one. A failure has to be visible somewhere.
       console.warn("Vote error:", e);
+      setVoteError(
+        t("guia.voteFailed", "No pudimos registrar tu voto. Inténtalo de nuevo más tarde.")
+      );
     }
   };
 
@@ -289,6 +318,35 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
             </button>
           </div>
 
+          {/*
+            Where the vote counts came from. A denied read used to be swallowed
+            by a catch and replaced with an invented 18 per visa, so a broken
+            collection and a working one looked identical (#79, #24).
+          */}
+          <div role="status" aria-live="polite" className="empty:hidden">
+            {votesStatus === "failed" && (
+              <p
+                id="visa-votes-failed-status"
+                className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400"
+              >
+                <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                {t(
+                  "guia.votesUnavailable",
+                  "No pudimos cargar cuántas personas marcaron estas guías como útiles."
+                )}
+              </p>
+            )}
+            {voteError && (
+              <p
+                id="visa-vote-error"
+                className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400"
+              >
+                <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                {voteError}
+              </p>
+            )}
+          </div>
+
           {/* Visa Category Filter Chips */}
           {availableCategories.length > 0 && (
             <div className="flex flex-wrap items-center gap-2 pt-1">
@@ -442,8 +500,13 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
                       <button
                         onClick={() => handleVoteVisa(visa.id)}
                         disabled={userVotedVisas[visa.id]}
-                        title="Votar información útil"
-                        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-bold transition-all border cursor-pointer ${
+                        id={`visa-vote-${visa.id}`}
+                        title={
+                          currentUser
+                            ? t("guia.voteTitle", "Marcar esta información como útil")
+                            : t("guia.voteSignIn", "Inicia sesión para marcar esta guía como útil")
+                        }
+                        className={`inline-flex items-center gap-1.5 min-h-[44px] px-2.5 py-1 rounded-lg text-xs font-bold transition-all border cursor-pointer ${
                           userVotedVisas[visa.id]
                             ? "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/60 dark:text-emerald-300 dark:border-emerald-800"
                             : "bg-surface hover:bg-surface-container text-on-surface-variant dark:bg-slate-900 dark:text-slate-300 border-outline-variant/40 dark:border-slate-800"
@@ -452,7 +515,18 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
                         <ThumbsUp
                           className={`w-3.5 h-3.5 ${userVotedVisas[visa.id] ? "fill-current" : ""}`}
                         />
-                        <span>{visaVotes[visa.id]?.helpfulVotes || 18} útiles</span>
+                        {/*
+                          A count is shown only when one was read. No vote yet
+                          is "sé el primero", not a number — the control used to
+                          print 18 for every visa in the product.
+                        */}
+                        <span>
+                          {votesStatus === "loaded" && visaVotes[visa.id]
+                            ? `${visaVotes[visa.id].helpfulVotes} ${t("guia.voteCount", "útiles")}`
+                            : votesStatus === "loaded"
+                              ? t("guia.voteFirst", "Sé el primero en marcarla útil")
+                              : t("guia.voteUseful", "Marcar como útil")}
+                        </span>
                       </button>
                     </div>
 

--- a/src/components/GuiaMigracion.votes.test.tsx
+++ b/src/components/GuiaMigracion.votes.test.tsx
@@ -24,7 +24,13 @@ describe("Visa usefulness votes", () => {
     onAskAIAboutGuide: vi.fn(),
   };
 
-  const user = { id: "user-1", name: "Ana", email: "ana@example.com", picture: "" };
+  const user = {
+    id: "user-1",
+    name: "Ana",
+    email: "ana@example.com",
+    avatar: "",
+    signedInAt: new Date().toISOString(),
+  };
 
   beforeEach(() => {
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/components/GuiaMigracion.votes.test.tsx
+++ b/src/components/GuiaMigracion.votes.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { renderWithProviders as render } from "../test/renderWithProviders";
+import { GuiaMigracion } from "./GuiaMigracion";
+import * as firebase from "../lib/firebase";
+import { MIGRATION_GUIDES_DATA } from "../data/migrationGuides";
+
+/**
+ * Regression for #79.
+ *
+ * The counter rendered `visaVotes[visa.id]?.helpfulVotes || 18`, so every visa
+ * in the product claimed eighteen people had found it useful — a number nobody
+ * voted for, on the screen whose whole claim is that its information is
+ * sourced. Voting was component state and the failed write was answered from an
+ * in-memory cache, so a denied write looked exactly like a successful one.
+ */
+
+const firstVisaId = MIGRATION_GUIDES_DATA.ES.visas[0].id;
+
+describe("Visa usefulness votes", () => {
+  const defaultProps = {
+    setActiveTab: vi.fn(),
+    onAskAIAboutGuide: vi.fn(),
+  };
+
+  const user = { id: "user-1", name: "Ana", email: "ana@example.com", picture: "" };
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows no number when no votes were read", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockResolvedValue({});
+    render(<GuiaMigracion {...defaultProps} />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/Sé el primero en marcarla útil/).length).toBeGreaterThan(0)
+    );
+    expect(screen.queryByText(/18 útiles/)).not.toBeInTheDocument();
+  });
+
+  it("shows the count that was actually read", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockResolvedValue({
+      [firstVisaId]: { helpfulVotes: 3 },
+    });
+    render(<GuiaMigracion {...defaultProps} />);
+
+    await waitFor(() => expect(screen.getByText("3 útiles")).toBeInTheDocument());
+  });
+
+  it("says so when the counts could not be loaded, instead of inventing them", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockRejectedValue(new Error("permission denied"));
+    render(<GuiaMigracion {...defaultProps} />);
+
+    await waitFor(() =>
+      expect(document.getElementById("visa-votes-failed-status")).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/\d+ útiles/)).not.toBeInTheDocument();
+  });
+
+  it("asks a guest to sign in rather than pretending to record a vote", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockResolvedValue({});
+    const voteSpy = vi.spyOn(firebase, "voteVisaHelpful");
+    const onOpenAuthModal = vi.fn();
+
+    render(<GuiaMigracion {...defaultProps} onOpenAuthModal={onOpenAuthModal} />);
+    await waitFor(() => expect(document.getElementById(`visa-vote-${firstVisaId}`)).toBeTruthy());
+
+    fireEvent.click(document.getElementById(`visa-vote-${firstVisaId}`)!);
+
+    expect(onOpenAuthModal).toHaveBeenCalled();
+    expect(voteSpy).not.toHaveBeenCalled();
+  });
+
+  it("records a signed-in vote against that user and shows the new count", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockResolvedValue({});
+    const voteSpy = vi.spyOn(firebase, "voteVisaHelpful").mockResolvedValue(1);
+
+    render(<GuiaMigracion {...defaultProps} currentUser={user} />);
+    await waitFor(() => expect(document.getElementById(`visa-vote-${firstVisaId}`)).toBeTruthy());
+
+    fireEvent.click(document.getElementById(`visa-vote-${firstVisaId}`)!);
+
+    await waitFor(() => expect(screen.getByText("1 útiles")).toBeInTheDocument());
+    expect(voteSpy).toHaveBeenCalledWith(user.id, "ES", firstVisaId);
+  });
+
+  it("reports a rejected vote instead of showing a number nobody stored", async () => {
+    vi.spyOn(firebase, "fetchVisaGuideVotes").mockResolvedValue({});
+    vi.spyOn(firebase, "voteVisaHelpful").mockRejectedValue(new Error("permission denied"));
+
+    render(<GuiaMigracion {...defaultProps} currentUser={user} />);
+    await waitFor(() => expect(document.getElementById(`visa-vote-${firstVisaId}`)).toBeTruthy());
+
+    fireEvent.click(document.getElementById(`visa-vote-${firstVisaId}`)!);
+
+    await waitFor(() => expect(document.getElementById("visa-vote-error")).toBeInTheDocument());
+    expect(screen.queryByText(/\d+ útiles/)).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -23,6 +23,7 @@ import {
   updateDoc,
   deleteDoc,
   increment,
+  getCountFromServer,
   QueryDocumentSnapshot,
   DocumentData,
 } from "firebase/firestore";
@@ -812,75 +813,71 @@ export async function triggerScholarshipSync(
 
 export interface VisaVotesData {
   helpfulVotes: number;
-  difficultyRating: number; // 1-5
-  totalReviews: number;
 }
 
 /**
- * Fetch persistent community votes and rating stats for visas of a country from Firestore
+ * How many people marked each visa of a country as useful.
+ *
+ * One document per (user, country, visa), with the document id built from all
+ * three — so the id itself enforces one vote per person and no rule has to
+ * check for a second one. The count is an aggregation over those documents
+ * rather than a stored counter: a counter any signed-in client may increment
+ * is a counter anyone can inflate, and there is no server here to hold it.
+ *
+ * Returns votes only for the visas that have any. A visa missing from the
+ * result has an unknown count, which the interface renders as unknown — it
+ * used to render as 18, a number nobody voted for.
  */
-/**
- * In-memory fallback used when Firestore is unavailable. Nothing is written to
- * localStorage, so the cache lives only for the current page session.
- */
-const visaVotesMemoryCache = new Map<string, Record<string, VisaVotesData>>();
-
 export async function fetchVisaGuideVotes(
   countryCode: string
 ): Promise<Record<string, VisaVotesData>> {
-  try {
-    if (!db) {
-      return visaVotesMemoryCache.get(countryCode) || {};
-    }
-    const q = collection(db, "visa_guide_votes", countryCode, "visas");
-    const snapshot = await getDocs(q);
-    const result: Record<string, VisaVotesData> = {};
-    snapshot.forEach((docSnap) => {
-      const data = docSnap.data();
-      result[docSnap.id] = {
-        helpfulVotes: data.helpfulVotes || 0,
-        difficultyRating: data.difficultyRating || 3,
-        totalReviews: data.totalReviews || 1,
-      };
-    });
-    visaVotesMemoryCache.set(countryCode, result);
-    return result;
-  } catch (err) {
-    console.warn("Could not fetch visa votes from Firestore, using in-memory fallback:", err);
-    return visaVotesMemoryCache.get(countryCode) || {};
-  }
+  if (!db) throw new Error("Firestore is not configured");
+
+  const snapshot = await getDocs(
+    query(collection(db, "visa_guide_votes"), where("countryCode", "==", countryCode))
+  );
+
+  const result: Record<string, VisaVotesData> = {};
+  snapshot.forEach((docSnap) => {
+    const visaId = docSnap.data().visaId;
+    if (typeof visaId !== "string") return;
+    result[visaId] = { helpfulVotes: (result[visaId]?.helpfulVotes ?? 0) + 1 };
+  });
+  return result;
+}
+
+/** Whether this user has already marked this visa as useful. */
+export function visaVoteId(userId: string, countryCode: string, visaId: string): string {
+  return `${userId}__${countryCode}__${visaId}`;
 }
 
 /**
- * Save / upvote a specific visa in Firestore with fallback
+ * Records one vote and returns the new count.
+ *
+ * Throws rather than falling back. The previous version answered a failed write
+ * with an invented number from an in-memory cache, so a denied write and a
+ * successful one looked identical on screen.
  */
-export async function voteVisaHelpful(countryCode: string, visaId: string): Promise<number> {
-  try {
-    if (db) {
-      const docRef = doc(db, "visa_guide_votes", countryCode, "visas", visaId);
-      await setDoc(
-        docRef,
-        {
-          helpfulVotes: increment(1),
-          lastVotedAt: new Date().toISOString(),
-        },
-        { merge: true }
-      );
-      const snap = await getDoc(docRef);
-      return snap.data()?.helpfulVotes || 1;
-    }
-  } catch (err) {
-    console.warn("Firestore vote failed, updating local store:", err);
-  }
+export async function voteVisaHelpful(
+  userId: string,
+  countryCode: string,
+  visaId: string
+): Promise<number> {
+  if (!db) throw new Error("Firestore is not configured");
 
-  // In-memory fallback for the current session.
-  const existing = visaVotesMemoryCache.get(countryCode) || {};
-  const current = existing[visaId]?.helpfulVotes || 12;
-  const updated = current + 1;
-  existing[visaId] = {
-    ...(existing[visaId] || { difficultyRating: 3, totalReviews: 5 }),
-    helpfulVotes: updated,
-  };
-  visaVotesMemoryCache.set(countryCode, existing);
-  return updated;
+  await setDoc(doc(db, "visa_guide_votes", visaVoteId(userId, countryCode, visaId)), {
+    userId,
+    countryCode,
+    visaId,
+    createdAt: new Date().toISOString(),
+  });
+
+  const counted = await getCountFromServer(
+    query(
+      collection(db, "visa_guide_votes"),
+      where("countryCode", "==", countryCode),
+      where("visaId", "==", visaId)
+    )
+  );
+  return counted.data().count;
 }

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -308,6 +308,25 @@ export const TRANSLATIONS: TranslationDictionary = {
   "estudios.rejectedNotice": { es: "No mostramos", en: "We are not showing" },
   "estudios.rejectedOne": { es: "programa porque", en: "programme because" },
   "estudios.rejectedMany": { es: "programas porque", en: "programmes because" },
+  "guia.voteUseful": { es: "Marcar como útil", en: "Mark as useful" },
+  "guia.voteCount": { es: "útiles", en: "found it useful" },
+  "guia.voteFirst": { es: "Sé el primero en marcarla útil", en: "Be the first to mark it useful" },
+  "guia.voteTitle": {
+    es: "Marcar esta información como útil",
+    en: "Mark this information as useful",
+  },
+  "guia.voteSignIn": {
+    es: "Inicia sesión para marcar esta guía como útil",
+    en: "Sign in to mark this guide as useful",
+  },
+  "guia.voteFailed": {
+    es: "No pudimos registrar tu voto. Inténtalo de nuevo más tarde.",
+    en: "We could not record your vote. Try again later.",
+  },
+  "guia.votesUnavailable": {
+    es: "No pudimos cargar cuántas personas marcaron estas guías como útiles.",
+    en: "We could not load how many people marked these guides as useful.",
+  },
   "guia.costsIntro": {
     es: "Promedio estimado para un estudiante o profesional en",
     en: "Estimated average for a student or professional in",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -82,6 +82,7 @@ vi.mock("firebase/firestore", () => ({
   updateDoc: vi.fn(() => Promise.resolve()),
   deleteDoc: vi.fn(() => Promise.resolve()),
   increment: vi.fn(),
+  getCountFromServer: vi.fn(() => Promise.resolve({ data: () => ({ count: 0 }) })),
   onSnapshot: vi.fn((query, cb) => {
     cb({ docs: [] });
     return () => {};


### PR DESCRIPTION
Closes #79. Closes #24.

> ⚠️ **Stacked on #77.** The base is `claude/issue-75-guia-currency`, not `main`.
> Both changes touch the same region of `GuiaMigracion.tsx`, and CLAUDE.md is
> explicit that two branches over one component merge cleanly into something
> that compiles and is wrong. Stacking makes the diff here only this change.
> Merge #77 first; GitHub retargets this to `main` automatically.

## The defect

```tsx
<span>{visaVotes[visa.id]?.helpfulVotes || 18} útiles</span>
```

Firestore returned nothing for every visa in the product — `visa_guide_votes`
had no rule, so the catch-all denied every read and write (#24) — so **every
visa in seven countries claimed eighteen people had found it useful**. Nobody
had. The number was invented and the interface presented it with full
confidence, on the screen whose entire claim is that its information comes from
official sources.

Two more of the same shape underneath:

- the failed write was answered from a module-level `Map` seeded at **12**, so a
  denied write looked exactly like a successful one;
- the reader's own vote lived in `useState`, so it vanished on reload and
  nothing stopped a second one.

## Storage

One document per `(user, country, visa)`, id `{uid}__{countryCode}__{visaId}`.

| Decision | Why |
|---|---|
| The id carries all three parts, and the rule requires it to match the document's own fields | The id **is** the uniqueness constraint: a second vote writes the same document and `create` fails once it exists. No rule has to hunt for a duplicate. |
| No `update`, no `delete` | A vote is a fact about a moment. An editable one is a counter in disguise. |
| No stored counter | A counter any signed-in client may increment is a counter anyone can inflate, and there is no server here to hold it. |
| The count is `getCountFromServer` over the documents | Which is why `read` is public — a guest sees the counts and cannot vote. |

## On screen

A number appears **only when one was read**:

- votes read → the count that was read;
- none yet → "sé el primero en marcarla útil";
- read failed → a notice saying the counts could not be loaded, and no number;
- write rejected → a notice saying the vote was not recorded, and no number;
- guest taps → the sign-in modal, not a vote that goes nowhere.

`fetchVisaGuideVotes` and `voteVisaHelpful` throw now instead of falling back.
The in-memory cache is deleted with them.

## Database change — read before merging

| | |
|---|---|
| **What changes** | `firestore.rules` gains a `visa_guide_votes/{voteId}` match: public read, create-only for the signed-in owner with the id matching the payload, no update or delete. The old subcollection path `visa_guide_votes/{code}/visas` is no longer written. |
| **Risk** | Low. A collection that has never had a rule and therefore has never held a document. Nothing existing is read, rewritten or deleted. |
| **Affected** | `visa_guide_votes` only. |
| **Rollback** | Remove the `match` block and redeploy the rules; the client then fails its reads, which the screen already reports as "counts unavailable". No data migration either way. |
| **Environment** | None. **Nothing was deployed from here.** Development and production share one Firebase project, so a human deploys these rules after review (`docs/data.md`). |

Note #18: there is still no backup or restore capability. This adds a
collection rather than touching one, so the exposure is bounded, but it is
worth stating.

## Tests

6 regression tests in `src/components/GuiaMigracion.votes.test.tsx`, through
`renderWithProviders`, covering: no votes read, votes read, read failure, guest
tap, signed-in vote, and rejected write. **Confirmed: putting `|| 18` back fails
3 of them.** Full suite 266 passing, lint 0 errors, `format:check` clean.

## Also worth knowing

Sign-in is currently broken (#78), so the signed-in vote path cannot be
exercised by hand in the running app until that lands. The tests cover it; a
human should re-verify after #78.

## Documentation

`docs/data.md` (the collection table and the section that described the
undeclared path) and `docs/ux.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_