### PR TITLE
fix(guias): count each visa category, and correct the visa figure in the docs (#84)

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -74,7 +74,7 @@ and in the datasets.
 ## Retrieval
 
 There is none. The model answers from its training data. The application's own
-verified content — 57 visa records, 22 scholarships, anti-scam guidance, consular
+verified content — 24 visa records, 22 scholarships, anti-scam guidance, consular
 addresses — is never passed as context.
 
 `ChatIA` already renders a `sources` array on assistant messages, but the backend

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Two decisions constrain them:
 
 | Dataset | Records | Size |
 |---|---|---|
-| `migrationGuides.ts` | 7 countries, 57 visas | 48 KB |
+| `migrationGuides.ts` | 7 countries, 24 visas | 48 KB |
 | `scholarships.ts` | 22 | 35 KB |
 | `locations.ts` | 32 consulates and campuses | 20 KB |
 | `antiScamData.ts` | anti-scam guidance per country | 15 KB |

--- a/docs/data.md
+++ b/docs/data.md
@@ -18,7 +18,7 @@ means database failures are invisible to the user.
 
 | File | Records | Size | Changes with |
 |---|---|---|---|
-| `migrationGuides.ts` | 7 countries / 57 visas | 48 KB | Immigration law |
+| `migrationGuides.ts` | 7 countries / 24 visas | 48 KB | Immigration law |
 | `scholarships.ts` | 22 | 35 KB | Annual calls and deadlines |
 | `locations.ts` | 32 | 20 KB | Consular addresses, phones, hours |
 | `antiScamData.ts` | per-country guidance | 15 KB | Rarely |

--- a/docs/product.md
+++ b/docs/product.md
@@ -9,7 +9,7 @@ planning to migrate to Europe or North America. It combines a verified
 scholarship catalogue, step-by-step visa guides, cost-of-living planning,
 consular directory, community forum and an AI assistant.
 
-The content is the product's core asset: 22 scholarships, 57 visa types across
+The content is the product's core asset: 22 scholarships, 24 visa types across
 7 destination countries, 32 consulates and campuses, and country-specific
 anti-scam guidance.
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -38,7 +38,7 @@ achieve.
 **No routing.** Navigation is `useState` in `App.tsx`, so the entire application
 lives at one URL. There is no page for a scholarship, a country guide or a
 consulate. A crawler can only index the home screen, regardless of the 22
-scholarships, 57 visa types and 32 consular records the app contains. A sitemap
+scholarships, 24 visa types and 32 consular records the app contains. A sitemap
 would have exactly one entry.
 
 **No server-side rendering.** `server.ts` runs Vite in `appType: "spa"`, and on

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -240,6 +240,10 @@ Recently addressed and verified by tests:
   The breakpoint sits on a wrapper rather than on the control itself:
   `lg:hidden` and a display utility on one element let the emitted order pick
   the winner, and it picked `inline-flex`.
+- The visa category filter is chips with a live count, through the same
+  `FilterChipGroup`. The counts come from the predicate the list itself uses, so
+  a chip cannot promise routes the list will not show — the "Todas (4)" label
+  was the only count before, and the per-category chips had none.
 - The country picker is one swipeable row of chips with a count of visa routes
   per country, through the same `FilterChipGroup` the scholarship filters use.
   It was seven full-size buttons in a `flex-wrap` row: three lines of blocks at

--- a/src/components/GuiaMigracion.tsx
+++ b/src/components/GuiaMigracion.tsx
@@ -17,7 +17,7 @@ import {
   Check,
   ThumbsUp,
 } from "lucide-react";
-import { NavigationTab } from "../types";
+import { NavigationTab, VisaType } from "../types";
 import { useLanguage } from "../lib/i18n";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { MIGRATION_GUIDES_DATA } from "../data/migrationGuides";
@@ -53,6 +53,7 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
   const selectedCountryCode = destinationCountryCode || "ES";
   const setSelectedCountryCode = setDestinationCountryByCode;
   const [selectedCategory, setSelectedCategory] = useState<string>("todos");
+
   const [visaVotes, setVisaVotes] = useState<Record<string, VisaVotesData>>({});
   const [userVotedVisas, setUserVotedVisas] = useState<Record<string, boolean>>({});
 
@@ -122,6 +123,8 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
    * checklist: the document ids differ per country, so keeping the old state
    * would tick boxes for documents the new country does not ask for.
    */
+  const selectCategory = (category: string) => setSelectedCategory(category);
+
   const selectCountry = (code: string) => {
     const next = MIGRATION_GUIDES_DATA[code];
     if (!next) return;
@@ -183,14 +186,33 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
     URL.revokeObjectURL(url);
   };
 
-  const filteredVisas = guide.visas.filter((v) => {
-    if (selectedCategory === "todos") return true;
-    return v.category === selectedCategory;
-  });
+  /**
+   * One definition of the rule, used by the list and by the counts beside it.
+   *
+   * Written twice they drift, and the chips start promising a number the list
+   * does not have — the defect the scholarship filters were opened about.
+   */
+  const matchesCategory = (visa: VisaType, category: string) =>
+    category === "todos" || visa.category === category;
 
-  const availableCategories = Array.from(
-    new Set(guide.visas.map((v) => v.category).filter(Boolean))
-  ) as string[];
+  const filteredVisas = useMemo(
+    () => guide.visas.filter((visa) => matchesCategory(visa, selectedCategory)),
+    [guide.visas, selectedCategory]
+  );
+
+  const categoryOptions = useMemo(
+    () => [
+      { id: "todos", label: t("guia.categoryAll", "Todas"), count: guide.visas.length },
+      ...(Array.from(new Set(guide.visas.map((v) => v.category).filter(Boolean))) as string[]).map(
+        (category) => ({
+          id: category,
+          label: category,
+          count: guide.visas.filter((visa) => matchesCategory(visa, category)).length,
+        })
+      ),
+    ],
+    [guide.visas, t]
+  );
 
   const roadmapSteps = [
     { num: 1, title: "Decisión y Búsqueda", desc: "Programa académico, idiomas o contrato" },
@@ -367,33 +389,22 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
             )}
           </div>
 
-          {/* Visa Category Filter Chips */}
-          {availableCategories.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 pt-1">
-              <button
-                onClick={() => setSelectedCategory("todos")}
-                className={`px-3 py-1.5 rounded-xl text-xs font-bold transition-colors ${
-                  selectedCategory === "todos"
-                    ? "bg-primary dark:bg-sky-600 text-white shadow-sm"
-                    : "bg-surface dark:bg-slate-800 text-on-surface-variant dark:text-slate-300 hover:bg-surface-container"
-                }`}
-              >
-                Todas ({guide.visas.length})
-              </button>
-              {availableCategories.map((cat) => (
-                <button
-                  key={cat}
-                  onClick={() => setSelectedCategory(cat)}
-                  className={`px-3 py-1.5 rounded-xl text-xs font-bold transition-colors ${
-                    selectedCategory === cat
-                      ? "bg-primary dark:bg-sky-600 text-white shadow-sm"
-                      : "bg-surface dark:bg-slate-800 text-on-surface-variant dark:text-slate-300 hover:bg-surface-container"
-                  }`}
-                >
-                  {cat}
-                </button>
-              ))}
-            </div>
+          {/*
+            Chips with a live count, the same component the country picker and
+            the scholarship filters use. The counts come from the predicate the
+            list itself uses, so a chip cannot promise routes the list will not
+            show.
+          */}
+          {categoryOptions.length > 1 && (
+            <FilterChipGroup
+              label={t("guia.categoryLabel", "Tipo de vía")}
+              icon={<Briefcase className="w-4 h-4 text-secondary dark:text-teal-400" />}
+              options={categoryOptions}
+              value={selectedCategory}
+              onChange={selectCategory}
+              idPrefix="visa-category"
+              onClear={selectedCategory !== "todos" ? () => selectCategory("todos") : undefined}
+            />
           )}
 
           <div className="space-y-5">

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -308,6 +308,8 @@ export const TRANSLATIONS: TranslationDictionary = {
   "estudios.rejectedNotice": { es: "No mostramos", en: "We are not showing" },
   "estudios.rejectedOne": { es: "programa porque", en: "programme because" },
   "estudios.rejectedMany": { es: "programas porque", en: "programmes because" },
+  "guia.categoryLabel": { es: "Tipo de vía", en: "Route type" },
+  "guia.categoryAll": { es: "Todas", en: "All" },
   "guia.countryLabel": { es: "País de destino", en: "Destination country" },
   "guia.voteUseful": { es: "Marcar como útil", en: "Mark as useful" },
   "guia.voteCount": { es: "útiles", en: "found it useful" },

--- a/tests/e2e/guias.mobile.spec.ts
+++ b/tests/e2e/guias.mobile.spec.ts
@@ -60,6 +60,23 @@ test.describe("Migration guides on a phone", () => {
     await expect(page.getByText(/Tipos de Visado en Alemania/)).toBeVisible();
   });
 
+  test("counts each visa category, and the count matches what it shows", async ({ page }) => {
+    const chips = page.locator('button[id^="visa-category-"]');
+    const count = await chips.count();
+    expect(count).toBeGreaterThan(1);
+
+    // Every chip carries a number, and selecting one renders exactly that many
+    // routes — the list and the counts come from one predicate.
+    for (let i = 1; i < count; i += 1) {
+      const chip = chips.nth(i);
+      const promised = Number((await chip.innerText()).match(/(\d+)\s*$/)?.[1]);
+      expect(promised, await chip.innerText()).toBeGreaterThan(0);
+
+      await chip.click();
+      await expect(page.locator('[id^="visa-details-"]:not([id$="-panel"])')).toHaveCount(promised);
+    }
+  });
+
   test("collapses the heavy sections", async ({ page }) => {
     for (const id of GUIDE_DISCLOSURES) {
       const control = page.locator(`#${id}`);


### PR DESCRIPTION
Closes #84.

> ⚠️ **Fourth in the guides chain.** Merge order: **#77 → #91 → #92 → this.**
> All four touch `GuiaMigracion.tsx`; stacking keeps each diff to its own
> change. GitHub retargets as each merges.

## What landed

The category filter offered `Todas (4)` and then five **unlabelled** chips.
Picking one was a guess: nothing said whether "Nómada Digital" led to three
routes or none, which is the information a count exists to give.

The chips are `FilterChipGroup` now — the same component the country picker
(#92) and the scholarship filters (#50) use — with counts from the predicate
the list itself uses, so a chip cannot promise routes the list will not show.

## What I did **not** implement, and why

**The paging half of this issue is dropped on purpose.**

The issue is premised on *"up to a dozen on one screen, 57 across the seven
guides"*. Measured against the data:

| Country | Visa routes |
|---|---|
| España | 4 |
| Canadá | 4 |
| Alemania | 4 |
| Irlanda | 3 |
| Estados Unidos | 3 |
| Portugal | 3 |
| Australia | 3 |
| **Total** | **24** |

A "ver más" control at a batch of six would **never render for any country in
the product**. I built it, measured that it never appeared, and took it back
out: a control nobody can reach is speculative code that still has to be read
and maintained.

## Where the 57 came from

The documentation, and the documentation was wrong. The figure counts every
`id:` at that indentation in `migrationGuides.ts`, which sweeps in the
document-checklist entries alongside the visas. Five documents repeated it —
`docs/product.md`, `docs/data.md`, `docs/ai.md`, `docs/architecture.md`,
`docs/seo.md` — and all five now say 24.

Worth noting because #90 and #10 both size their work off that figure, and
because "57 visa types" is a claim the product makes to its readers.

## Tests

One E2E in `tests/e2e/guias.mobile.spec.ts` walks **every** category chip,
selects it, and asserts the number of routes rendered equals the number the chip
promised. 10 passing on that spec, 298 unit tests, lint 33 of a 35 warning
budget, `format:check` clean.

## Documentation

`docs/ux.md`, plus the five documents carrying the corrected count.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_