### PR TITLE
fix(becas): split saved items into two sub-tabs with their own filters

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -231,8 +231,18 @@ Recently addressed and verified by tests:
 - The tab is "Mis Guardados" and holds both catalogues: a language
   certification or a vocational programme can be saved beside a scholarship
   (#82). The badge counts both.
-- Saved programmes render above the saved scholarships, each under its own
-  heading with its own count.
+- Two sub-tabs inside it — "Becas guardadas (N)" and "Programas guardados (N)"
+  — and the filter panel narrows whichever is open (#106). They rendered as two
+  stacked lists under a single panel, which narrowed the scholarships while the
+  programmes ignored it, and counted its chips against the whole catalogue
+  rather than against what was saved. A scholarship has an education level and
+  a closing date; a programme has a format and a migration route, so one panel
+  above both could only ever narrow one of them.
+- The saved programmes carry their own `useStudyFilters` instance, separate
+  from the Estudios tab's, so each chip's count is measured against the list it
+  sits beside.
+- An empty saved list says nothing was saved. It previously fell through to the
+  catalogue's own empty state, which blames the official-source check instead.
 - A favourite is stored as `"{kind}:{id}"`. A bare id stopped identifying
   anything once two catalogues shared a screen.
 

--- a/src/components/BecasExplorer.test.tsx
+++ b/src/components/BecasExplorer.test.tsx
@@ -159,8 +159,87 @@ describe("BecasExplorer Component", () => {
 
       await user.click(screen.getByRole("tab", { name: /Mis Guardados/i }));
 
-      expect(document.getElementById("saved-programmes")).toBeInTheDocument();
+      // Saved programmes live behind their own sub-tab since #106: one filter
+      // panel above two kinds of item could only ever narrow one of them.
+      const programmesTab = document.getElementById("saved-kind-programmes")!;
+      expect(programmesTab).toHaveTextContent("(1)");
+      expect(document.getElementById(`estudio-card-${programmeId}`)).not.toBeInTheDocument();
+
+      fireEvent.click(programmesTab);
       expect(document.getElementById(`estudio-card-${programmeId}`)).toBeInTheDocument();
+    });
+
+    /*
+      One filter panel above two kinds of item narrowed the scholarships while
+      the programmes ignored it, and counted its chips against the whole
+      catalogue rather than against what was saved (#106).
+    */
+    describe("filters per kind", () => {
+      /** Saves one programme and one scholarship, then opens favourites. */
+      const saveOneOfEach = async () => {
+        const result = await openStudies();
+        fireEvent.click(document.querySelector('[id^="estudio-fav-"]') as HTMLElement);
+        await result.user.click(screen.getByRole("tab", { name: /Todas las Convocatorias/i }));
+        fireEvent.click(
+          document.querySelector('button[title*="favoritos"], button[title*="beca"]') as HTMLElement
+        );
+        await result.user.click(screen.getByRole("tab", { name: /Mis Guardados/i }));
+        return result;
+      };
+
+      it("shows one kind at a time, each with its own count", async () => {
+        await saveOneOfEach();
+
+        expect(document.getElementById("saved-kind-scholarships")).toHaveTextContent("(1)");
+        expect(document.getElementById("saved-kind-programmes")).toHaveTextContent("(1)");
+
+        // The scholarship half is open first, so no programme card is rendered
+        // beneath the scholarship filters.
+        expect(document.querySelector('[id^="estudio-card-"]')).toBeNull();
+      });
+
+      it("gives each kind the filters that describe it", async () => {
+        const { container } = await saveOneOfEach();
+
+        const sidebar = container.querySelector("aside")!;
+        expect(sidebar.querySelector("#sidebar-country-Todos")).toBeInTheDocument();
+        expect(sidebar.querySelector("#sidebar-estudios-route-chip-directa")).toBeNull();
+
+        fireEvent.click(document.getElementById("saved-kind-programmes")!);
+
+        // A saved scholarship has no migration route and a saved programme has
+        // no education level, so the panel swaps rather than spanning both.
+        expect(sidebar.querySelector("#sidebar-estudios-route-chip-directa")).toBeInTheDocument();
+        expect(sidebar.querySelector("#sidebar-country-Todos")).toBeNull();
+      });
+
+      it("counts the chips against what is saved, not the whole catalogue", async () => {
+        const { container } = await saveOneOfEach();
+        fireEvent.click(document.getElementById("saved-kind-programmes")!);
+
+        const sidebar = container.querySelector("aside")!;
+        const total = Number(
+          sidebar
+            .querySelector("#sidebar-estudios-country-chip-Todos")!
+            .textContent?.match(/(\d+)\s*$/)?.[1]
+        );
+
+        // One programme is saved. Counting the catalogue would give thirteen.
+        expect(total).toBe(1);
+      });
+
+      it("says nothing is saved rather than blaming the catalogue", async () => {
+        const result = await openStudies();
+        await result.user.click(screen.getByRole("tab", { name: /Mis Guardados/i }));
+        fireEvent.click(document.getElementById("saved-kind-programmes")!);
+
+        // With no saved programmes the list is empty because nothing was saved,
+        // not because every entry failed its official-source check.
+        expect(document.getElementById("empty-saved-programmes")).toBeInTheDocument();
+        expect(
+          screen.queryByText(/No pudimos mostrar el catálogo de estudios/i)
+        ).not.toBeInTheDocument();
+      });
     });
 
     it("counts saved scholarships and programmes together", async () => {

--- a/src/components/BecasExplorer.tsx
+++ b/src/components/BecasExplorer.tsx
@@ -323,6 +323,17 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
       };
 
   /**
+   * Which half of the favourites tab is open (#106).
+   *
+   * A saved scholarship and a saved programme describe themselves in different
+   * words — one has an education level and a closing date, the other a format
+   * and a migration route — so one filter panel above both lists could only
+   * ever narrow one of them while appearing to narrow both. It did: the panel
+   * filtered the scholarships and the programmes ignored it.
+   */
+  const [savedKind, setSavedKind] = useState<"scholarships" | "programmes">("scholarships");
+
+  /**
    * What the Estudios tab will actually show — not `STUDY_PROGRAMMES_DATA.length`.
    * An entry without an official source does not render, and a badge counting
    * the entries rather than the results is the "counted the whole catalogue
@@ -444,6 +455,19 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     () => favouritesOfKind(favorites, "scholarship"),
     [favorites]
   );
+
+  /**
+   * The saved programmes get their own filter state rather than sharing the
+   * Estudios tab's. The counts on a chip have to be measured against the list
+   * the chip sits beside — counting the whole catalogue while the list beside
+   * it is filtered is the defect this screen already shipped once.
+   */
+  const savedProgrammeFilters = useStudyFilters(savedProgrammes);
+
+  /** Whether the list and the filter panel on screen are study programmes. */
+  const showingProgrammes =
+    showingStudies || (viewModeTab === "favorites" && savedKind === "programmes");
+  const programmeFilters = showingStudies ? studyFilters : savedProgrammeFilters;
 
   const clearFilters = () => {
     setSelectedCountry("Todos");
@@ -652,9 +676,13 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
     while the studies list is showing is exactly the "value from the wrong
     source" the option counts already got wrong once.
   */
-  const clearActiveFilters = showingStudies ? studyFilters.clearFilters : clearFilters;
-  const activeFilterTotal = showingStudies ? studyFilters.activeFilterCount : activeFilterCount;
-  const sheetFilterCount = showingStudies ? studyFilters.activeFilterCount : advancedFilterCount;
+  const clearActiveFilters = showingProgrammes ? programmeFilters.clearFilters : clearFilters;
+  const activeFilterTotal = showingProgrammes
+    ? programmeFilters.activeFilterCount
+    : activeFilterCount;
+  const sheetFilterCount = showingProgrammes
+    ? programmeFilters.activeFilterCount
+    : advancedFilterCount;
 
   /**
    * The whole filter set, rendered identically in the desktop sidebar and the
@@ -870,20 +898,20 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
           <div className="relative flex-1 min-w-[200px] md:w-64">
             <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant dark:text-slate-400" />
             <Input
-              value={showingStudies ? studyFilters.filters.search : searchQuery}
+              value={showingProgrammes ? programmeFilters.filters.search : searchQuery}
               onChange={(e) =>
-                showingStudies
-                  ? studyFilters.setFilter("search", e.target.value)
+                showingProgrammes
+                  ? programmeFilters.setFilter("search", e.target.value)
                   : setSearchQuery(e.target.value)
               }
               placeholder={
-                showingStudies
+                showingProgrammes
                   ? t("estudios.searchPlaceholder", "Buscar por nombre o institución…")
                   : t("becas.searchPlaceholder", "Buscar por nombre, país, área o universidad...")
               }
               id="becas-search-input"
               aria-label={
-                showingStudies
+                showingProgrammes
                   ? t("estudios.searchLabel", "Buscar programa o institución")
                   : t("becas.searchLabel", "Buscar convocatorias")
               }
@@ -896,14 +924,14 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
             do — a programme has no closing date, so offering "cierre más
             próximo" here would sort by a field it does not carry.
           */}
-          {showingStudies ? (
+          {showingProgrammes ? (
             <div className="flex items-center gap-2">
               <span className="text-xs font-semibold text-on-surface-variant dark:text-slate-400 whitespace-nowrap">
                 {t("estudios.sortLabel", "Ordenar por:")}
               </span>
               <Select
-                value={studyFilters.sortBy}
-                onValueChange={(value) => studyFilters.setSortBy(value as StudySortOption)}
+                value={programmeFilters.sortBy}
+                onValueChange={(value) => programmeFilters.setSortBy(value as StudySortOption)}
               >
                 <SelectTrigger
                   id="estudios-sort-select"
@@ -1151,7 +1179,7 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
             </div>
           </div>
 
-          {!showingStudies && (
+          {!showingProgrammes && (
             <>
               <FilterChipGroup
                 label={t("becas.countryLabel", "País Destino")}
@@ -1233,7 +1261,9 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                 </button>
               </div>
 
-              {showingStudies ? studyFilters.renderGroups("sheet") : renderFilterGroups("sheet")}
+              {showingProgrammes
+                ? programmeFilters.renderGroups("sheet")
+                : renderFilterGroups("sheet")}
             </div>
 
             {/* Bottom Apply Action */}
@@ -1251,8 +1281,10 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                 <CheckCircle2 className="w-4 h-4" />
                 <span>
                   {t("becas.applyFilters", "Ver")}{" "}
-                  {showingStudies ? studyFilters.matching.length : filteredScholarships.length}{" "}
-                  {showingStudies
+                  {showingProgrammes
+                    ? programmeFilters.matching.length
+                    : filteredScholarships.length}{" "}
+                  {showingProgrammes
                     ? t("becas.programmesNoun", "programas")
                     : t("becas.scholarshipsNoun", "convocatorias")}
                 </span>
@@ -1307,8 +1339,8 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
                 </button>
               </div>
 
-              {showingStudies
-                ? studyFilters.renderGroups("sidebar")
+              {showingProgrammes
+                ? programmeFilters.renderGroups("sidebar")
                 : renderFilterGroups("sidebar")}
             </aside>
           }
@@ -1321,42 +1353,89 @@ export const BecasExplorer: React.FC<BecasExplorerProps> = ({
             ref={mainListRef}
             id="scholarships-main-section"
             className="lg:col-span-9"
-            aria-busy={!showingStudies && catalogueStatus === "loading"}
+            aria-busy={!showingProgrammes && catalogueStatus === "loading"}
           >
             <TabsContent value={viewModeTab} className="space-y-6">
               {/*
-                Saved study programmes, above the saved scholarships. The tab
-                holds both catalogues since #82, so a reader who saved a
-                language certification finds it where they saved it.
+                Two sub-tabs rather than two stacked lists under one filter
+                panel (#106). The panel above narrows whichever is open, and
+                its counts are measured against that list.
               */}
-              {viewModeTab === "favorites" && savedProgrammes.length > 0 && (
-                <div className="space-y-3" id="saved-programmes">
-                  <h3 className="font-headline-sm text-lg font-bold text-primary dark:text-sky-300">
-                    {t("becas.savedProgrammes", "Programas de estudio guardados")} (
-                    {savedProgrammes.length})
-                  </h3>
-                  <EstudiosSection
-                    scholarships={scholarshipsList}
-                    onOpenScholarship={(scholarship) => setSelectedScholarship(scholarship)}
-                    programmes={savedProgrammes}
-                    favourites={favorites}
-                    onToggleFavourite={(id) => toggleFavorite("programme", id)}
-                    hideHeading
-                  />
-                  <h3 className="font-headline-sm text-lg font-bold text-primary dark:text-sky-300 pt-2">
-                    {t("becas.savedScholarships", "Becas guardadas")} (
-                    {favoriteScholarshipIds.length})
-                  </h3>
+              {viewModeTab === "favorites" && (
+                <div
+                  className="flex items-center gap-2 p-1 bg-surface-container dark:bg-slate-800 rounded-xl"
+                  role="tablist"
+                  aria-label={t("becas.savedKindLabel", "Tipo de guardado")}
+                  id="saved-kind-tabs"
+                >
+                  {(
+                    [
+                      [
+                        "scholarships",
+                        t("becas.savedScholarships", "Becas guardadas"),
+                        favoriteScholarshipIds.length,
+                      ],
+                      [
+                        "programmes",
+                        t("becas.savedProgrammes", "Programas guardados"),
+                        savedProgrammes.length,
+                      ],
+                    ] as const
+                  ).map(([kind, copy, count]) => (
+                    <button
+                      key={kind}
+                      type="button"
+                      role="tab"
+                      aria-selected={savedKind === kind}
+                      id={`saved-kind-${kind}`}
+                      onClick={() => setSavedKind(kind)}
+                      className={`flex-1 min-h-[44px] px-3 py-2 rounded-lg text-xs font-bold transition-all cursor-pointer active:scale-95 ${
+                        savedKind === kind
+                          ? "bg-surface-container-lowest dark:bg-slate-900 text-primary dark:text-sky-300 shadow-xs"
+                          : "text-on-surface-variant dark:text-slate-400"
+                      }`}
+                    >
+                      {copy} ({count})
+                    </button>
+                  ))}
                 </div>
               )}
 
-              {showingStudies ? (
+              {showingProgrammes && savedProgrammes.length === 0 && !showingStudies ? (
+                /* Saved-but-empty is not the same as "the catalogue failed". */
+                <div
+                  id="empty-saved-programmes"
+                  className="bg-surface-container-lowest dark:bg-slate-800 rounded-2xl p-12 text-center space-y-4 border border-outline-variant/40 dark:border-slate-700"
+                >
+                  <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-950/60 flex items-center justify-center mx-auto text-red-500">
+                    <Heart className="w-8 h-8" aria-hidden="true" />
+                  </div>
+                  <h3 className="font-headline-sm text-lg font-bold text-primary dark:text-sky-300">
+                    {t("becas.emptySavedProgrammesTitle", "Aún no tienes programas guardados")}
+                  </h3>
+                  <p className="text-sm text-on-surface-variant dark:text-slate-400 max-w-md mx-auto">
+                    {t(
+                      "becas.emptySavedProgrammesBody",
+                      "Pulsa el corazón (♥) en cualquier curso, certificado o FP para guardarlo y encontrarlo aquí."
+                    )}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setViewModeTab("estudios")}
+                    id="empty-saved-programmes-explore-btn"
+                    className="bg-primary dark:bg-sky-600 text-white px-5 py-2.5 rounded-xl text-sm font-semibold hover:bg-primary-container"
+                  >
+                    {t("becas.seeAllProgrammes", "Ver Todos los Programas")}
+                  </button>
+                </div>
+              ) : showingProgrammes ? (
                 <EstudiosSection
                   scholarships={scholarshipsList}
                   onOpenScholarship={(scholarship) => setSelectedScholarship(scholarship)}
+                  programmes={showingStudies ? STUDY_PROGRAMMES_DATA : savedProgrammes}
                   favourites={favorites}
                   onToggleFavourite={(id) => toggleFavorite("programme", id)}
-                  filterState={studyFilters}
+                  filterState={programmeFilters}
                   hideHeading
                 />
               ) : (

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -380,8 +380,9 @@ export const TRANSLATIONS: TranslationDictionary = {
     es: "Tus becas y programas de estudio guardados, para consultarlos, agendarlos y comparar requisitos en cualquier momento.",
     en: "Your saved scholarships and study programmes, to revisit, schedule and compare whenever you like.",
   },
-  "becas.savedProgrammes": { es: "Programas de estudio guardados", en: "Saved study programmes" },
+  "becas.savedProgrammes": { es: "Programas guardados", en: "Saved programmes" },
   "becas.savedScholarships": { es: "Becas guardadas", en: "Saved scholarships" },
+  "becas.savedKindLabel": { es: "Tipo de guardado", en: "Kind of saved item" },
   "estudios.kindLabel": { es: "Tipo de programa", en: "Programme type" },
   "estudios.countryLabel": { es: "País", en: "Country" },
   "estudios.modalityLabel": { es: "Modalidad", en: "Format" },
@@ -538,6 +539,15 @@ export const TRANSLATIONS: TranslationDictionary = {
     en: "Tap the heart (♥) on any call to save it and find it quickly here.",
   },
   "becas.seeAllCalls": { es: "Ver Todas las Convocatorias", en: "See All Calls" },
+  "becas.seeAllProgrammes": { es: "Ver Todos los Programas", en: "See All Programmes" },
+  "becas.emptySavedProgrammesTitle": {
+    es: "Aún no tienes programas guardados",
+    en: "You have not saved any programmes yet",
+  },
+  "becas.emptySavedProgrammesBody": {
+    es: "Pulsa el corazón (♥) en cualquier curso, certificado o FP para guardarlo y encontrarlo aquí.",
+    en: "Tap the heart (♥) on any course, certificate or vocational programme to save it and find it here.",
+  },
   "becas.emptyFilteredTitle": {
     es: "No encontramos becas con los filtros seleccionados",
     en: "No scholarships match the filters you picked",

--- a/tests/e2e/favoritos.mobile.spec.ts
+++ b/tests/e2e/favoritos.mobile.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Mis Guardados on a phone (#106).
+ *
+ * The tab holds both catalogues since #82, and until now one filter panel sat
+ * above both lists. It narrowed the scholarships; the programmes ignored it,
+ * and the chip counts were measured against the whole catalogue rather than
+ * against what the reader had saved. Two sub-tabs now, each with the filters
+ * that describe its own kind.
+ */
+test.describe("Saved items on a phone", () => {
+  /** Saves one programme and one scholarship, then opens Mis Guardados. */
+  const saveOneOfEach = async (page: import("@playwright/test").Page) => {
+    await page.goto("/");
+    await page.locator("#bottom-nav-becas").click();
+    await expect(page.locator("#btn-open-mobile-filters")).toBeVisible();
+
+    await page.locator("#tab-estudios").click();
+    await page.locator('[id^="estudio-fav-"]').first().click();
+
+    await page.locator("#tab-all-scholarships").click();
+    await page.locator('button[title*="favoritos"], button[title*="beca"]').first().click();
+
+    await page.getByRole("tab", { name: /Mis Guardados/ }).click();
+    await expect(page.locator("#saved-kind-tabs")).toBeVisible();
+  };
+
+  test("splits the two kinds into sub-tabs, each with its own count", async ({ page }) => {
+    await saveOneOfEach(page);
+
+    await expect(page.locator("#saved-kind-scholarships")).toContainText("(1)");
+    await expect(page.locator("#saved-kind-programmes")).toContainText("(1)");
+
+    // Both are real tap targets, unlike the shared small button (#110).
+    for (const id of ["saved-kind-scholarships", "saved-kind-programmes"]) {
+      const box = await page.locator(`#${id}`).boundingBox();
+      expect(box!.height, id).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test("shows one kind at a time, never both under one filter panel", async ({ page }) => {
+    await saveOneOfEach(page);
+
+    // The scholarship half opens first.
+    await expect(page.locator('[id^="estudio-card-"]')).toHaveCount(0);
+
+    await page.locator("#saved-kind-programmes").click();
+    await expect(page.locator('[id^="estudio-card-"]')).toHaveCount(1);
+    await expect(page.locator('[id^="scholarship-card-"]')).toHaveCount(0);
+  });
+
+  test("gives each kind the filters that describe it", async ({ page }) => {
+    await saveOneOfEach(page);
+    await page.locator("#btn-open-mobile-filters").click();
+
+    const sheet = page.getByRole("dialog");
+    await expect(sheet.locator("#sheet-country-Todos")).toBeVisible();
+    await expect(sheet.locator("#sheet-estudios-route-chip-directa")).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    await page.locator("#saved-kind-programmes").click();
+    await page.locator("#btn-open-mobile-filters").click();
+
+    // A saved scholarship has no migration route and a saved programme has no
+    // education level, so the panel swaps rather than spanning both.
+    await expect(sheet.locator("#sheet-estudios-route-chip-directa")).toBeVisible();
+    await expect(sheet.locator("#sheet-country-Todos")).toHaveCount(0);
+  });
+
+  test("counts the chips against what is saved, not the whole catalogue", async ({ page }) => {
+    await saveOneOfEach(page);
+    await page.locator("#saved-kind-programmes").click();
+    await page.locator("#btn-open-mobile-filters").click();
+
+    const chip = page.getByRole("dialog").locator("#sheet-estudios-country-chip-Todos");
+    await expect(chip).toBeVisible();
+
+    // One programme is saved. Counting the catalogue would give thirteen.
+    const promised = Number((await chip.innerText()).match(/(\d+)\s*$/)?.[1]);
+    expect(promised).toBe(1);
+  });
+
+  test("says nothing is saved rather than blaming the catalogue", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#bottom-nav-becas").click();
+    await expect(page.locator("#btn-open-mobile-filters")).toBeVisible();
+    await page.getByRole("tab", { name: /Mis Guardados/ }).click();
+    await page.locator("#saved-kind-programmes").click();
+
+    await expect(page.locator("#empty-saved-programmes")).toBeVisible();
+    await expect(page.getByText(/No pudimos mostrar el catálogo de estudios/)).toHaveCount(0);
+  });
+
+  test("fits a 375px viewport without sideways scrolling", async ({ page }) => {
+    await saveOneOfEach(page);
+    await page.locator("#saved-kind-programmes").click();
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
       // tests, so coverage can only go up. Never lower these to make a build
       // pass — write the test instead.
       thresholds: {
-        statements: 64,
+        statements: 65,
         branches: 58,
         functions: 61,
         lines: 65,


### PR DESCRIPTION
Closes #106.

**Rebased onto `main`; the stack is gone.** #107 and #109 have both merged, so the branch no longer carries its own copies of them. It now holds one commit against `main`: 6 files, +328/−46 (was 3 commits, 13 files, +1607/−696).

## The defect, concretely

> 5 saved scholarships, 3 saved programmes. The sidebar says "País: España". The scholarships narrow to 2. The programmes still show all 3 — the filter says España and the programme list never heard about it.

And the count on each chip was measured against the **whole scholarship catalogue**, not against what was saved: `España (12)` sitting above a list holding one. Same signature as the option-count defect this screen already shipped once — a value produced from the wrong source, presented with full confidence.

The cause is one filter panel above two lists of different things. A scholarship describes itself with an education level and a closing date; a programme with a format and a migration route. A single panel above both can only ever narrow one of them.

## What changed

Two sub-tabs inside Mis Guardados — `Becas guardadas (N)` and `Programas guardados (N)` — with the sidebar and the sheet rendering the filters of whichever is open. This is the mechanism #105 established for the Becas/Estudios tabs, reused rather than reinvented.

- The saved programmes get their own `useStudyFilters` instance, separate from the Estudios tab's, so each chip's count is measured against the list it sits beside.
- An empty saved list now says nothing was saved. It previously fell through to the catalogue's own empty state, which blames the official-source check — "No pudimos mostrar el catálogo de estudios" when the real answer is "you haven't saved anything yet".
- The sub-tabs are 44px tall, measured.

## How the rebase conflict was resolved

Three conflicts in `BecasExplorer.tsx`, all where #109 rewrote the same region. Resolved by rewriting each region as one piece rather than picking sides:

1. **Both sides added a distinct declaration** — `catalogueCopy` (#109) and `savedKind` (#106). Kept both.
2. **The sort control.** #109 chose between a study sort and a scholarship sort keyed on `showingStudies`; #106 generalised the predicate to `showingProgrammes` (the Estudios tab *or* the saved-programmes sub-tab). Kept #109's two controls on #106's broader predicate, bound to `programmeFilters`.
3. **`EstudiosSection` props.** Took `filterState={programmeFilters}` from #106 and the unconditional `hideHeading` from #109. #106's `hideHeading={!showingStudies}` predates `catalogueCopy`, which now renders the Estudios title in the page `h1` — keeping the conditional would have rendered that heading twice.

## Measured in Chromium

With one scholarship and one programme saved, identical at 375px and 1440px:

| | Becas guardadas | Programas guardados |
| --- | --- | --- |
| scholarship chips in sidebar | 14 | 0 |
| study chips in sidebar | 0 | 17 |
| programme cards | 0 | 1 |
| scholarship cards | 1 | 0 |
| `Todos` chip count | — | **1** (was 13) |

No horizontal overflow at either width. Sub-tab height 44px.

Re-measured after the rebase, at 375px, checking the three resolutions above rather than reasoning about them:

| | measured | expected |
| --- | --- | --- |
| `"Estudiar sin beca"` headings in Estudios tab | 1 | 1 (2 would mean the duplicate heading) |
| `#estudios-sort-select` in Estudios tab | 1 | 1 |
| `#becas-sort-select` in Estudios tab | 0 | 0 |

## Tests

Four unit cases under `describe("filters per kind")` and a new `tests/e2e/favoritos.mobile.spec.ts` with six.

Both verified to fail with the fix reverted:
- pointing the panel back at the scholarship filters → 3 of 4 unit cases fail
- pointing the saved filters at the full catalogue → the count case fails

The pre-existing "saves a study programme and shows it in the saved tab" test was updated, since saved programmes now live behind their sub-tab rather than in a strip above the scholarships. That is the behaviour change, not a test bent to pass.

After the rebase: `npm run lint` 0 errors, `format:check` clean, **390 unit pass, 83 Playwright pass**.