### PR TITLE
fix(auth): translate the sign-in modal (#80)

### DIFF
--- a/src/components/AuthModal.test.tsx
+++ b/src/components/AuthModal.test.tsx
@@ -4,6 +4,18 @@ import { renderWithProviders as render } from "../test/renderWithProviders";
 import { AuthModal, describeSignInError } from "./AuthModal";
 import * as firebase from "../lib/firebase";
 import { GoogleUser } from "../types";
+import { TRANSLATIONS, useLanguage } from "../lib/i18n";
+import React from "react";
+
+/** Flips the shared language from inside the provider tree. */
+const LanguageSwitch: React.FC = () => {
+  const { setLanguage } = useLanguage();
+  return (
+    <button type="button" onClick={() => setLanguage("en")}>
+      switch-to-english
+    </button>
+  );
+};
 
 describe("AuthModal Component", () => {
   const defaultProps = {
@@ -167,29 +179,98 @@ describe("AuthModal Component", () => {
    * through four more renders.
    */
   describe("describeSignInError", () => {
+    /** Stands in for `useLanguage().t`, which resolves to the fallback in `es`. */
+    const es = (_key: string, fallback?: string) => fallback ?? _key;
+
     it("explains a blocked popup, which the visitor can act on", () => {
-      expect(describeSignInError({ code: "auth/popup-blocked" })).toMatch(/ventanas emergentes/i);
+      expect(describeSignInError({ code: "auth/popup-blocked" }, es)).toMatch(
+        /ventanas emergentes/i
+      );
     });
 
     it("does not blame the visitor for closing the window", () => {
-      expect(describeSignInError({ code: "auth/popup-closed-by-user" })).toMatch(/Cerraste/i);
-      expect(describeSignInError({ code: "auth/cancelled-popup-request" })).toMatch(/Cerraste/i);
+      expect(describeSignInError({ code: "auth/popup-closed-by-user" }, es)).toMatch(/Cerraste/i);
+      expect(describeSignInError({ code: "auth/cancelled-popup-request" }, es)).toMatch(
+        /Cerraste/i
+      );
     });
 
     it("points at the connection when that is the cause", () => {
-      expect(describeSignInError({ code: "auth/network-request-failed" })).toMatch(/conexión/i);
+      expect(describeSignInError({ code: "auth/network-request-failed" }, es)).toMatch(/conexión/i);
     });
 
     it("falls back to a generic message rather than showing the raw error", () => {
-      const message = describeSignInError(new Error("FirebaseError: internal-error"));
+      const message = describeSignInError(new Error("FirebaseError: internal-error"), es);
       expect(message).toMatch(/No pudimos completar/i);
       expect(message).not.toMatch(/Firebase/i);
     });
 
     it("survives an error that is not an object", () => {
-      expect(describeSignInError("boom")).toMatch(/No pudimos completar/i);
-      expect(describeSignInError(null)).toMatch(/No pudimos completar/i);
-      expect(describeSignInError(undefined)).toMatch(/No pudimos completar/i);
+      expect(describeSignInError("boom", es)).toMatch(/No pudimos completar/i);
+      expect(describeSignInError(null, es)).toMatch(/No pudimos completar/i);
+      expect(describeSignInError(undefined, es)).toMatch(/No pudimos completar/i);
+    });
+  });
+
+  /**
+   * Regression for #80. The modal rendered entirely in Spanish whatever the
+   * chosen language — including the strings it asks for personal data with.
+   */
+  describe("in English", () => {
+    const en = (key: string) => TRANSLATIONS[key]?.en ?? key;
+
+    it("translates the sign-in errors", () => {
+      expect(describeSignInError({ code: "auth/popup-blocked" }, en)).toMatch(/pop-ups/i);
+      expect(describeSignInError({ code: "auth/network-request-failed" }, en)).toMatch(
+        /could not reach Google/i
+      );
+      expect(describeSignInError("boom", en)).toMatch(/could not complete/i);
+    });
+
+    it("has an English entry for every string the modal renders", () => {
+      const keys = [
+        "auth.titleSignIn",
+        "auth.titleAccount",
+        "auth.descSignIn",
+        "auth.descAccount",
+        "auth.continueWithGoogle",
+        "auth.signOut",
+        "auth.verifiedAccount",
+        "auth.roleLabel",
+        "auth.roleAdmin",
+        "auth.roleStandard",
+        "auth.roleAdminBody",
+        "auth.roleStandardBody",
+        "auth.syncBookmarks",
+        "auth.syncCalendar",
+        "auth.syncChat",
+        "auth.originCountry",
+        "auth.privacyNotice",
+        "auth.errorPopupBlocked",
+        "auth.errorPopupClosed",
+        "auth.errorNetwork",
+        "auth.errorGeneric",
+      ];
+
+      for (const key of keys) {
+        expect(TRANSLATIONS[key], key).toBeDefined();
+        expect(TRANSLATIONS[key].en, key).not.toBe(TRANSLATIONS[key].es);
+      }
+    });
+
+    it("renders the modal in English when the language is English", () => {
+      render(
+        <>
+          <LanguageSwitch />
+          <AuthModal {...defaultProps} />
+        </>
+      );
+
+      fireEvent.click(screen.getByText("switch-to-english"));
+
+      expect(screen.getByText(/Continue with Google/i)).toBeInTheDocument();
+      expect(screen.getByText(/Country of origin/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Continuar con Google/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -4,6 +4,7 @@ import { GoogleUser } from "../types";
 import { signInWithGoogle, isUserAdmin } from "../lib/firebase";
 import { getSafeImageUrl } from "../lib/sanitize";
 import { Modal } from "./ui/Modal";
+import { useLanguage } from "../lib/i18n";
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -13,25 +14,44 @@ interface AuthModalProps {
   onSignOut: () => void;
 }
 
+/** Resolves a key to the visitor's language. `useLanguage().t`, in practice. */
+type Translate = (key: string, fallback?: string) => string;
+
 /**
  * What to tell the visitor when sign-in did not complete.
  *
  * Firebase reports the common cases by code. Everything else gets the generic
  * message rather than the raw error, which is English and mentions Firebase.
+ *
+ * The translator is passed in rather than the strings being written here: the
+ * whole modal rendered in Spanish regardless of the chosen language, and this
+ * function held four of those strings (#80).
  */
-export function describeSignInError(err: unknown): string {
+export function describeSignInError(err: unknown, t: Translate): string {
   const code = typeof err === "object" && err !== null && "code" in err ? String(err.code) : "";
 
   if (code === "auth/popup-blocked") {
-    return "Tu navegador bloqueó la ventana de Google. Permite las ventanas emergentes de este sitio e inténtalo de nuevo.";
+    return t(
+      "auth.errorPopupBlocked",
+      "Tu navegador bloqueó la ventana de Google. Permite las ventanas emergentes de este sitio e inténtalo de nuevo."
+    );
   }
   if (code === "auth/popup-closed-by-user" || code === "auth/cancelled-popup-request") {
-    return "Cerraste la ventana de Google antes de terminar. Inténtalo de nuevo cuando quieras.";
+    return t(
+      "auth.errorPopupClosed",
+      "Cerraste la ventana de Google antes de terminar. Inténtalo de nuevo cuando quieras."
+    );
   }
   if (code === "auth/network-request-failed") {
-    return "No pudimos conectar con Google. Revisa tu conexión e inténtalo de nuevo.";
+    return t(
+      "auth.errorNetwork",
+      "No pudimos conectar con Google. Revisa tu conexión e inténtalo de nuevo."
+    );
   }
-  return "No pudimos completar el inicio de sesión con Google. Inténtalo de nuevo.";
+  return t(
+    "auth.errorGeneric",
+    "No pudimos completar el inicio de sesión con Google. Inténtalo de nuevo."
+  );
 }
 
 export const AuthModal: React.FC<AuthModalProps> = ({
@@ -41,9 +61,10 @@ export const AuthModal: React.FC<AuthModalProps> = ({
   onSignIn,
   onSignOut,
 }) => {
+  const { t } = useLanguage();
   const [selectedCountry, setSelectedCountry] = useState<string>("Colombia");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  /** Spanish message shown when sign-in did not complete. */
+  /** Message shown, in the visitor's language, when sign-in did not complete. */
   const [signInError, setSignInError] = useState<string | null>(null);
 
   const handleFirebaseGoogleSignIn = async () => {
@@ -80,7 +101,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
       // saved went under an id that changed on every attempt — and vanished
       // on the next reload, because Firebase had never heard of it.
       console.warn("Google sign-in did not complete:", err);
-      setSignInError(describeSignInError(err));
+      setSignInError(describeSignInError(err, t));
     } finally {
       setIsLoading(false);
     }
@@ -92,11 +113,21 @@ export const AuthModal: React.FC<AuthModalProps> = ({
       onOpenChange={(next) => {
         if (!next) onClose();
       }}
-      title={currentUser ? "Tu Cuenta LatinoMigra" : "Inicia Sesión con Google"}
+      title={
+        currentUser
+          ? t("auth.titleAccount", "Tu Cuenta LatinoMigra")
+          : t("auth.titleSignIn", "Inicia Sesión con Google")
+      }
       description={
         currentUser
-          ? "Tus becas guardadas, progreso de visas y recordatorios están sincronizados."
-          : "Guarda tu progreso de postulación, recordatorios en Google Calendar e historial de IA."
+          ? t(
+              "auth.descAccount",
+              "Tus becas guardadas, progreso de visas y recordatorios están sincronizados."
+            )
+          : t(
+              "auth.descSignIn",
+              "Guarda tu progreso de postulación, recordatorios en Google Calendar e historial de IA."
+            )
       }
       size="md"
       id="auth-modal"
@@ -121,7 +152,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
               <div className="flex items-center gap-2 mt-1">
                 <span className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-[10px] font-bold px-2 py-0.5 rounded-full flex items-center gap-1">
                   <ShieldCheck className="w-3 h-3" />
-                  Cuenta Google Verificada
+                  {t("auth.verifiedAccount", "Cuenta Google Verificada")}
                 </span>
               </div>
             </div>
@@ -135,7 +166,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           <div className="p-3 bg-surface dark:bg-slate-800/90 rounded-2xl border border-outline-variant/40 dark:border-slate-700 space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-xs font-bold text-on-surface dark:text-slate-200">
-                Rol de Cuenta:
+                {t("auth.roleLabel", "Rol de Cuenta:")}
               </span>
               <span
                 className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
@@ -144,13 +175,21 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                     : "bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700"
                 }`}
               >
-                {currentUser.isAdmin ? "🔑 Administrador" : "👤 Usuario Estándar"}
+                {currentUser.isAdmin
+                  ? t("auth.roleAdmin", "🔑 Administrador")
+                  : t("auth.roleStandard", "👤 Usuario Estándar")}
               </span>
             </div>
             <p className="text-[11px] text-on-surface-variant dark:text-slate-400">
               {currentUser.isAdmin
-                ? "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos."
-                : "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración."}
+                ? t(
+                    "auth.roleAdminBody",
+                    "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos."
+                  )
+                : t(
+                    "auth.roleStandardBody",
+                    "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración."
+                  )}
             </p>
           </div>
 
@@ -158,15 +197,15 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           <div className="space-y-2 text-xs text-on-surface-variant dark:text-slate-300">
             <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
               <Bookmark className="w-4 h-4 text-primary dark:text-sky-400" />
-              <span>Sincronización activa de Becas Guardadas</span>
+              <span>{t("auth.syncBookmarks", "Sincronización activa de Becas Guardadas")}</span>
             </div>
             <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
               <Calendar className="w-4 h-4 text-emerald-500" />
-              <span>Conexión directa con Google Calendar</span>
+              <span>{t("auth.syncCalendar", "Conexión directa con Google Calendar")}</span>
             </div>
             <div className="flex items-center gap-2 p-2.5 bg-surface dark:bg-slate-800 rounded-xl">
               <Sparkles className="w-4 h-4 text-amber-500" />
-              <span>Historial del Asistente LatinoMigra IA</span>
+              <span>{t("auth.syncChat", "Historial del Asistente LatinoMigra IA")}</span>
             </div>
           </div>
 
@@ -178,7 +217,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
             className="btn-tactile w-full flex items-center justify-center gap-2 py-3 border border-red-500/30 text-red-600 dark:text-red-400 font-bold text-xs rounded-xl hover:bg-red-50 dark:hover:bg-red-950/30 transition-all shadow-xs"
           >
             <LogOut className="w-4 h-4" />
-            <span>Cerrar Sesión</span>
+            <span>{t("auth.signOut", "Cerrar Sesión")}</span>
           </button>
         </div>
       ) : (
@@ -189,7 +228,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
             onClick={handleFirebaseGoogleSignIn}
             disabled={isLoading}
             id="google-signin-btn"
-            aria-label="Continuar con Google"
+            aria-label={t("auth.continueWithGoogle", "Continuar con Google")}
             className="btn-tactile w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-800 font-bold text-sm py-3 px-4 rounded-xl border border-slate-300 shadow-sm transition-all hover:shadow-md disabled:opacity-50"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24">
@@ -210,7 +249,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                 d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84c.87-2.6 3.3-4.52 6.16-4.52z"
               />
             </svg>
-            <span>Continuar con Google</span>
+            <span>{t("auth.continueWithGoogle", "Continuar con Google")}</span>
           </button>
 
           {/* A failed sign-in has to be visible: it used to close the modal and
@@ -229,7 +268,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           {/* Country Selection */}
           <div className="space-y-1.5 pt-2">
             <label className="text-xs font-bold text-on-surface-variant dark:text-slate-300 block">
-              País de origen (para personalización de visas):
+              {t("auth.originCountry", "País de origen (para personalización de visas):")}
             </label>
             <select
               value={selectedCountry}
@@ -249,7 +288,12 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           </div>
 
           <div className="pt-2 text-center text-[11px] text-on-surface-variant dark:text-slate-400 space-y-1">
-            <p>Protegido por Google OAuth 2.0. No compartiremos tu información personal.</p>
+            <p>
+              {t(
+                "auth.privacyNotice",
+                "Protegido por Google OAuth 2.0. No compartiremos tu información personal."
+              )}
+            </p>
           </div>
         </div>
       )}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -11,6 +11,68 @@ interface TranslationDictionary {
 }
 
 export const TRANSLATIONS: TranslationDictionary = {
+  // Sign-in modal (#80)
+  "auth.titleSignIn": { es: "Inicia Sesión con Google", en: "Sign in with Google" },
+  "auth.titleAccount": { es: "Tu Cuenta LatinoMigra", en: "Your LatinoMigra Account" },
+  "auth.descSignIn": {
+    es: "Guarda tu progreso de postulación, recordatorios en Google Calendar e historial de IA.",
+    en: "Keep your application progress, Google Calendar reminders and assistant history.",
+  },
+  "auth.descAccount": {
+    es: "Tus becas guardadas, progreso de visas y recordatorios están sincronizados.",
+    en: "Your saved scholarships, visa progress and reminders are in sync.",
+  },
+  "auth.continueWithGoogle": { es: "Continuar con Google", en: "Continue with Google" },
+  "auth.signOut": { es: "Cerrar Sesión", en: "Sign out" },
+  "auth.verifiedAccount": { es: "Cuenta Google Verificada", en: "Verified Google account" },
+  "auth.roleLabel": { es: "Rol de Cuenta:", en: "Account role:" },
+  "auth.roleAdmin": { es: "🔑 Administrador", en: "🔑 Administrator" },
+  "auth.roleStandard": { es: "👤 Usuario Estándar", en: "👤 Standard user" },
+  "auth.roleAdminBody": {
+    es: "Como administrador puedes gestionar convocatorias, acceder al Panel Admin y sincronizar la base de datos.",
+    en: "As an administrator you can manage calls, reach the admin panel and sync the database.",
+  },
+  "auth.roleStandardBody": {
+    es: "Como usuario estándar ves la plataforma limpia sin herramientas técnicas ni botones de administración.",
+    en: "As a standard user you see the platform without the technical tools or admin controls.",
+  },
+  "auth.syncBookmarks": {
+    es: "Sincronización activa de Becas Guardadas",
+    en: "Saved scholarships kept in sync",
+  },
+  "auth.syncCalendar": {
+    es: "Conexión directa con Google Calendar",
+    en: "Direct connection to Google Calendar",
+  },
+  "auth.syncChat": {
+    es: "Historial del Asistente LatinoMigra IA",
+    en: "LatinoMigra assistant history",
+  },
+  "auth.originCountry": {
+    es: "País de origen (para personalización de visas):",
+    en: "Country of origin (to tailor visa guidance):",
+  },
+  "auth.privacyNotice": {
+    es: "Protegido por Google OAuth 2.0. No compartiremos tu información personal.",
+    en: "Secured by Google OAuth 2.0. We will not share your personal information.",
+  },
+  "auth.errorPopupBlocked": {
+    es: "Tu navegador bloqueó la ventana de Google. Permite las ventanas emergentes de este sitio e inténtalo de nuevo.",
+    en: "Your browser blocked the Google window. Allow pop-ups for this site and try again.",
+  },
+  "auth.errorPopupClosed": {
+    es: "Cerraste la ventana de Google antes de terminar. Inténtalo de nuevo cuando quieras.",
+    en: "You closed the Google window before it finished. Try again whenever you like.",
+  },
+  "auth.errorNetwork": {
+    es: "No pudimos conectar con Google. Revisa tu conexión e inténtalo de nuevo.",
+    en: "We could not reach Google. Check your connection and try again.",
+  },
+  "auth.errorGeneric": {
+    es: "No pudimos completar el inicio de sesión con Google. Inténtalo de nuevo.",
+    en: "We could not complete the Google sign-in. Please try again.",
+  },
+
   // Navigation
   "nav.planificador": { es: "Planificador 360°", en: "360° Planner" },
   "nav.calculadora": { es: "Calculadora Costo de Vida", en: "Cost of Living Calculator" },


### PR DESCRIPTION
Closes #80.

With the language set to English the modal rendered **entirely in Spanish** —
title, description, the Google button, the role card, the sync list, the privacy
notice, the country label, and all four sign-in error messages.

This is #51's shape again: the mechanism has always worked and the coverage was
never built. It matters more here than elsewhere — the modal is the first thing
a new visitor interacts with and the one that **asks them for personal data**,
so ignoring a preference they explicitly set is worse on this screen than on any
other.

## What changed

Twenty-one strings go through `t()`, with `es` and `en` entries for each. No
`language === "en" ? … : …` ternary was added (CLAUDE.md constraint 3).

`describeSignInError` takes the translator as an argument rather than holding
four Spanish strings. It stays a pure exported function, so its existing tests
keep asserting the Spanish copy by passing a translator that resolves to the
fallback, and the new English test passes one that resolves against
`TRANSLATIONS`.

## Tests

Three added:

- the four sign-in errors resolve in English;
- **every one of the twenty-one keys exists and its `en` differs from its `es`**
  — which is what stops a key landing with the Spanish text copied into both
  fields, the failure mode a spot-check would miss;
- a render that flips the language inside the provider tree and asserts the
  modal follows, and that the Spanish is gone.

**Confirmed to fail when one string is put back as a literal.** 290 unit tests
passing, lint 33 of a 35 warning budget, `format:check` clean.

## Follow-up spotted, not fixed

Two fabrications sit in the sign-in success path, outside this change's scope:

- `email: fbUser.email || "usuario@latinomigra.com"` — an invented address
  attributed to a real person;
- `avatar: fbUser.photoURL || "https://images.unsplash.com/photo-1534528741775…"`
  — a stock photograph of a stranger presented as the visitor's own.

Both are the same "value produced from no source, presented with confidence"
pattern CLAUDE.md lists. Worth an issue; happy to open one.

Related: the country list in this same modal offers nine countries, which is
#88.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_