### PR TITLE
fix(becas): put each filter group on one row inside the mobile sheet (#85)

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -204,6 +204,18 @@ Recently addressed and verified by tests:
   answer usefully about one specific call, and the handler, the prop and the
   path through `App` stay wired so restoring it is one word.
 
+## Scholarship filters in the mobile sheet
+
+- Each of the six groups is one swipeable row of chips, the same as the quick
+  filters directly above the sheet. They used `wrap` in both the sidebar and the
+  sheet: on a phone that made every group a block — the country group alone was
+  356px — and the six ran to **1435px inside a 716px dialog**, so reaching the
+  last filter meant scrolling past five others.
+- The sidebar keeps `wrap`. There is vertical room on a desktop, and showing
+  every option at once is worth it there. The layout differs because the
+  surfaces do.
+- Measured after: 679px of content, which fits the sheet.
+
 ## Estudios (cursos, certificados y FP)
 
 - The Becas & Estudios screen carries a fourth tab, **Cursos, Certificados y

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -590,6 +590,17 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
    * mobile sheet. Both can be in the DOM at once, so each copy scopes its
    * element ids.
    */
+  /**
+   * The six advanced filters, in the sidebar and in the mobile sheet.
+   *
+   * The layout differs because the surfaces do. On the desktop sidebar there is
+   * vertical room, so `wrap` shows every option at once. In the sheet `wrap`
+   * turned each group into a block — the country group alone was 356px — and
+   * the six of them ran to 1435px inside a 716px dialog, so reaching the last
+   * filter meant scrolling past five others and the apply button went with
+   * them. One swipeable row per group is also what the quick filters directly
+   * above the sheet already do; the sheet was the odd one out.
+   */
   const renderFilterGroups = (scope: "sidebar" | "sheet") => (
     <>
       <FilterChipGroup
@@ -599,7 +610,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedCountry}
         onChange={setSelectedCountry}
         idPrefix={`${scope}-country`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
       <FilterChipGroup
         label={t("becas.levelLabel", "Nivel Educativo")}
@@ -608,7 +619,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedEducationLevel}
         onChange={setSelectedEducationLevel}
         idPrefix={`${scope}-education`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
       <FilterChipGroup
         label={t("becas.areaLabel", "Área de Estudio")}
@@ -617,7 +628,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedArea}
         onChange={setSelectedArea}
         idPrefix={`${scope}-area`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
       <FilterChipGroup
         label={t("becas.supportLabel", "Tipo de Apoyo")}
@@ -626,7 +637,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedSupportType}
         onChange={setSelectedSupportType}
         idPrefix={`${scope}-support`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
       <FilterChipGroup
         label={t("becas.institutionLabel", "Tipo de Entidad")}
@@ -635,7 +646,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedInstitutionType}
         onChange={setSelectedInstitutionType}
         idPrefix={`${scope}-institution`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
       <FilterChipGroup
         label={t("becas.deadlineLabel", "Fecha de Cierre")}
@@ -644,7 +655,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
         value={selectedDateRange}
         onChange={setSelectedDateRange}
         idPrefix={`${scope}-deadline`}
-        layout="wrap"
+        layout={scope === "sidebar" ? "wrap" : "scroll"}
       />
     </>
   );

--- a/tests/e2e/becas.mobile.spec.ts
+++ b/tests/e2e/becas.mobile.spec.ts
@@ -15,6 +15,58 @@ test.describe("Scholarship list on a phone", () => {
     await expect(page.locator("#btn-open-mobile-filters")).toBeVisible();
   });
 
+  /**
+   * The sheet's six filter groups used `wrap`, so each became a block — the
+   * country group alone was 356px — and the six ran to 1435px inside a 716px
+   * dialog. Reaching the last filter meant scrolling past five others (#85).
+   */
+  test("fits its filter groups inside the sheet instead of stacking blocks", async ({ page }) => {
+    await page.locator("#btn-open-mobile-filters").click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+
+    const { dialogHeight, contentHeight, groups } = await dialog.evaluate((el) => {
+      const scroller = el.querySelector("div[class*='overflow-y-auto']");
+      return {
+        dialogHeight: Math.round(el.getBoundingClientRect().height),
+        contentHeight: scroller ? scroller.scrollHeight : Number.MAX_SAFE_INTEGER,
+        groups: el.querySelectorAll('[role="group"]').length,
+      };
+    });
+
+    expect(groups).toBeGreaterThanOrEqual(6);
+
+    /*
+      A ratchet, not a target. The wrapped layout measured 1435px against a
+      716px dialog at 375px — over two screens of filters. One row per group
+      brings it to 679px, so anything approaching the old figure is a
+      regression, whatever the exact viewport of the run.
+    */
+    expect(contentHeight).toBeLessThan(900);
+    expect(contentHeight).toBeLessThan(dialogHeight * 1.2);
+  });
+
+  test("keeps each filter group on one row, as the quick filters do", async ({ page }) => {
+    await page.locator("#btn-open-mobile-filters").click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+
+    const rows = await page
+      .locator('[role="dialog"] [role="group"]')
+      .evaluateAll((groups) =>
+        groups.map(
+          (group) =>
+            new Set(
+              Array.from(group.querySelectorAll("button")).map((chip) =>
+                Math.round(chip.getBoundingClientRect().top)
+              )
+            ).size
+        )
+      );
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const rowCount of rows) expect(rowCount).toBe(1);
+  });
+
   test("has one way to see more, and no numbered pager", async ({ page }) => {
     await expect(page.locator("#btn-load-more-scholarships")).toBeVisible();
 


### PR DESCRIPTION
Closes #85.

## The defect

The six advanced filter groups used `layout="wrap"` in **both** the desktop
sidebar and the mobile sheet. On a phone that turned every group into a block —
the country group alone was 356px — and the six ran to **1435px inside a 716px
dialog**. Reaching the last filter meant scrolling past five others.

## The fix

`FilterChipGroup` already has the other layout, and the quick filters *directly
above the sheet* already use it: one swipeable row per group. The sheet was the
odd one out, so the sheet was what was wrong — not the component, and not the
styling.

The sidebar keeps `wrap`. There is vertical room on a desktop and showing every
option at once is worth it there. The layout differs because the surfaces do,
which is the whole reason `renderFilterGroups` takes a `scope`.

## Measured at 375px

| | Before | After |
|---|---|---|
| Sheet content height | 1435px | **679px** |
| Dialog height | 716px | 716px |
| Rows per filter group | up to 5 | **1** |

## Tests

Two E2E in `tests/e2e/becas.mobile.spec.ts`:

- the content height, as a ratchet with the old figure written into the comment
  so a regression toward it fails rather than passing quietly;
- every group occupies a single row — the structural claim, independent of
  viewport.

14 passing on that spec, 287 unit tests, lint 33 of a 35 warning budget,
`format:check` clean.

## Follow-up spotted, not fixed

The sheet's apply button reads `Ver {n} Convocatorias` as a bare string, not
through `t()`, as do "Vaciar mis favoritas" and several labels around it. Those
are part of #51's remaining coverage rather than this change's scope.

## Documentation

`docs/ux.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_