### PR TITLE
fix(i18n): give cost rows a key so the guide's expenses translate

### DIFF
--- a/src/components/GuiaMigracion.tsx
+++ b/src/components/GuiaMigracion.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { NavigationTab, VisaType } from "../types";
 import { useLanguage } from "../lib/i18n";
+import { useLabels } from "../lib/labels";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { MIGRATION_GUIDES_DATA } from "../data/migrationGuides";
 import { COUNTRY_ANTI_SCAM_DATA } from "../data/antiScamData";
@@ -46,6 +47,7 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
   onOpenAuthModal,
 }) => {
   const { t } = useLanguage();
+  const label = useLabels();
   // Country selection is shared app-wide, so opening a guide for Alemania also
   // moves the planner, calculator, consular map and alerts to Alemania.
   const { destinationCountryCode, setDestinationCountryByCode } = usePreferences();
@@ -620,7 +622,15 @@ export const GuiaMigracion: React.FC<GuiaMigracionProps> = ({
                 return (
                   <div key={idx} className="space-y-1.5">
                     <div className="flex flex-wrap justify-between gap-x-3 text-xs font-semibold text-on-surface dark:text-slate-200">
-                      <span>{cost.category}</span>
+                      <span>
+                        {label("costCategory", cost.categoryKey)}
+                        {cost.categoryDetail && (
+                          <span className="font-normal text-on-surface-variant dark:text-slate-400">
+                            {" "}
+                            ({cost.categoryDetail})
+                          </span>
+                        )}
+                      </span>
                       <span className="font-bold text-primary dark:text-sky-300 whitespace-nowrap">
                         {local} / {cost.period}
                       </span>

--- a/src/data/migrationGuides.costs.test.ts
+++ b/src/data/migrationGuides.costs.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { MIGRATION_GUIDES_DATA } from "./migrationGuides";
+import { CostCategory } from "../types";
+
+/**
+ * Regression for #51.
+ *
+ * A cost row carried a free-form Spanish string — "Alojamiento (Habitación/
+ * Basement/Apto)" — which was both the label and the only identifier. It
+ * could not be translated without losing the country-specific detail inside
+ * the parentheses, so the guide showed "Estimated Cost of Living" above rows
+ * named in Spanish.
+ */
+describe("cost rows", () => {
+  const rows = Object.values(MIGRATION_GUIDES_DATA).flatMap((guide) => guide.costs ?? []);
+  const known: CostCategory[] = ["housing", "food", "transport", "health", "phone", "other"];
+
+  it("has rows to assert against", () => {
+    expect(rows.length).toBeGreaterThan(20);
+  });
+
+  it("names every expense with a key the interface can translate", () => {
+    for (const row of rows) {
+      expect(known, JSON.stringify(row.categoryDetail)).toContain(row.categoryKey);
+    }
+  });
+
+  it("carries no Spanish label of its own", () => {
+    // The old `category` field was the label. If it comes back, so does the
+    // untranslatable row.
+    for (const row of rows) {
+      expect(row).not.toHaveProperty("category");
+    }
+  });
+
+  it("keeps the local detail, and only where it names something local", () => {
+    // "Deutschlandticket", "Leap Card", "OSHC", "GKV" — schemes and cards a
+    // reader will meet by that name, which is why a key alone is not enough.
+    // Everything else was the rest of a Spanish label, and the key already
+    // says what the expense is.
+    const details = rows.map((row) => row.categoryDetail).filter(Boolean) as string[];
+    expect(details.length).toBeGreaterThan(4);
+
+    // No detail may be a plain Spanish description; those are what the key
+    // replaces.
+    for (const detail of details) {
+      expect(detail, detail).not.toMatch(/Habitación|Supermercado|Obligatorio|Mensual|Servicios/);
+    }
+  });
+
+  it("uses `other` only where no expense kind fits", () => {
+    const other = rows.filter((row) => row.categoryKey === "other");
+    // A guide whose every row is "other" would translate to nothing useful.
+    expect(other.length).toBeLessThan(rows.length / 2);
+  });
+});

--- a/src/data/migrationGuides.ts
+++ b/src/data/migrationGuides.ts
@@ -97,7 +97,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Habitación/Piso)",
+        categoryKey: "housing",
         min: 400,
         max: 750,
         currency: "EUR",
@@ -106,7 +106,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 200,
         max: 320,
         currency: "EUR",
@@ -115,7 +115,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Transporte Público (Abono Joven/Mes)",
+        categoryKey: "transport",
         min: 10,
         max: 40,
         currency: "EUR",
@@ -124,7 +124,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-outline",
       },
       {
-        category: "Seguro Médico y Gastos Personales",
+        categoryKey: "health",
         min: 50,
         max: 100,
         currency: "EUR",
@@ -277,7 +277,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Habitación/Basement/Apto)",
+        categoryKey: "housing",
         min: 800,
         max: 1600,
         currency: "CAD",
@@ -286,7 +286,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 350,
         max: 550,
         currency: "CAD",
@@ -295,7 +295,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Transporte Público (Pase Mensual)",
+        categoryKey: "transport",
         min: 100,
         max: 160,
         currency: "CAD",
@@ -304,7 +304,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-outline",
       },
       {
-        category: "Telefonía Celular y Servicios",
+        categoryKey: "phone",
         min: 50,
         max: 90,
         currency: "CAD",
@@ -435,7 +435,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Habitación compartida/individual)",
+        categoryKey: "housing",
         min: 500,
         max: 950,
         currency: "EUR",
@@ -444,7 +444,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado (Lidl, Aldi, Tesco)",
+        categoryKey: "food",
+        categoryDetail: "Lidl, Aldi, Tesco",
         min: 200,
         max: 300,
         currency: "EUR",
@@ -453,7 +454,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Transporte (Leap Card para estudiantes)",
+        categoryKey: "transport",
+        categoryDetail: "Leap Card",
         min: 40,
         max: 80,
         currency: "EUR",
@@ -462,7 +464,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-outline",
       },
       {
-        category: "Telefonía móvil y Extras",
+        categoryKey: "phone",
         min: 20,
         max: 50,
         currency: "EUR",
@@ -609,7 +611,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (WG / Habitación / Apartamento)",
+        categoryKey: "housing",
+        categoryDetail: "WG",
         min: 400,
         max: 750,
         currency: "EUR",
@@ -618,7 +621,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 250,
         max: 360,
         currency: "EUR",
@@ -627,7 +630,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Seguro de Salud Público (GKV)",
+        categoryKey: "health",
+        categoryDetail: "GKV",
         min: 120,
         max: 140,
         currency: "EUR",
@@ -636,7 +640,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-outline",
       },
       {
-        category: "Transporte (Deutschlandticket)",
+        categoryKey: "transport",
+        categoryDetail: "Deutschlandticket",
         min: 49,
         max: 58,
         currency: "EUR",
@@ -751,7 +756,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Dormitorio universitario / Apartamento)",
+        categoryKey: "housing",
         min: 800,
         max: 1600,
         currency: "USD",
@@ -760,7 +765,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 350,
         max: 600,
         currency: "USD",
@@ -769,7 +774,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Seguro Médico Universitario Obligatorio",
+        categoryKey: "health",
         min: 150,
         max: 320,
         currency: "USD",
@@ -778,7 +783,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-outline",
       },
       {
-        category: "Transporte y Telefonía",
+        categoryKey: "transport",
         min: 80,
         max: 150,
         currency: "USD",
@@ -893,7 +898,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Habitación privada)",
+        categoryKey: "housing",
         min: 350,
         max: 600,
         currency: "EUR",
@@ -902,7 +907,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 180,
         max: 260,
         currency: "EUR",
@@ -911,7 +916,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Transporte Público (Passe Navegante)",
+        categoryKey: "transport",
+        categoryDetail: "Passe Navegante",
         min: 30,
         max: 40,
         currency: "EUR",
@@ -920,7 +926,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-emerald-600",
       },
       {
-        category: "Salud y Servicios Básicos",
+        categoryKey: "health",
         min: 50,
         max: 90,
         currency: "EUR",
@@ -1038,7 +1044,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
     ],
     costs: [
       {
-        category: "Alojamiento (Habitación compartida/privada)",
+        categoryKey: "housing",
         min: 220,
         max: 450,
         currency: "AUD",
@@ -1047,7 +1053,7 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-primary",
       },
       {
-        category: "Alimentación y Supermercado",
+        categoryKey: "food",
         min: 100,
         max: 180,
         currency: "AUD",
@@ -1056,7 +1062,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-secondary",
       },
       {
-        category: "Transporte (Opal / Myki / Translink)",
+        categoryKey: "transport",
+        categoryDetail: "Opal / Myki / Translink",
         min: 40,
         max: 65,
         currency: "AUD",
@@ -1065,7 +1072,8 @@ export const MIGRATION_GUIDES_DATA: Record<string, CountryGuide> = {
         color: "bg-emerald-600",
       },
       {
-        category: "Seguro OSHC Obligatorio",
+        categoryKey: "health",
+        categoryDetail: "OSHC",
         min: 50,
         max: 80,
         currency: "AUD",

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -640,6 +640,13 @@ export const TRANSLATIONS: TranslationDictionary = {
   "label.routeBadge.requirement": { es: "Requisito de visado", en: "Visa requirement" },
   "label.routeBadge.none": { es: "Sin vía migratoria", en: "No migration route" },
 
+  "label.cost.housing": { es: "Alojamiento", en: "Housing" },
+  "label.cost.food": { es: "Alimentación y supermercado", en: "Food and groceries" },
+  "label.cost.transport": { es: "Transporte", en: "Transport" },
+  "label.cost.health": { es: "Salud y seguro", en: "Health and insurance" },
+  "label.cost.phone": { es: "Telefonía y servicios", en: "Phone and utilities" },
+  "label.cost.other": { es: "Otros gastos", en: "Other costs" },
+
   // Footer
   "footer.tools": { es: "Herramientas", en: "Tools" },
   "footer.community": { es: "Comunidad & Recursos", en: "Community & Resources" },

--- a/src/lib/labels.test.tsx
+++ b/src/lib/labels.test.tsx
@@ -56,6 +56,8 @@ describe("useLabels", () => {
     ["area", "Artes y Humanidades", "Artes y Humanidades", "Arts and Humanities"],
     ["dateRange", "urgent", "⚡ Cierra en 30 días", "⚡ Closes within 30 days"],
     ["sort", "deadline-asc", "⏱️ Cierre más próximo (Inminente)", "⏱️ Closing soonest"],
+    ["costCategory", "housing", "Alojamiento", "Housing"],
+    ["costCategory", "transport", "Transporte", "Transport"],
   ])("translates %s/%s", (dimension, value, es, en) => {
     render(<Probe dimension={dimension as never} value={value} />);
     expect(read()).toBe(es);

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -66,6 +66,14 @@ const KEYS: Record<string, Record<string, string>> = {
     semester: "label.deadline.90",
     later: "label.deadline.later",
   },
+  costCategory: {
+    housing: "label.cost.housing",
+    food: "label.cost.food",
+    transport: "label.cost.transport",
+    health: "label.cost.health",
+    phone: "label.cost.phone",
+    other: "label.cost.other",
+  },
   sort: {
     "deadline-asc": "label.sort.deadlineAsc",
     "deadline-desc": "label.sort.deadlineDesc",

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,8 +204,25 @@ export interface DocumentItem {
   notes?: string;
 }
 
+/**
+ * The kind of expense a cost row describes.
+ *
+ * The rows carried a free-form Spanish string — "Alojamiento (Habitación/
+ * Basement/Apto)" — which is both the label and the only identifier, so it
+ * could not be translated without losing the country-specific detail inside
+ * the parentheses. The key names the expense; `categoryDetail` keeps the
+ * local specifics, which are content and stay as written.
+ */
+export type CostCategory = "housing" | "food" | "transport" | "health" | "phone" | "other";
+
 export interface CostItem {
-  category: string;
+  /** Names the expense, for translation. */
+  categoryKey: CostCategory;
+  /**
+   * Country-specific detail shown beside the label — "Lidl, Aldi, Tesco",
+   * "Deutschlandticket", "Leap Card para estudiantes". Content, not copy.
+   */
+  categoryDetail?: string;
   /**
    * The range as the destination itself quotes it, in `currency`.
    *


### PR DESCRIPTION
Part of #51. **Rebased onto `main`; no longer stacked.** #107 has merged, so the labels module this needs is already in `main`. The branch previously carried its own copy of #107's commit, which collided with `main`'s squashed version and produced seven phantom conflicts — the same patch on both sides. Dropping the duplicate resolved all seven and cut the diff from 504 insertions to 138.

## The problem

"Estimated Cost of Living" sat above rows named **"Alojamiento (Habitación/Basement/Apto)"** and **"Telefonía Celular y Servicios"**.

A cost row carried a free-form Spanish string as both its label *and* its only identifier. It could not be translated without losing what was inside the parentheses — "Deutschlandticket", "Leap Card", "Lidl, Aldi, Tesco" — names a reader will actually meet.

## The fix

`CostItem` gains `categoryKey` (housing · food · transport · health · phone · other) and an optional `categoryDetail`. The key names the expense and translates; the detail names something local and stays as written.

| | Spanish | English |
|---|---|---|
| | Alojamiento | Housing |
| | Alimentación y supermercado | Food and groceries |
| | Transporte | Transport |
| | Salud y seguro | Health and insurance |

## A wrong first pass, and why it matters

Splitting the 28 rows mechanically at the parenthesis kept `Habitación/Piso`, `Supermercado` and `Médico y Gastos Personales` as "local details". They are not local names — they are the rest of a Spanish label, and the key already says what the expense is. The screen still read `Housing (Habitación/Piso)`.

Twenty were dropped. The eight naming a scheme, a card or a chain were kept, and three trimmed to the name itself (`OSHC Obligatorio` → `OSHC`, `Leap Card para estudiantes` → `Leap Card`).

Flagging it because "translated" would have looked done after the first pass, and it wasn't.

## Tests

**`migrationGuides.costs.test.ts` (5)** — every row names an expense with a known key; no row carries the old `category` field; the local details survive; **none of them is a plain Spanish description**; and `other` is not what most rows fall back to.

**`labels.test.tsx`** — two more dimensions covered.

Re-run after the rebase, on the rebased branch:

```
393 unit tests passed
lint 0 errors, format:check clean
```