### PR TITLE
fix(auth): say when the build cannot sign anyone in (#78)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,10 +16,18 @@ npm run dev             # tsx server.ts — Express + Vite middleware on :3000
 ```
 
 > The app starts **without** a `.env`. `src/lib/firebase.ts` falls back to a
-> hardcoded configuration pointing at the `refined-coral-0zp2g` project, and
-> `server.ts` constructs the Gemini client with `"dummy-key-for-boot"`. Nothing
-> warns about this, so an unconfigured checkout can read from and write to a real
-> Firebase project.
+> placeholder configuration naming the `refined-coral-0zp2g` project, and
+> `server.ts` constructs the Gemini client with `"dummy-key-for-boot"`.
+>
+> Note that the repository's own `.env` ships every `VITE_FIREBASE_*` value as
+> an **empty string**, and `"" || fallback` is the fallback — so filling in
+> `.env.example` is not optional, and a build that skipped it looks configured
+> while nothing authenticated works.
+>
+> Since #78, `isFirebaseConfigured()` compares the resolved configuration
+> against those placeholders, logs a warning at start-up, and the sign-in modal
+> says the build cannot sign anyone in rather than offering a retry that can
+> never succeed. The Gemini side still warns about nothing.
 
 ## Environment variables
 

--- a/src/components/AuthModal.test.tsx
+++ b/src/components/AuthModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders as render } from "../test/renderWithProviders";
 import { AuthModal, describeSignInError } from "./AuthModal";
@@ -19,6 +19,16 @@ const LanguageSwitch: React.FC = () => {
 };
 
 describe("AuthModal Component", () => {
+  /*
+    Tests run without a Firebase environment, so the real
+    `isFirebaseConfigured` is false and the sign-in button is disabled — which
+    is the point of #78. Every test that exercises signing in states that the
+    build is configured.
+  */
+  beforeEach(() => {
+    vi.spyOn(firebase, "isFirebaseConfigured").mockReturnValue(true);
+  });
+
   const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
@@ -222,6 +232,54 @@ describe("AuthModal Component", () => {
    * someone from Panamá, Paraguay or Uruguay could not say where they were
    * from — on a platform whose audience is Latin America.
    */
+  /**
+   * Regression for #78. `.env` ships every `VITE_FIREBASE_*` value as an empty
+   * string, and `"" || fallback` is the fallback — so a build with no
+   * environment silently used placeholder credentials and every sign-in failed
+   * with a message blaming the visitor's connection.
+   */
+  describe("when the build has no Firebase configuration", () => {
+    beforeEach(() => {
+      vi.spyOn(firebase, "isFirebaseConfigured").mockReturnValue(false);
+    });
+
+    it("says so, instead of offering a retry that cannot work", () => {
+      render(<AuthModal {...defaultProps} />);
+
+      const notice = document.getElementById("auth-unconfigured");
+      expect(notice).toBeInTheDocument();
+      expect(notice).toHaveAttribute("role", "alert");
+      expect(notice).toHaveTextContent(/no está disponible en esta versión/i);
+      // And says what still works without an account.
+      expect(notice).toHaveTextContent(/becas/i);
+    });
+
+    it("disables the Google button rather than letting it fail", () => {
+      render(<AuthModal {...defaultProps} />);
+
+      const button = document.getElementById("google-signin-btn") as HTMLButtonElement;
+      expect(button).toBeDisabled();
+    });
+
+    it("never calls Firebase", () => {
+      const signIn = vi.spyOn(firebase, "signInWithGoogle");
+      render(<AuthModal {...defaultProps} />);
+
+      fireEvent.click(document.getElementById("google-signin-btn")!);
+
+      expect(signIn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the build is configured", () => {
+    it("offers sign-in with no warning", () => {
+      render(<AuthModal {...defaultProps} />);
+
+      expect(document.getElementById("auth-unconfigured")).not.toBeInTheDocument();
+      expect(document.getElementById("google-signin-btn")).not.toBeDisabled();
+    });
+  });
+
   describe("country of origin", () => {
     it("offers every Latin American country the platform knows about", () => {
       render(<AuthModal {...defaultProps} />);

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { ShieldCheck, Bookmark, Calendar, Sparkles, LogOut, AlertTriangle } from "lucide-react";
 import { GoogleUser } from "../types";
-import { signInWithGoogle, isUserAdmin } from "../lib/firebase";
+import { signInWithGoogle, isUserAdmin, isFirebaseConfigured } from "../lib/firebase";
 import { Avatar } from "./ui/Avatar";
 import { Modal } from "./ui/Modal";
 import { useLanguage } from "../lib/i18n";
@@ -76,6 +76,12 @@ export const AuthModal: React.FC<AuthModalProps> = ({
   onSignOut,
 }) => {
   const { t } = useLanguage();
+  /*
+    Read once per render rather than at module load, so a build that is
+    configured and one that is not both render honestly and the state is
+    reachable from a test.
+  */
+  const canSignIn = isFirebaseConfigured();
   const [selectedCountry, setSelectedCountry] = useState<string>("Colombia");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   /** Message shown, in the visitor's language, when sign-in did not complete. */
@@ -239,9 +245,32 @@ export const AuthModal: React.FC<AuthModalProps> = ({
         /* Sign In View */
         <div className="space-y-4">
           {/* Direct Official Google Button */}
+          {/*
+            The application cannot sign anyone in without its Firebase
+            configuration, and every value in `.env` ships empty, so a build
+            that missed its environment reported "inténtalo de nuevo" forever
+            while retrying could never work (#78). Say what is actually wrong
+            and stop offering a control that cannot succeed.
+          */}
+          {!canSignIn && (
+            <p
+              id="auth-unconfigured"
+              role="alert"
+              className="flex items-start gap-2 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-3 text-xs font-semibold text-amber-800 dark:text-amber-300"
+            >
+              <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
+              <span>
+                {t(
+                  "auth.notConfigured",
+                  "El inicio de sesión no está disponible en esta versión de la aplicación. Puedes seguir usando las becas, las guías y el asistente sin cuenta."
+                )}
+              </span>
+            </p>
+          )}
+
           <button
             onClick={handleFirebaseGoogleSignIn}
-            disabled={isLoading}
+            disabled={isLoading || !canSignIn}
             id="google-signin-btn"
             aria-label={t("auth.continueWithGoogle", "Continuar con Google")}
             className="btn-tactile w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-800 font-bold text-sm py-3 px-4 rounded-xl border border-slate-300 shadow-sm transition-all hover:shadow-md disabled:opacity-50"

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -41,18 +41,29 @@ for (const path in configModules) {
 
 const env: Record<string, any> = (import.meta as any).env || {};
 
+/**
+ * Stand-ins that let the bundle build without credentials.
+ *
+ * They are not a working configuration: Firebase initialises against them and
+ * every call then fails, so sign-in reports "no pudimos completar el inicio de
+ * sesión" while the real cause is that the application was built without its
+ * environment (#78). Naming them here is what makes that detectable — see
+ * `isFirebaseConfigured`.
+ */
+const PLACEHOLDER_API_KEY = "AIzaSyDummyKeyForSafeInitialization0000";
+const PLACEHOLDER_PROJECT_ID = "refined-coral-0zp2g";
+
 const firebaseConfig = {
-  apiKey:
-    env.VITE_FIREBASE_API_KEY || localConfig.apiKey || "AIzaSyDummyKeyForSafeInitialization0000",
+  apiKey: env.VITE_FIREBASE_API_KEY || localConfig.apiKey || PLACEHOLDER_API_KEY,
   authDomain:
     env.VITE_FIREBASE_AUTH_DOMAIN ||
     localConfig.authDomain ||
-    "refined-coral-0zp2g.firebaseapp.com",
-  projectId: env.VITE_FIREBASE_PROJECT_ID || localConfig.projectId || "refined-coral-0zp2g",
+    `${PLACEHOLDER_PROJECT_ID}.firebaseapp.com`,
+  projectId: env.VITE_FIREBASE_PROJECT_ID || localConfig.projectId || PLACEHOLDER_PROJECT_ID,
   storageBucket:
     env.VITE_FIREBASE_STORAGE_BUCKET ||
     localConfig.storageBucket ||
-    "refined-coral-0zp2g.appspot.com",
+    `${PLACEHOLDER_PROJECT_ID}.appspot.com`,
   messagingSenderId:
     env.VITE_FIREBASE_MESSAGING_SENDER_ID || localConfig.messagingSenderId || "123456789",
   appId: env.VITE_FIREBASE_APP_ID || localConfig.appId || "1:123456789:web:abcdef",
@@ -73,6 +84,35 @@ try {
       : getFirestore(appInstance);
 } catch (error) {
   console.warn("Firebase initialization warning (running in safe fallback mode):", error);
+}
+
+/**
+ * Whether this build carries a real Firebase configuration.
+ *
+ * `.env` ships every `VITE_FIREBASE_*` value as an empty string, and `"" ||
+ * fallback` is the fallback — so a build with no environment silently uses the
+ * placeholders above and every authenticated feature fails with a message that
+ * blames the visitor's connection. A failure has to be visible somewhere
+ * (CLAUDE.md constraint 5), and "the app was built without its keys" is not
+ * something a visitor can be expected to infer from "inténtalo de nuevo".
+ *
+ * This reads the configuration, never a secret: it compares against the two
+ * placeholder constants and answers a boolean.
+ */
+export function isFirebaseConfigured(): boolean {
+  return (
+    firebaseConfig.apiKey !== PLACEHOLDER_API_KEY &&
+    firebaseConfig.projectId !== PLACEHOLDER_PROJECT_ID &&
+    Boolean(firebaseConfig.apiKey) &&
+    Boolean(firebaseConfig.projectId)
+  );
+}
+
+if (!isFirebaseConfigured()) {
+  console.warn(
+    "Firebase is running on placeholder configuration: sign-in and every " +
+      "Firestore read or write will fail. Set the VITE_FIREBASE_* variables."
+  );
 }
 
 // Initialize Firebase App & Exports safely

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -77,6 +77,10 @@ export const TRANSLATIONS: TranslationDictionary = {
   // Navigation
   "nav.planificador": { es: "Planificador 360°", en: "360° Planner" },
   "nav.calculadora": { es: "Calculadora Costo de Vida", en: "Cost of Living Calculator" },
+  "auth.notConfigured": {
+    es: "El inicio de sesión no está disponible en esta versión de la aplicación. Puedes seguir usando las becas, las guías y el asistente sin cuenta.",
+    en: "Sign-in is not available in this build. You can still use the scholarships, the guides and the assistant without an account.",
+  },
   "nav.becas": { es: "Becas & Estudios", en: "Scholarships & Studies" },
   "nav.voluntariados": { es: "Voluntariados & Intercambios", en: "Volunteering & Exchanges" },
   "nav.guia": { es: "Guía de Migración", en: "Migration Guide" },


### PR DESCRIPTION
Addresses #78. **Does not close it** — see below.

> ⚠️ **Fourth in the auth chain.** Merge order: **#97 → #98 → #101 → this.**

## What I found

`.env` ships **every** `VITE_FIREBASE_*` value as an empty string:

```
VITE_FIREBASE_API_KEY=""
VITE_FIREBASE_AUTH_DOMAIN=""
VITE_FIREBASE_PROJECT_ID=""
…
```

In JavaScript `"" || fallback` **is** the fallback. So a build that did not fill
them in gets the placeholder credentials in `firebase.ts` — a dummy API key and
the `refined-coral-0zp2g` project — initialises Firebase against them, and every
authenticated call fails. The modal then says *"no pudimos completar el inicio
de sesión … inténtalo de nuevo"*, and retrying can never work.

Nothing said so, anywhere: not in the console, not on screen. That is the silent
fallback CLAUDE.md constraint 5 is about, sitting directly under the most
visible broken feature in the product.

## What this changes

`isFirebaseConfigured()` compares the resolved configuration against the two
placeholder constants, which are named now rather than inlined. **It reads
configuration and returns a boolean — no secret is read, logged or committed.**

- An unconfigured build warns in the console at start-up.
- The modal renders an alert saying sign-in is unavailable in this build, and
  names what still works without an account — becas, guías and the assistant,
  all of which genuinely do.
- The Google button is **disabled** rather than offered as a retry that cannot
  succeed.

## Why this does not close the issue

**This does not by itself make sign-in work.** If the deployment *does* have its
variables set, the next suspects are the authorised-domains list in the Firebase
console and the popup itself — neither reachable from this environment, and
both requiring someone with console access.

What this does is make the difference **visible**, so the next person sees which
of the two cases they are in instead of guessing. Please leave #78 open until
sign-in completes end to end.

## Tests

4 added: the unconfigured build's notice and its `role="alert"`, the disabled
button, that Firebase is never called, and that a configured build shows no
warning.

The existing sign-in tests now state that the build is configured — **without
that they were exercising a disabled button**, which is worth noting because it
means they would have kept passing while asserting nothing.

307 unit tests passing, lint 33 of a 35 warning budget, `format:check` clean.

## Documentation

`docs/development.md` — the note about starting without a `.env` was true but
did not mention that the committed `.env` is itself empty, which is the trap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtHNqskaaj9segRLDK9yv)_