### PR TITLE
fix(chat): one assistant behind both surfaces (#4)

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -54,22 +54,36 @@ Express Entry age points, Stamp 2 conditions. These duplicate values that also
 exist in `src/data/migrationGuides.ts` and can drift from it. Updating them
 requires editing the prompt and redeploying.
 
-## Two chat surfaces that behave differently
+## One assistant, two presentations
 
 | Surface | Component | Backend |
 |---|---|---|
-| Chat IA tab | `ChatIA.tsx` (857 lines) | `POST /api/chat` → Gemini |
-| Floating bubble | `FloatingChatWidget.tsx` (273 lines) | Hardcoded `if/else` over keywords |
+| Chat IA tab | `ChatIA.tsx` | `POST /api/chat` → Gemini |
+| Floating bubble | `FloatingChatWidget.tsx` | `POST /api/chat` → Gemini |
 
-`FloatingChatWidget.handleSendMessage` matches five keyword branches — scams,
-empadronamiento, budget, student work, and a generic fallback — and returns a
-fixed string. It makes no network call. The bubble is rendered on every screen,
-so it is the more prominent entry point.
+Both call `useMigrationChat` in `src/lib/useMigrationChat.ts`, which is the only
+place the request is made. The bubble is the shell; `ChatIA` is the full view.
 
-The consequence: the same question produces different answers depending on where
-it is asked. The fixed replies also embed their own figures (350–650 € rent,
-2,500–4,000 € starting buffer), a third copy of numbers that exist in the prompt
-and in the datasets.
+Until #4 they were different assistants. `FloatingChatWidget.handleSendMessage`
+matched five keyword branches — scams, empadronamiento, budget, student work,
+and a generic fallback — and returned a fixed string with no network call at
+all. The bubble renders on every screen, so the more prominent entry point was
+the one that could not answer, and the same question gave different answers
+depending on where it was asked. The fixed replies also embedded their own
+figures (350–650 € rent, a 2,500–4,000 € buffer), a third copy of numbers that
+exist in the prompt and in the datasets.
+
+Three things follow from having one implementation:
+
+- **Maximising carries the conversation.** The bubble hands its messages to
+  `ChatIA` through `initialHistory`; it used to pass only the draft, so seeing
+  the exchange in a bigger window meant losing it.
+- **A failure is visible.** A non-2xx response or a body with no reply throws,
+  and both surfaces render the same "no pudimos conectar" message. Reading
+  `data.reply` from a 429 body used to produce "No se pudo obtener la
+  respuesta." rendered as though the assistant had said it.
+- **Sources come from the answer or not at all.** They used to fall back to two
+  fixed portals, so every reply was credited to sources it had never cited.
 
 ## Retrieval
 
@@ -77,8 +91,10 @@ There is none. The model answers from its training data. The application's own
 verified content — 57 visa records, 22 scholarships, anti-scam guidance, consular
 addresses — is never passed as context.
 
-`ChatIA` already renders a `sources` array on assistant messages, but the backend
-never populates it, so citations only appear on the seeded example conversation.
+`ChatIA` renders a `sources` array on assistant messages, but the backend never
+populates it, so no citation appears. It used to appear to work because every
+reply was given two hardcoded sources and the screen opened on a seeded example
+conversation; both are gone (#4).
 
 ## Entry points into the chat
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { NavigationTab, ThemeMode, Scholarship, GoogleUser } from "./types";
+import { ChatMessage, NavigationTab, ThemeMode, Scholarship, GoogleUser } from "./types";
 import { TopNavBar } from "./components/TopNavBar";
 import { HeroLanding } from "./components/HeroLanding";
 import { BecasExplorer } from "./components/BecasExplorer";
@@ -44,6 +44,8 @@ export default function App() {
   });
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [chatInitialPrompt, setChatInitialPrompt] = useState<string>("");
+  /** The exchange the floating bubble hands over when it is maximised (#4). */
+  const [chatHandover, setChatHandover] = useState<ChatMessage[] | undefined>(undefined);
   const [selectedScholarshipForChat, setSelectedScholarshipForChat] = useState<Scholarship | null>(
     null
   );
@@ -292,6 +294,7 @@ export default function App() {
           <main className="animate-fade-in">
             <ChatIA
               initialPrompt={chatInitialPrompt}
+              initialHistory={chatHandover}
               scholarshipContext={selectedScholarshipForChat}
             />
           </main>
@@ -301,7 +304,8 @@ export default function App() {
       {/* Floating Popup Chatbot */}
       <FloatingChatWidget
         currentUser={currentUser}
-        onNavigateToFullChat={(prompt) => {
+        onNavigateToFullChat={(prompt, history) => {
+          setChatHandover(history);
           if (prompt) setChatInitialPrompt(prompt);
           setActiveTab("chat");
         }}

--- a/src/components/ChatIA.test.tsx
+++ b/src/components/ChatIA.test.tsx
@@ -4,18 +4,44 @@ import { renderWithProviders as render } from "../test/renderWithProviders";
 import { ChatIA } from "./ChatIA";
 
 describe("ChatIA Component", () => {
-  it("renders AI assistant header, chat history and input field", () => {
+  /**
+   * This test used to assert the seeded conversation — a question the reader
+   * had never asked and a long assistant reply hardcoded in the client,
+   * addressed to "Ana" by name. The test was pinning a fabricated exchange as
+   * though it were history, so it is the test that was wrong, not the fix
+   * (#4). What the screen owes a new reader is its welcome state.
+   */
+  it("opens on the welcome state rather than on a conversation nobody had", () => {
     render(<ChatIA />);
-    expect(screen.getByText(/Nueva Consulta/i)).toBeInTheDocument();
     expect(screen.getAllByText(/LatinoMigra IA/i).length).toBeGreaterThan(0);
     expect(
       screen.getByPlaceholderText(/Pregunta sobre visas, becas, ciudades/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/¿Cómo puedo orientar tu plan migratorio\?/i)).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         /¿Cuáles son los requisitos clave para la visa de estudiante de España desde Colombia\?/i
       )
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+  });
+
+  it("carries the floating bubble's exchange over when handed one", () => {
+    render(
+      <ChatIA
+        initialHistory={[
+          { id: "m1", role: "user", content: "¿Cómo evito estafas?", timestamp: "10:00" },
+          {
+            id: "m2",
+            role: "assistant",
+            content: "Nunca transfieras antes de ver.",
+            timestamp: "10:00",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/¿Cómo evito estafas\?/)).toBeInTheDocument();
+    expect(screen.getByText(/Nunca transfieras antes de ver./)).toBeInTheDocument();
   });
 
   it("updates text input when user types a custom question", () => {
@@ -29,7 +55,7 @@ describe("ChatIA Component", () => {
 
   it("allows starting a new conversation", () => {
     render(<ChatIA />);
-    const newChatBtn = screen.getByText(/Nueva Consulta/i);
+    const newChatBtn = document.getElementById("new-chat-btn")!;
     fireEvent.click(newChatBtn);
     expect(screen.getByText(/¿Cómo puedo orientar tu plan migratorio\?/i)).toBeInTheDocument();
   });

--- a/src/components/ChatIA.tsx
+++ b/src/components/ChatIA.tsx
@@ -21,68 +21,41 @@ import { ChatMessage, ChatConversation, Scholarship } from "../types";
 import { useLanguage } from "../lib/i18n";
 import { useCurrency } from "../lib/CurrencyContext";
 import { formatCurrency } from "../lib/currency";
+import { chatErrorMessage, useMigrationChat } from "../lib/useMigrationChat";
 import { Modal } from "./ui/Modal";
 
 interface ChatIAProps {
   initialPrompt?: string;
+  /**
+   * The exchange carried over from the floating bubble.
+   *
+   * Maximising used to start a fresh conversation, so the reader lost what
+   * they had asked in order to see it in a bigger window (#4).
+   */
+  initialHistory?: ChatMessage[];
   scholarshipContext?: Scholarship | null;
 }
 
-export const ChatIA: React.FC<ChatIAProps> = ({ initialPrompt }) => {
+export const ChatIA: React.FC<ChatIAProps> = ({ initialPrompt, initialHistory }) => {
   const { language, t } = useLanguage();
+  const { ask } = useMigrationChat();
   const { currency } = useCurrency();
-  const [conversations, setConversations] = useState<ChatConversation[]>([
+  /**
+   * One empty conversation, seeded with whatever the floating bubble was
+   * carrying.
+   *
+   * The screen used to open on a fabricated exchange — a question the reader
+   * had never asked and a long assistant reply hardcoded in the client,
+   * addressed to "Ana" by name. It read as history and was not, which is the
+   * same defect as the invented vote counts and the invented sources: a value
+   * presented with confidence from no source at all.
+   */
+  const [conversations, setConversations] = useState<ChatConversation[]>(() => [
     {
       id: "conv-1",
-      title: "Requisitos visa estudiante España",
-      updatedAt: "Hoy, 10:15 AM",
-      messages: [
-        {
-          id: "m-1",
-          role: "user",
-          content:
-            "¿Cuáles son los requisitos clave para la visa de estudiante de España desde Colombia?",
-          timestamp: "10:15 AM",
-        },
-        {
-          id: "m-2",
-          role: "assistant",
-          content: `¡Hola, Ana! Para solicitar el **Visado de Estudiante para España** (estancias superiores a 90 días) desde Colombia o cualquier país latinoamericano, los requisitos consulares principales son:
-
-### 1. Documentación Personal y Académica
-* **Pasaporte Vigente**: Mínimo 1 año de validez restante.
-* **Carta de Aceptación Oficial**: Emitida por una universidad o centro registrado en España (RUCT).
-* **Certificado de Antecedentes Penales**: Apostillado por el Ministerio de Relaciones Exteriores en tu país de origen (emitido dentro de los últimos 3 meses).
-
-### 2. Acreditación Económica y Sanitaria
-* **Medios Económicos Demostrables**: Debes acreditar al menos el 100% del IPREM mensual (aprox. **600 €/mes** de estancia). Puedes certificarlo con extractos bancarios propios, carta de patrocinio familiar o concesión de Beca.
-* **Seguro Médico Privado**: Debe ser de una compañía autorizada en España (Adeslas, Sanitas, DKV), **sin copagos** y con cobertura completa de repatriación.
-
-### 3. Siguientes Pasos al Llegar a España
-1. **Empadronamiento**: En el Ayuntamiento de tu ciudad.
-2. **Solicitud de la TIE (Tarjeta de Identidad de Extranjero)**: Solicitar cita previa de extranjería dentro de los primeros 30 días.`,
-          timestamp: "10:16 AM",
-          sources: [
-            { title: "Consulado General de España", url: "https://www.exteriores.gob.es" },
-            {
-              title: "Ministerio de Inclusión, Seguridad Social y Migraciones",
-              url: "https://www.inclusion.gob.es",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: "conv-2",
-      title: "Becas CONACYT para maestría",
-      updatedAt: "Ayer",
-      messages: [],
-    },
-    {
-      id: "conv-3",
-      title: "Costo de vida en Buenos Aires vs Madrid",
-      updatedAt: "Hace 3 días",
-      messages: [],
+      title: t("chat.newConversation", "Nueva Consulta"),
+      updatedAt: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+      messages: initialHistory ?? [],
     },
   ]);
 
@@ -155,65 +128,27 @@ export const ChatIA: React.FC<ChatIAProps> = ({ initialPrompt }) => {
     setInputText("");
     setIsLoading(true);
 
-    try {
-      // Call server API route /api/chat
-      const response = await fetch("/api/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message: prompt,
-          language: language,
-          history: activeConv.messages.map((m) => ({
-            role: m.role,
-            content: m.content,
-          })),
-        }),
-      });
-
-      const data = await response.json();
-
-      const assistantMessage: ChatMessage = {
-        id: `msg-ai-${Date.now()}`,
-        role: "assistant",
-        content: data.reply || data.text || "No se pudo obtener la respuesta.",
-        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-        sources: data.sources || [
-          { title: "Ministerio de Asuntos Exteriores", url: "https://www.exteriores.gob.es" },
-          { title: "Portal de Inmigración Oficial", url: "https://extranjeros.inclusion.gob.es" },
-        ],
-      };
-
+    const appendToActive = (message: ChatMessage) =>
       setConversations((prev) =>
-        prev.map((conv) => {
-          if (conv.id === activeConvId) {
-            return {
-              ...conv,
-              messages: [...conv.messages, assistantMessage],
-            };
-          }
-          return conv;
-        })
+        prev.map((conv) =>
+          conv.id === activeConvId ? { ...conv, messages: [...conv.messages, message] } : conv
+        )
       );
-    } catch (err) {
-      console.error("Error al enviar mensaje:", err);
-      const errorMessage: ChatMessage = {
-        id: `msg-err-${Date.now()}`,
-        role: "assistant",
-        content:
-          "Ocurrió un error al conectar con LatinoMigra IA. Por favor, verifica tu conexión o intenta nuevamente.",
-        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-      };
 
-      setConversations((prev) =>
-        prev.map((conv) => {
-          if (conv.id === activeConvId) {
-            return {
-              ...conv,
-              messages: [...conv.messages, errorMessage],
-            };
-          }
-          return conv;
-        })
+    try {
+      appendToActive(await ask(prompt, { history: activeConv.messages, language }));
+    } catch (err) {
+      // The bubble and this screen fail the same way now: the conversation
+      // says the assistant did not answer, rather than showing a reply it
+      // never gave.
+      console.error("Error al enviar mensaje:", err);
+      appendToActive(
+        chatErrorMessage(
+          t(
+            "chat.requestFailed",
+            "No pudimos conectar con el asistente. Revisa tu conexión e inténtalo de nuevo."
+          )
+        )
       );
     } finally {
       setIsLoading(false);

--- a/src/components/FloatingChatWidget.tsx
+++ b/src/components/FloatingChatWidget.tsx
@@ -1,14 +1,24 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Bot, X, Send, Maximize2 } from "lucide-react";
 import { ChatMessage, GoogleUser } from "../types";
+import { useLanguage } from "../lib/i18n";
+import { chatErrorMessage, useMigrationChat } from "../lib/useMigrationChat";
 
 interface FloatingChatWidgetProps {
   currentUser?: GoogleUser | null;
-  /** Hands the current draft over to the full-screen Chat IA tab. */
-  onNavigateToFullChat: (prompt?: string) => void;
+  /**
+   * Hands the conversation over to the full-screen Chat IA tab.
+   *
+   * The whole exchange, not just the draft: maximising used to start over,
+   * which on the surface most people use meant losing the conversation to see
+   * it in a bigger window.
+   */
+  onNavigateToFullChat: (prompt: string, history: ChatMessage[]) => void;
 }
 
 export const FloatingChatWidget: React.FC<FloatingChatWidgetProps> = ({ onNavigateToFullChat }) => {
+  const { language, t } = useLanguage();
+  const { ask } = useMigrationChat();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [inputMessage, setInputMessage] = useState<string>("");
   const [isTyping, setIsTyping] = useState<boolean>(false);
@@ -37,9 +47,17 @@ export const FloatingChatWidget: React.FC<FloatingChatWidgetProps> = ({ onNaviga
     "¿Puedo trabajar con visa de estudiante en España?",
   ];
 
-  const handleSendMessage = (textToSend?: string) => {
-    const text = textToSend || inputMessage;
-    if (!text.trim()) return;
+  /**
+   * One implementation, two presentations.
+   *
+   * This used to be an `if/else` over five keywords with fixed replies, and
+   * anything outside them got a paragraph that answered nothing — while the
+   * Chat IA tab asked Gemini. Same question, different answers, and the bubble
+   * is the surface people actually reach for (#4).
+   */
+  const handleSendMessage = async (textToSend?: string) => {
+    const text = (textToSend || inputMessage).trim();
+    if (!text || isTyping) return;
 
     const userMsg: ChatMessage = {
       id: `user-${Date.now()}`,
@@ -48,50 +66,30 @@ export const FloatingChatWidget: React.FC<FloatingChatWidgetProps> = ({ onNaviga
       timestamp: "Ahora",
     };
 
+    const history = messages;
     setMessages((prev) => [...prev, userMsg]);
     setInputMessage("");
     setIsTyping(true);
 
-    // Simulate smart AI assistance
-    setTimeout(() => {
-      let botReply = "";
-      const lower = text.toLowerCase();
-
-      if (lower.includes("estafa") || lower.includes("alquiler") || lower.includes("hotel")) {
-        botReply =
-          "🛡️ **Reglas de Oro Anti-Estafas en Alquiler:**\n1. **NUNCA transfieras dinero previo por Bizum/Western Union** sin haber visto la vivienda o sin una plataforma con retención legal (como Spotahome o Uniplaces).\n2. Si el anunciante dice estar fuera del país y promete enviar llaves por mensajero, es 100% una estafa.\n3. Reserva tus primeros 10-15 días en un hostal/Airbnb para visitar habitaciones en persona antes de firmar contrato.";
-      } else if (
-        lower.includes("empadronamiento") ||
-        lower.includes("padron") ||
-        lower.includes("españa")
-      ) {
-        botReply =
-          "📍 **El Empadronamiento en España:**\nEs el registro administrativo donde resides. Es imprescindible para sacar tu TIE (tarjeta física), tarjeta sanitaria y escolarizar a tus hijos.\n**Requisitos:** Contrato de alquiler de al menos 6 meses a tu nombre o autorización firmada del dueño de la casa con copia de su DNI. Se solicita con cita previa en el Ayuntamiento de tu ciudad.";
-      } else if (
-        lower.includes("presupuesto") ||
-        lower.includes("dinero") ||
-        lower.includes("cuanto")
-      ) {
-        botReply =
-          "💰 **Presupuesto Realista Inicial Sugerido:**\n- **Alojamiento (habitación):** 350€ - 650€/mes.\n- **Fianza/Depósito:** 1 a 2 meses de alquiler.\n- **Supermercado y comida:** 200€ - 250€/mes.\n- **Transporte y telefonía:** 40€ - 60€/mes.\n- **Colchón recomendado de llegada:** Entre 2.500€ y 4.000€ para cubrir imprevistos del primer mes.";
-      } else if (lower.includes("trabajar") || lower.includes("estudiante")) {
-        botReply =
-          "🎓 **Trabajo con Visa de Estudiante:**\nEn España, la reforma del reglamento de extranjería permite a los estudiantes de educación superior trabajar hasta **30 horas semanales**, siempre que no interfiera con sus horarios de clase. El empleador solo debe tramitar una comunicación a Extranjería.";
-      } else {
-        botReply =
-          "He recibido tu consulta sobre tu plan migratorio. Recuerda que para trámites oficiales como visados, es clave reunir tu pasaporte vigente, título apostillado, antecedentes penales y certificado médico legalizado. ¿Te gustaría ver las guías paso a paso o el directorio de becas abiertas?";
-      }
-
-      const assistantMsg: ChatMessage = {
-        id: `ai-${Date.now()}`,
-        role: "assistant",
-        content: botReply,
-        timestamp: "Ahora",
-      };
-
-      setMessages((prev) => [...prev, assistantMsg]);
+    try {
+      const reply = await ask(text, { history, language });
+      setMessages((prev) => [...prev, reply]);
+    } catch (e) {
+      // A failure is visible in the conversation rather than swallowed: the
+      // reader has to know the assistant did not answer.
+      console.warn("Chat request failed:", e);
+      setMessages((prev) => [
+        ...prev,
+        chatErrorMessage(
+          t(
+            "chat.requestFailed",
+            "No pudimos conectar con el asistente. Revisa tu conexión e inténtalo de nuevo."
+          )
+        ),
+      ]);
+    } finally {
       setIsTyping(false);
-    }, 900);
+    }
   };
 
   return (
@@ -152,8 +150,9 @@ export const FloatingChatWidget: React.FC<FloatingChatWidgetProps> = ({ onNaviga
               <button
                 onClick={() => {
                   setIsOpen(false);
-                  onNavigateToFullChat(inputMessage.trim() || undefined);
+                  onNavigateToFullChat(inputMessage.trim(), messages);
                 }}
+                id="chat-widget-maximise"
                 title="Abrir en pantalla completa"
                 aria-label="Abrir el chat en pantalla completa"
                 className="tap-target p-1.5 text-white/80 hover:text-white hover:bg-white/10 rounded-lg transition-colors"

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -136,6 +136,11 @@ export const TRANSLATIONS: TranslationDictionary = {
   },
 
   // Chat
+  "chat.newConversation": { es: "Nueva Consulta", en: "New Consultation" },
+  "chat.requestFailed": {
+    es: "No pudimos conectar con el asistente. Revisa tu conexión e inténtalo de nuevo.",
+    en: "We could not reach the assistant. Check your connection and try again.",
+  },
   "chat.evalProfile": { es: "🎯 Diagnosticar Mi Perfil", en: "🎯 Diagnose My Profile" },
   "chat.welcomeTitle": {
     es: "¡Hola! ¿Cómo puedo orientar tu plan migratorio?",

--- a/src/lib/useMigrationChat.test.tsx
+++ b/src/lib/useMigrationChat.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { renderWithProviders as render } from "../test/renderWithProviders";
+import { FloatingChatWidget } from "../components/FloatingChatWidget";
+import { ChatIA } from "../components/ChatIA";
+
+/**
+ * Regression for #4.
+ *
+ * There were two assistants. `ChatIA` called `/api/chat` and reached Gemini;
+ * `FloatingChatWidget` — the bubble on every screen, and so the surface most
+ * people used — ran an `if/else` over five keywords and answered everything
+ * else with a paragraph that answered nothing. The same question gave
+ * different answers depending on where it was asked.
+ */
+
+const mockChatResponse = (reply: string, extra: Record<string, unknown> = {}) =>
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => ({ reply, ...extra }),
+  } as Response);
+
+const askInWidget = async (question: string) => {
+  fireEvent.click(screen.getByLabelText(/Abrir asistente|Abrir chat|asistente/i));
+  const input = await screen.findByPlaceholderText(/Escribe|Pregunta/i);
+  fireEvent.change(input, { target: { value: question } });
+  fireEvent.submit(input.closest("form")!);
+};
+
+describe("Both chat surfaces", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("answers from /api/chat in the floating bubble, not from keywords", async () => {
+    const fetchSpy = mockChatResponse("Respuesta del servidor.");
+
+    render(<FloatingChatWidget onNavigateToFullChat={vi.fn()} />);
+    // "estafa" was one of the five hardcoded branches, so a keyword reply
+    // would still look like an answer. It has to come from the network.
+    await askInWidget("¿Cómo evito una estafa de alquiler?");
+
+    await waitFor(() => expect(screen.getByText("Respuesta del servidor.")).toBeInTheDocument());
+    expect(fetchSpy).toHaveBeenCalledWith("/api/chat", expect.objectContaining({ method: "POST" }));
+    expect(screen.queryByText(/Reglas de Oro Anti-Estafas/)).not.toBeInTheDocument();
+  });
+
+  it("answers from /api/chat in the full screen too", async () => {
+    const fetchSpy = mockChatResponse("Respuesta del servidor.");
+
+    render(<ChatIA />);
+    const input = screen.getByPlaceholderText(/Pregunta sobre visas, becas, ciudades/i);
+    fireEvent.change(input, { target: { value: "¿Cómo evito una estafa de alquiler?" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => expect(screen.getByText("Respuesta del servidor.")).toBeInTheDocument());
+    expect(fetchSpy).toHaveBeenCalledWith("/api/chat", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("sends the conversation so far, so the assistant has the thread", async () => {
+    const fetchSpy = mockChatResponse("Primera.");
+
+    render(<FloatingChatWidget onNavigateToFullChat={vi.fn()} />);
+    await askInWidget("Primera pregunta");
+    await waitFor(() => expect(screen.getByText("Primera.")).toBeInTheDocument());
+
+    fetchSpy.mockResolvedValue({ ok: true, json: async () => ({ reply: "Segunda." }) } as Response);
+    const input = screen.getByPlaceholderText(/Escribe|Pregunta/i);
+    fireEvent.change(input, { target: { value: "Segunda pregunta" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => expect(screen.getByText("Segunda.")).toBeInTheDocument());
+
+    const body = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string);
+    expect(body.message).toBe("Segunda pregunta");
+    expect(body.history.map((m: { content: string }) => m.content)).toContain("Primera pregunta");
+  });
+
+  it("says the assistant did not answer instead of showing a reply it never gave", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+    } as Response);
+
+    render(<FloatingChatWidget onNavigateToFullChat={vi.fn()} />);
+    await askInWidget("¿Cuánto dinero necesito?");
+
+    await waitFor(() =>
+      expect(screen.getByText(/No pudimos conectar con el asistente/)).toBeInTheDocument()
+    );
+    // The old fallback answered a rate-limited request with a budget breakdown.
+    expect(screen.queryByText(/Presupuesto Realista/)).not.toBeInTheDocument();
+  });
+
+  it("attributes no sources the answer did not carry", async () => {
+    mockChatResponse("Sin fuentes.");
+
+    render(<ChatIA />);
+    const input = screen.getByPlaceholderText(/Pregunta sobre visas, becas, ciudades/i);
+    fireEvent.change(input, { target: { value: "Una pregunta" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => expect(screen.getByText("Sin fuentes.")).toBeInTheDocument());
+    // Every reply used to be credited to two fixed portals it had never cited.
+    expect(screen.queryByText(/Ministerio de Asuntos Exteriores/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Portal de Inmigración Oficial/)).not.toBeInTheDocument();
+  });
+
+  it("hands the whole exchange to the full screen when maximised", async () => {
+    mockChatResponse("Respuesta.");
+    const onNavigateToFullChat = vi.fn();
+
+    render(<FloatingChatWidget onNavigateToFullChat={onNavigateToFullChat} />);
+    await askInWidget("Mi pregunta");
+    await waitFor(() => expect(screen.getByText("Respuesta.")).toBeInTheDocument());
+
+    fireEvent.click(document.getElementById("chat-widget-maximise")!);
+
+    const [, history] = onNavigateToFullChat.mock.calls[0];
+    expect(history.map((m: { content: string }) => m.content)).toEqual(
+      expect.arrayContaining(["Mi pregunta", "Respuesta."])
+    );
+  });
+});

--- a/src/lib/useMigrationChat.ts
+++ b/src/lib/useMigrationChat.ts
@@ -1,0 +1,103 @@
+import { useCallback, useState } from "react";
+
+import { ChatMessage } from "../types";
+
+/** What `POST /api/chat` answers with. */
+interface ChatApiResponse {
+  reply?: string;
+  text?: string;
+  sources?: { title: string; url: string }[];
+}
+
+export interface AskOptions {
+  /** Turns already exchanged, oldest first. */
+  history: ChatMessage[];
+  language: string;
+}
+
+export interface MigrationChat {
+  /** Sends one turn and resolves with the assistant's message. */
+  ask: (prompt: string, options: AskOptions) => Promise<ChatMessage>;
+  isLoading: boolean;
+}
+
+const now = () => new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+/**
+ * The one implementation of "ask the assistant".
+ *
+ * There used to be two. `ChatIA` called `/api/chat` and reached Gemini;
+ * `FloatingChatWidget` — the bubble on every screen, and so the surface most
+ * people actually used — ran an `if/else` over five keywords and answered
+ * anything else with a paragraph that answered nothing. The same question gave
+ * different answers depending on where it was asked, and the more prominent
+ * surface was the one that could not answer (#4).
+ *
+ * The fixed replies also carried their own figures — 350–650 € rent, a
+ * 2,500–4,000 € buffer — duplicating numbers that also live in the server's
+ * system instruction and in the datasets. Three copies that could drift.
+ */
+export function useMigrationChat(): MigrationChat {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const ask = useCallback(async (prompt: string, options: AskOptions): Promise<ChatMessage> => {
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: prompt,
+          language: options.language,
+          history: options.history.map((m) => ({ role: m.role, content: m.content })),
+        }),
+      });
+
+      /*
+        A 429 or a 500 answers with a body too, and reading `data.reply` from
+        it yields undefined — which used to become "No se pudo obtener la
+        respuesta." rendered as though the assistant had said it.
+      */
+      if (!response.ok) {
+        throw new Error(`chat request failed with ${response.status}`);
+      }
+
+      const data: ChatApiResponse = await response.json();
+      const reply = data.reply ?? data.text;
+      if (!reply) throw new Error("chat response carried no reply");
+
+      return {
+        id: `msg-ai-${Date.now()}`,
+        role: "assistant",
+        content: reply,
+        timestamp: now(),
+        /*
+          Sources come from the answer or not at all. They used to fall back to
+          two fixed portals, so every reply was attributed to sources it had
+          never cited — on a platform whose credibility rests on official
+          sourcing.
+        */
+        sources: data.sources?.length ? data.sources : undefined,
+      };
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { ask, isLoading };
+}
+
+/**
+ * The message shown when the request could not be completed.
+ *
+ * The copy is passed in rather than written here: it is user-visible, so it
+ * comes from `t()` in the component that renders it.
+ */
+export function chatErrorMessage(text: string): ChatMessage {
+  return {
+    id: `msg-err-${Date.now()}`,
+    role: "assistant",
+    content: text,
+    timestamp: now(),
+  };
+}


### PR DESCRIPTION
Closes #4.

## The defect

There were two assistants:

| Surface | Backend |
|---|---|
| Chat IA tab | `POST /api/chat` → Gemini |
| Floating bubble (**every screen**) | `if/else` over five keywords, **no network call** |

Anything outside those five branches got a paragraph that answered nothing. The
same question gave different answers depending on where it was asked, and the
more prominent surface was the one that could not answer.

`useMigrationChat` is now the only place the request is made. The bubble is the
shell; `ChatIA` is the full view.

## Three things follow from one implementation

**Maximising carries the conversation.** The bubble hands its messages over
through `initialHistory`. It used to pass only the draft, so seeing an exchange
in a bigger window meant losing it.

**A failure is visible.** A non-2xx response or a body with no reply throws, and
both surfaces render the same *"no pudimos conectar"* message. Reading
`data.reply` from a 429 body used to yield `undefined` and render
*"No se pudo obtener la respuesta."* as though the assistant had said it.

**Nothing is attributed to a source it did not cite.** `sources` fell back to
two fixed portals, so **every reply in the product was credited to official
sources it had never used** — on a platform whose credibility rests on official
sourcing.

## Two fabrications removed with them

- The fixed replies carried their own figures — 350–650 € rent, a 2,500–4,000 €
  buffer — a third copy of numbers that live in the server prompt and in the
  datasets, free to drift from both.
- `ChatIA` **opened on a seeded conversation**: a question the reader had never
  asked and a long assistant reply hardcoded in the client, addressed to "Ana"
  by name. It read as history and was not. The screen opens on its welcome
  state now.

## A test I changed, and why

`ChatIA.test.tsx` asserted that seeded exchange, so it was pinning the
fabrication in place. Per CLAUDE.md I am flagging it explicitly: **the test was
wrong, not the fix.** It now asserts the welcome state, and asserts the seeded
question is *absent*.

## Tests

6 new in `src/lib/useMigrationChat.test.tsx`:

- both surfaces call `/api/chat` — asked with `"estafa"`, which was a hardcoded
  branch, so a keyword reply would still have looked like an answer
- the conversation so far is sent as `history`
- a 429 renders the failure message and **not** the old budget breakdown
- no sources are rendered when the answer carried none
- maximising hands the whole exchange over

**Confirmed to fail when a keyword branch is put back.** 294 unit tests and
**65 E2E** passing, lint 33 of a 35 warning budget, `format:check` clean.

## Risks

The bubble now depends on the network, so on a dead connection it says it could
not answer where it used to produce something. That is the intended trade:
"something" was five canned paragraphs and a fallback that answered nothing.

Worth knowing: `sources` is rendered but the backend never populates it, so no
citation appears at all now. That is the true state — it only looked like it
worked because of the hardcoded fallback. Retrieval is #3.

## Documentation

`docs/ai.md` — the *"Two chat surfaces that behave differently"* section is
replaced, and the retrieval section corrected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_